### PR TITLE
add unit tests for heart beat call

### DIFF
--- a/client/cadence/internal_task_handlers.go
+++ b/client/cadence/internal_task_handlers.go
@@ -414,7 +414,7 @@ func (i *cadenceInvoker) Heartbeat(details []byte) error {
 			return err
 		}, serviceOperationRetryPolicy, isServiceTransientError)
 
-	if heartbeatErr == nil && heartbeatResponse.GetCancelRequested() {
+	if heartbeatErr == nil && heartbeatResponse != nil && heartbeatResponse.GetCancelRequested() {
 		return NewCanceledError()
 	}
 


### PR DESCRIPTION
Summary: add unit test for heart beat call

Test Plan:
add unit test for heartbeat
run unit test: go test -v, verify unit test passes.
before the fix by D778067, this unit test would crash with below message:

FAIL: TestHeartBeat_NilResponseWithError (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x13dea8b]

goroutine 147 [running]:
testing.tRunner.func1(0xc420126270)
/usr/local/Cellar/go/1.8/libexec/src/testing/testing.go:622 +0x29d
panic(0x14793c0, 0x17827a0)
/usr/local/Cellar/go/1.8/libexec/src/runtime/panic.go:489 +0x2cf
code.uber.internal/devexp/minions-client-go.git/client/cadence.(*cadenceInvoker).Heartbeat.func1(0x0, 0x0)
/Users/yiminc/gocode/src/code.uber.internal/devexp/minions-client-go.git/client/cadence/internal_task_handlers.go:413 +0x11b
code.uber.internal/devexp/minions-client-go.git/common/backoff.Retry(0xc420135920, 0x1758100, 0xc42010c330, 0x151c668, 0x1011b88, 0x40)
/Users/yiminc/gocode/src/code.uber.internal/devexp/minions-client-go.git/common/backoff/retry.go:79 +0x87
code.uber.internal/devexp/minions-client-go.git/client/cadence.(*cadenceInvoker).Heartbeat(0xc420015900, 0x0, 0x0, 0x0, 0xc420358460, 0x2)
/Users/yiminc/gocode/src/code.uber.internal/devexp/minions-client-go.git/client/cadence/internal_task_handlers.go:417 +0x16d
code.uber.internal/devexp/minions-client-go.git/client/cadence.(*TaskHandlersTestSuite).TestHeartBeat_NilResponseWithError(0xc42031cb40)
/Users/yiminc/gocode/src/code.uber.internal/devexp/minions-client-go.git/client/cadence/internal_task_handlers_test.go:228 +0x30f
reflect.Value.call(0xc42013f6e0, 0xc4201442c8, 0x13, 0x1500f17, 0x4, 0xc420041f80, 0x1, 0x1, 0xc42012d720, 0x14fc7a0, ...)
/usr/local/Cellar/go/1.8/libexec/src/reflect/value.go:434 +0x91f
reflect.Value.Call(0xc42013f6e0, 0xc4201442c8, 0x13, 0xc42012d780, 0x1, 0x1, 0x0, 0xc42012d798, 0x102aede)
/usr/local/Cellar/go/1.8/libexec/src/reflect/value.go:302 +0xa4
code.uber.internal/devexp/minions-client-go.git/vendor/github.com/stretchr/testify/suite.Run.func2(0xc420126270)
/Users/yiminc/gocode/src/code.uber.internal/devexp/minions-client-go.git/vendor/github.com/stretchr/testify/suite/suite.go:95 +0x17c
testing.tRunner(0xc420126270, 0xc4200afd50)
/usr/local/Cellar/go/1.8/libexec/src/testing/testing.go:657 +0x96
created by testing.(*T).Run
/usr/local/Cellar/go/1.8/libexec/src/testing/testing.go:697 +0x2ca
exit status 2
FAIL	code.uber.internal/devexp/minions-client-go.git/client/cadence	60.180s

Reviewers: sivakk, samar

Differential Revision: https://code.uberinternal.com/D780762