### PR TITLE
add visibility api to client

### DIFF
--- a/client/cadence/client.go
+++ b/client/cadence/client.go
@@ -39,9 +39,17 @@ type (
 		RecordActivityHeartbeat(taskToken, details []byte) error
 
 		// ListClosedWorkflow gets closed workflow executions based on request filters
+		// The errors it can throw:
+		//  - BadRequestError
+		//  - InternalServiceError
+		//  - EntityNotExistError
 		ListClosedWorkflow(request *s.ListClosedWorkflowExecutionsRequest) (*s.ListClosedWorkflowExecutionsResponse, error)
 
 		// ListClosedWorkflow gets open workflow executions based on request filters
+		// The errors it can throw:
+		//  - BadRequestError
+		//  - InternalServiceError
+		//  - EntityNotExistError
 		ListOpenWorkflow(request *s.ListOpenWorkflowExecutionsRequest) (*s.ListOpenWorkflowExecutionsResponse, error)
 	}
 

--- a/client/cadence/internal_workflow_client.go
+++ b/client/cadence/internal_workflow_client.go
@@ -157,6 +157,10 @@ func (wc *workflowClient) RecordActivityHeartbeat(taskToken, details []byte) err
 }
 
 // ListClosedWorkflow gets closed workflow executions based on request filters
+// The errors it can throw:
+//  - BadRequestError
+//  - InternalServiceError
+//  - EntityNotExistError
 func (wc *workflowClient) ListClosedWorkflow(request *s.ListClosedWorkflowExecutionsRequest) (*s.ListClosedWorkflowExecutionsResponse, error) {
 	if len(request.GetDomain()) == 0 {
 		request.Domain = common.StringPtr(wc.domain)
@@ -177,6 +181,10 @@ func (wc *workflowClient) ListClosedWorkflow(request *s.ListClosedWorkflowExecut
 }
 
 // ListClosedWorkflow gets open workflow executions based on request filters
+// The errors it can throw:
+//  - BadRequestError
+//  - InternalServiceError
+//  - EntityNotExistError
 func (wc *workflowClient) ListOpenWorkflow(request *s.ListOpenWorkflowExecutionsRequest) (*s.ListOpenWorkflowExecutionsResponse, error) {
 	if len(request.GetDomain()) == 0 {
 		request.Domain = common.StringPtr(wc.domain)


### PR DESCRIPTION
add visibility api to client library. reuse the data structure from thrift to avoid duplicate wrapper structures.