### PR TITLE
add panic handler to activity handler

### DIFF
--- a/client/cadence/internal_utils.go
+++ b/client/cadence/internal_utils.go
@@ -58,6 +58,10 @@ func getErrorDetails(err error) (string, []byte) {
 		wErr.Details(&details)
 		return "canceled", details
 	}
+	if wErr, ok := err.(PanicError); ok {
+		return err.Error(), []byte(wErr.StackTrace())
+	}
+
 	return err.Error(), []byte("")
 }
 

--- a/client/cadence/internal_workflow.go
+++ b/client/cadence/internal_workflow.go
@@ -279,7 +279,7 @@ func executeDispatcher(ctx Context, dispatcher dispatcher) {
 	panicErr := dispatcher.ExecuteUntilAllBlocked()
 	if panicErr != nil {
 		env := getWorkflowEnvironment(ctx)
-		env.GetLogger().Error("Dispatcher panic.", zap.Error(panicErr))
+		env.GetLogger().Error("Dispatcher panic.", zap.String("PanicStack", panicErr.StackTrace()))
 		env.Complete(nil, NewErrorWithDetails(panicErr.Error(), []byte(panicErr.StackTrace())))
 		return
 	}
@@ -452,16 +452,20 @@ func (s *coroutineState) yield(status string) {
 }
 
 func getStackTrace(coroutineName, status string, stackDepth int) string {
+	top := fmt.Sprintf("coroutine %s [%s]:", coroutineName, status)
+	// Omit top stackDepth frames + top status line.
+	// Omit bottom two frames which is wrapping of coroutine in a goroutine.
+	return getStackTraceRaw(top, stackDepth*2+1, 4)
+}
+
+func getStackTraceRaw(top string, omitTop, omitBottom int) string {
 	stack := stackBuf[:runtime.Stack(stackBuf[:], false)]
 	rawStack := fmt.Sprintf("%s", strings.TrimRightFunc(string(stack), unicode.IsSpace))
 	if disableCleanStackTraces {
 		return rawStack
 	}
 	lines := strings.Split(rawStack, "\n")
-	// Omit top stackDepth frames + top status line.
-	// Omit bottom two frames which is wrapping of coroutine in a goroutine.
-	lines = lines[stackDepth*2+1 : len(lines)-4]
-	top := fmt.Sprintf("coroutine %s [%s]:", coroutineName, status)
+	lines = lines[omitTop : len(lines)-omitBottom]
 	lines = append([]string{top}, lines...)
 	return strings.Join(lines, "\n")
 }
@@ -499,7 +503,7 @@ func (s *coroutineState) stackTrace() string {
 	}
 	stackCh := make(chan string, 1)
 	s.unblock <- func(status string, stackDepth int) bool {
-		stackCh <- getStackTrace(s.name, status, stackDepth+1)
+		stackCh <- getStackTrace(s.name, status, stackDepth+2)
 		return true
 	}
 	return <-stackCh
@@ -550,7 +554,7 @@ func (d *dispatcherImpl) newNamedCoroutine(ctx Context, name string, f func(ctx 
 		defer crt.close()
 		defer func() {
 			if r := recover(); r != nil {
-				st := getStackTrace(name, "panic", 3)
+				st := getStackTrace(name, "panic", 4)
 				crt.panicError = newPanicError(r, st)
 			}
 		}()


### PR DESCRIPTION
add activity panic handler. in case of panic from user's activity code, we recover that panic and respond activity failure to server.

verified in end to end manual test, the panic stack trace is correct.
