### PR TITLE
cleanup: tchannelContext with defaults options

### DIFF
--- a/client/cadence/internal_task_handlers.go
+++ b/client/cadence/internal_task_handlers.go
@@ -773,7 +773,7 @@ func recordActivityHeartbeat(
 	var heartbeatResponse *s.RecordActivityTaskHeartbeatResponse
 	heartbeatErr := backoff.Retry(
 		func() error {
-			ctx, cancel := newTChannelContext(respondTaskServiceTimeOut, retryDefaultOptions)
+			ctx, cancel := newTChannelContext()
 			defer cancel()
 
 			var err error

--- a/client/cadence/internal_task_pollers.go
+++ b/client/cadence/internal_task_pollers.go
@@ -16,8 +16,7 @@ import (
 )
 
 const (
-	pollTaskServiceTimeOut    = 3 * time.Minute // Server long poll is 1 * Minutes + delta
-	respondTaskServiceTimeOut = 10 * time.Second
+	pollTaskServiceTimeOut = 3 * time.Minute // Server long poll is 1 * Minutes + delta
 
 	retryServiceOperationInitialInterval    = time.Millisecond
 	retryServiceOperationMaxInterval        = 4 * time.Second
@@ -133,7 +132,7 @@ func (wtp *workflowTaskPoller) PollAndProcessSingleTask() error {
 	// Respond task completion.
 	err = backoff.Retry(
 		func() error {
-			ctx, cancel := newTChannelContext(respondTaskServiceTimeOut, retryDefaultOptions)
+			ctx, cancel := newTChannelContext()
 			defer cancel()
 			err1 := wtp.service.RespondDecisionTaskCompleted(ctx, completedRequest)
 			if err1 != nil {
@@ -167,7 +166,7 @@ func (wtp *workflowTaskPoller) poll() (*workflowTask, error) {
 		Identity: common.StringPtr(wtp.identity),
 	}
 
-	ctx, cancel := newTChannelContext(pollTaskServiceTimeOut, retryNeverOptions)
+	ctx, cancel := newTChannelContext(tchanTimeout(pollTaskServiceTimeOut), tchanRetryOption(retryNeverOptions))
 	defer cancel()
 
 	response, err := wtp.service.PollForDecisionTask(ctx, request)
@@ -211,7 +210,7 @@ func (atp *activityTaskPoller) poll() (*activityTask, error) {
 		Identity: common.StringPtr(atp.identity),
 	}
 
-	ctx, cancel := newTChannelContext(pollTaskServiceTimeOut, retryNeverOptions)
+	ctx, cancel := newTChannelContext(tchanTimeout(pollTaskServiceTimeOut), tchanRetryOption(retryNeverOptions))
 	defer cancel()
 
 	response, err := atp.service.PollForActivityTask(ctx, request)
@@ -274,7 +273,7 @@ func reportActivityComplete(service m.TChanWorkflowService, request interface{},
 		}
 	}()
 
-	ctx, cancel := newTChannelContext(respondTaskServiceTimeOut, retryDefaultOptions)
+	ctx, cancel := newTChannelContext()
 	defer cancel()
 	var reportErr error
 	switch request := request.(type) {

--- a/client/cadence/internal_utils_test.go
+++ b/client/cadence/internal_utils_test.go
@@ -1,0 +1,22 @@
+package cadence
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go"
+	"testing"
+	"time"
+)
+
+func TestTChannelBuilderOptions(t *testing.T) {
+	builder := tchannel.NewContextBuilder(defaultRpcTimeout)
+	require.Equal(t, defaultRpcTimeout, builder.Timeout)
+
+	opt1 := tchanTimeout(time.Minute)
+	opt2 := tchanRetryOption(retryNeverOptions)
+
+	opt1(builder)
+	opt2(builder)
+
+	require.Equal(t, time.Minute, builder.Timeout)
+	require.Equal(t, retryNeverOptions, builder.RetryOptions)
+}

--- a/client/cadence/internal_workflow_client.go
+++ b/client/cadence/internal_workflow_client.go
@@ -71,7 +71,7 @@ func (wc *workflowClient) StartWorkflow(
 	// Start creating workflow request.
 	err = backoff.Retry(
 		func() error {
-			ctx, cancel := newTChannelContext(respondTaskServiceTimeOut, retryDefaultOptions)
+			ctx, cancel := newTChannelContext()
 			defer cancel()
 
 			var err1 error
@@ -106,7 +106,7 @@ func (wc *workflowClient) CancelWorkflow(workflowID string, runID string) error 
 
 	return backoff.Retry(
 		func() error {
-			ctx, cancel := newTChannelContext(respondTaskServiceTimeOut, retryDefaultOptions)
+			ctx, cancel := newTChannelContext()
 			defer cancel()
 			return wc.workflowService.RequestCancelWorkflowExecution(ctx, request)
 		}, serviceOperationRetryPolicy, isServiceTransientError)
@@ -128,7 +128,7 @@ func (wc *workflowClient) TerminateWorkflow(workflowID string, runID string, rea
 
 	err := backoff.Retry(
 		func() error {
-			ctx, cancel := newTChannelContext(respondTaskServiceTimeOut, retryDefaultOptions)
+			ctx, cancel := newTChannelContext()
 			defer cancel()
 			return wc.workflowService.TerminateWorkflowExecution(ctx, request)
 		}, serviceOperationRetryPolicy, isServiceTransientError)
@@ -150,7 +150,7 @@ func (wc *workflowClient) GetWorkflowHistory(workflowID string, runID string) (*
 	err := backoff.Retry(
 		func() error {
 			var err1 error
-			ctx, cancel := newTChannelContext(respondTaskServiceTimeOut, retryDefaultOptions)
+			ctx, cancel := newTChannelContext()
 			defer cancel()
 			response, err1 = wc.workflowService.GetWorkflowExecutionHistory(ctx, request)
 			return err1
@@ -205,7 +205,7 @@ func (wc *workflowClient) ListClosedWorkflow(request *s.ListClosedWorkflowExecut
 	err := backoff.Retry(
 		func() error {
 			var err1 error
-			ctx, cancel := newTChannelContext(respondTaskServiceTimeOut, retryDefaultOptions)
+			ctx, cancel := newTChannelContext()
 			defer cancel()
 			response, err1 = wc.workflowService.ListClosedWorkflowExecutions(ctx, request)
 			return err1
@@ -229,7 +229,7 @@ func (wc *workflowClient) ListOpenWorkflow(request *s.ListOpenWorkflowExecutions
 	err := backoff.Retry(
 		func() error {
 			var err1 error
-			ctx, cancel := newTChannelContext(respondTaskServiceTimeOut, retryDefaultOptions)
+			ctx, cancel := newTChannelContext()
 			defer cancel()
 			response, err1 = wc.workflowService.ListOpenWorkflowExecutions(ctx, request)
 			return err1
@@ -248,7 +248,7 @@ func (wc *workflowClient) ListOpenWorkflow(request *s.ListOpenWorkflowExecutions
 func (dc *domainClient) Register(request *s.RegisterDomainRequest) error {
 	return backoff.Retry(
 		func() error {
-			ctx, cancel := newTChannelContext(respondTaskServiceTimeOut, retryDefaultOptions)
+			ctx, cancel := newTChannelContext()
 			defer cancel()
 			return dc.workflowService.RegisterDomain(ctx, request)
 		}, serviceOperationRetryPolicy, isServiceTransientError)
@@ -269,7 +269,7 @@ func (dc *domainClient) Describe(name string) (*s.DomainInfo, *s.DomainConfigura
 	var response *s.DescribeDomainResponse
 	err := backoff.Retry(
 		func() error {
-			ctx, cancel := newTChannelContext(respondTaskServiceTimeOut, retryDefaultOptions)
+			ctx, cancel := newTChannelContext()
 			defer cancel()
 			var err error
 			response, err = dc.workflowService.DescribeDomain(ctx, request)
@@ -297,7 +297,7 @@ func (dc *domainClient) Update(name string, domainInfo *s.UpdateDomainInfo, doma
 
 	return backoff.Retry(
 		func() error {
-			ctx, cancel := newTChannelContext(respondTaskServiceTimeOut, retryDefaultOptions)
+			ctx, cancel := newTChannelContext()
 			defer cancel()
 			_, err := dc.workflowService.UpdateDomain(ctx, request)
 			return err


### PR DESCRIPTION
TChannel context options are pretty much the same everywhere except for a couple of places. This patch supports construction of a newTChannelContext with reasonable defaults.