### PR TITLE
allow mock to wait on workflow clock before it returns

### DIFF
--- a/internal_workflow_testsuite.go
+++ b/internal_workflow_testsuite.go
@@ -63,7 +63,8 @@ type (
 	}
 
 	testChildWorkflowHandle struct {
-		env *testWorkflowEnvironmentImpl
+		env      *testWorkflowEnvironmentImpl
+		callback resultHandler
 	}
 
 	testCallbackHandle struct {
@@ -83,10 +84,14 @@ type (
 	}
 
 	mockWrapper struct {
-		mock       *mock.Mock
+		env        *testWorkflowEnvironmentImpl
 		name       string
 		fn         interface{}
 		isWorkflow bool
+	}
+
+	panicWrapper struct {
+		p interface{}
 	}
 
 	taskListSpecificActivity struct {
@@ -223,7 +228,7 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite) *testWorkflowEnvironme
 	return env
 }
 
-func (env *testWorkflowEnvironmentImpl) newTestWorkflowEnvironmentForChild(options *workflowOptions) *testWorkflowEnvironmentImpl {
+func (env *testWorkflowEnvironmentImpl) newTestWorkflowEnvironmentForChild(options *workflowOptions, callback resultHandler) *testWorkflowEnvironmentImpl {
 	// create a new test env
 	childEnv := newTestWorkflowEnvironmentImpl(env.testSuite)
 	childEnv.parentEnv = env
@@ -239,7 +244,7 @@ func (env *testWorkflowEnvironmentImpl) newTestWorkflowEnvironmentForChild(optio
 	childEnv.workflowInfo.TaskListName = *options.taskListName
 	childEnv.workflowInfo.ExecutionStartToCloseTimeoutSeconds = *options.executionStartToCloseTimeoutSeconds
 	childEnv.workflowInfo.TaskStartToCloseTimeoutSeconds = *options.taskStartToCloseTimeoutSeconds
-	env.childWorkflows[options.workflowID] = &testChildWorkflowHandle{env: childEnv}
+	env.childWorkflows[options.workflowID] = &testChildWorkflowHandle{env: childEnv, callback: callback}
 
 	return childEnv
 }
@@ -309,9 +314,6 @@ func (env *testWorkflowEnvironmentImpl) executeWorkflowInternal(workflowType str
 	// to make sure workflowDef.Execute() is run in main loop.
 	env.postCallback(func() {
 		env.workflowDef.Execute(env, input)
-		if env.isChildWorkflow() {
-			env.runningCount.Dec()
-		}
 	}, false)
 	env.startMainLoop()
 }
@@ -429,11 +431,13 @@ func (env *testWorkflowEnvironmentImpl) startMainLoop() {
 }
 
 func (env *testWorkflowEnvironmentImpl) registerDelayedCallback(f func(), delayDuration time.Duration) {
-	env.postCallback(func() {
-		env.NewTimer(delayDuration, func(result []byte, err error) {
-			f()
-		})
-	}, false)
+	timerCallback := func(result []byte, err error) {
+		f()
+	}
+	mainLoopCallback := func() {
+		env.newTimer(delayDuration, timerCallback, false)
+	}
+	env.postCallback(mainLoopCallback, false)
 }
 
 func (c *testCallbackHandle) processCallback() {
@@ -574,6 +578,21 @@ func (env *testWorkflowEnvironmentImpl) Complete(result []byte, err error) {
 	}
 
 	close(env.doneChannel)
+
+	if env.isChildWorkflow() {
+		// this is completion of child workflow
+		childWorkflowID := env.workflowInfo.WorkflowExecution.ID
+		if childWorkflowHandle, ok := env.childWorkflows[childWorkflowID]; ok {
+			delete(env.childWorkflows, childWorkflowID)
+			env.parentEnv.postCallback(func() {
+				// deliver result
+				childWorkflowHandle.callback(env.testResult, env.testError)
+				if env.onChildWorkflowCompletedListener != nil {
+					env.onChildWorkflowCompletedListener(env.workflowInfo, env.testResult, env.testError)
+				}
+			}, true /* true to trigger parent workflow to resume to handle child workflow's result */)
+		}
+	}
 }
 
 func (env *testWorkflowEnvironmentImpl) CompleteActivity(taskToken []byte, result interface{}, err error) error {
@@ -692,6 +711,39 @@ func (env *testWorkflowEnvironmentImpl) handleActivityResult(activityID string, 
 	env.startDecisionTask()
 }
 
+// runBeforeMockCallReturns is registered as mock call's RunFn by *mock.Call.Run(fn). It will be called by testify's
+// mock.MethodCalled() before it returns.
+func (env *testWorkflowEnvironmentImpl) runBeforeMockCallReturns(call *MockCallWrapper, args mock.Arguments) {
+	defer func() {
+		if p := recover(); p != nil {
+			// wrap the panic, so we know this is a real panic (aka not due to mock call unexpected), and should not be
+			// swallowed by panic handler in mockWrapper.getMockReturn()
+			panic(&panicWrapper{p})
+		}
+	}()
+
+	// mock call is expected, below code could block on wait, and we don't need the lock anymore. The corresponding Lock
+	// call is in mockWrapper.methodCalled().
+	env.locker.Unlock()
+
+	if call.waitDuration > 0 {
+		// we want this mock call to block until the wait duration is elapsed (on workflow clock).
+		waitCh := make(chan time.Time)
+		env.runningCount.Dec() // reduce runningCount, since this mock call is about to be blocked.
+		env.registerDelayedCallback(func() {
+			waitCh <- env.Now()    // this will unblock mock call
+			env.runningCount.Inc() // increase runningCount as the mock call is ready to resume.
+		}, call.waitDuration)
+
+		<-waitCh // this will block until mock clock move forward by waitDuration
+	}
+
+	// run the actual runFn if it was setup
+	if call.runFn != nil {
+		call.runFn(args)
+	}
+}
+
 // Execute executes the activity code.
 func (a *activityExecutorWrapper) Execute(ctx context.Context, input []byte) ([]byte, error) {
 	activityInfo := GetActivityInfo(ctx)
@@ -701,7 +753,7 @@ func (a *activityExecutorWrapper) Execute(ctx context.Context, input []byte) ([]
 		}, false)
 	}
 
-	m := &mockWrapper{mock: a.env.mock, name: a.name, fn: a.fn, isWorkflow: false}
+	m := &mockWrapper{env: a.env, name: a.name, fn: a.fn, isWorkflow: false}
 	if mockRet := m.getMockReturn(ctx, input); mockRet != nil {
 		return m.executeMock(ctx, input, mockRet)
 	}
@@ -716,19 +768,39 @@ func (a *activityExecutorWrapper) Execute(ctx context.Context, input []byte) ([]
 
 // Execute executes the workflow code.
 func (w *workflowExecutorWrapper) Execute(ctx Context, input []byte) (result []byte, err error) {
-	parentEnv := w.env.parentEnv
-	if parentEnv != nil && parentEnv.onChildWorkflowStartedListener != nil {
-		parentEnv.postCallback(func() {
-			parentEnv.onChildWorkflowStartedListener(GetWorkflowInfo(ctx), ctx, EncodedValues(input))
+	env := w.env
+	if env.isChildWorkflow() && env.onChildWorkflowStartedListener != nil {
+		env.postCallback(func() {
+			env.onChildWorkflowStartedListener(GetWorkflowInfo(ctx), ctx, EncodedValues(input))
 		}, false)
 	}
 
-	m := &mockWrapper{mock: w.env.mock, name: w.name, fn: w.fn, isWorkflow: true}
-	if mockRet := m.getMockReturn(ctx, input); mockRet != nil {
+	m := &mockWrapper{env: env, name: w.name, fn: w.fn, isWorkflow: true}
+	// This method is called by workflow's dispatcher. In this test suite, it is run in the main loop. We cannot block
+	// the main loop, but the mock could block if it is configured to wait. So we need to use a separate goroutinue to
+	// run the mock, and resume after mock call returns.
+	mockReadyChannel := NewChannel(ctx)
+	go func() {
+		mockRet := m.getMockReturn(ctx, input) // this call could block if mock is configured to wait
+		env.postCallback(func() {
+			mockReadyChannel.SendAsync(mockRet)
+		}, true /* true to trigger the dispatcher for this workflow so it resume from mockReadyChannel block*/)
+	}()
+
+	var mockRet mock.Arguments
+	mockReadyChannel.Receive(ctx, &mockRet) // this will block the workflow dispatcher, but not block the main loop.
+
+	if env.isChildWorkflow() {
+		env.postCallback(func() {
+			env.runningCount.Dec()
+		}, false)
+	}
+
+	if mockRet != nil {
 		return m.executeMock(ctx, input, mockRet)
 	}
 
-	if fakeFn, ok := w.env.overrodeWorkflows[w.name]; ok {
+	if fakeFn, ok := env.overrodeWorkflows[w.name]; ok {
 		executor := &workflowExecutor{name: w.name, fn: fakeFn}
 		return executor.Execute(ctx, input)
 	}
@@ -738,7 +810,7 @@ func (w *workflowExecutorWrapper) Execute(ctx Context, input []byte) (result []b
 }
 
 func (m *mockWrapper) getMockReturn(ctx interface{}, input []byte) (retArgs mock.Arguments) {
-	if m.mock == nil {
+	if m.env.mock == nil {
 		// no mock
 		return nil
 	}
@@ -760,16 +832,31 @@ func (m *mockWrapper) getMockReturn(ctx interface{}, input []byte) (retArgs mock
 		realArgs = append(realArgs, arg.Interface())
 	}
 
+	return m.methodCalled(m.name, realArgs...)
+}
+
+func (m *mockWrapper) methodCalled(name string, args ...interface{}) (retArgs mock.Arguments) {
+	// This method is run in separate go routinue, both for activity and child workflow.
+	// We need the lock because the args could include a cadence.Context which will be accessed by mock.MethodCalled()
+	// and is also accessed by the main loop.
+	m.env.locker.Lock()
 	// There is no way to check if a mock call is expected or not. A pull request to add it was rejected. See PR:
 	// https://github.com/stretchr/testify/pull/453. We could try to call the mock method, and if the call is not
 	// expected, the mock.MethodCalled() will panic, which we would catch and just return nil from this method.
 	defer func() {
 		if p := recover(); p != nil {
+			if pw, ok := p.(*panicWrapper); ok {
+				// re-panic, if this is a legit panic (aka not due to unexpected mock call)
+				panic(pw.p)
+			}
 			retArgs = nil
+			// if there is no panic, meaning mock call go through, and runBeforeMockCallReturns() is called. We would
+			// already Unlock the locker in  runBeforeMockCallReturns() before the potential wait.
+			m.env.locker.Unlock()
 		}
 	}()
 
-	return m.mock.MethodCalled(m.name, realArgs...)
+	return m.env.mock.MethodCalled(name, args...)
 }
 
 func (m *mockWrapper) executeMock(ctx interface{}, input []byte, mockRet mock.Arguments) ([]byte, error) {
@@ -906,14 +993,14 @@ func newTestActivityTask(workflowID, runID, activityID, activityType string, inp
 	return task
 }
 
-func (env *testWorkflowEnvironmentImpl) NewTimer(d time.Duration, callback resultHandler) *timerInfo {
+func (env *testWorkflowEnvironmentImpl) newTimer(d time.Duration, callback resultHandler, notifyListener bool) *timerInfo {
 	nextID := env.nextID()
 	timerInfo := &timerInfo{timerID: getStringID(nextID)}
 	timer := env.mockClock.AfterFunc(d, func() {
 		delete(env.timers, timerInfo.timerID)
 		env.postCallback(func() {
 			callback(nil, nil)
-			if env.onTimerFiredListener != nil {
+			if notifyListener && env.onTimerFiredListener != nil {
 				env.onTimerFiredListener(timerInfo.timerID)
 			}
 		}, true)
@@ -927,10 +1014,14 @@ func (env *testWorkflowEnvironmentImpl) NewTimer(d time.Duration, callback resul
 		duration:       d,
 		timerID:        nextID,
 	}
-	if env.onTimerScheduledListener != nil {
+	if notifyListener && env.onTimerScheduledListener != nil {
 		env.onTimerScheduledListener(timerInfo.timerID, d)
 	}
 	return timerInfo
+}
+
+func (env *testWorkflowEnvironmentImpl) NewTimer(d time.Duration, callback resultHandler) *timerInfo {
+	return env.newTimer(d, callback, true)
 }
 
 func (env *testWorkflowEnvironmentImpl) Now() time.Time {
@@ -955,10 +1046,9 @@ func (env *testWorkflowEnvironmentImpl) RequestCancelWorkflow(domainName, workfl
 		env.workflowCancelHandler()
 
 		// check if current workflow is a child workflow
-		parentEnv := env.parentEnv
-		if parentEnv != nil && parentEnv.onChildWorkflowCanceledListener != nil {
-			parentEnv.postCallback(func() {
-				parentEnv.onChildWorkflowCanceledListener(env.workflowInfo)
+		if env.isChildWorkflow() && env.onChildWorkflowCanceledListener != nil {
+			env.postCallback(func() {
+				env.onChildWorkflowCanceledListener(env.workflowInfo)
 			}, false)
 		}
 	} else if childHandle, ok := env.childWorkflows[workflowID]; ok {
@@ -971,25 +1061,15 @@ func (env *testWorkflowEnvironmentImpl) RequestCancelWorkflow(domainName, workfl
 }
 
 func (env *testWorkflowEnvironmentImpl) ExecuteChildWorkflow(options workflowOptions, callback resultHandler, startedHandler func(r WorkflowExecution, e error)) error {
-	childEnv := env.newTestWorkflowEnvironmentForChild(&options)
+	childEnv := env.newTestWorkflowEnvironmentForChild(&options, callback)
 	env.logger.Sugar().Infof("ExecuteChildWorkflow: %v", options.workflowType.Name)
 
 	// start immediately
-	env.runningCount.Inc()
 	startedHandler(childEnv.workflowInfo.WorkflowExecution, nil)
+	env.runningCount.Inc()
 
-	go func() {
-		childEnv.executeWorkflowInternal(options.workflowType.Name, options.input)
-		env.postCallback(func() {
-			delete(env.childWorkflows, options.workflowID)
-			// deliver result
-			callback(childEnv.testResult, childEnv.testError)
-
-			if env.onChildWorkflowCompletedListener != nil {
-				env.onChildWorkflowCompletedListener(childEnv.workflowInfo, childEnv.testResult, childEnv.testError)
-			}
-		}, true)
-	}()
+	// run child workflow in separate goroutinue
+	go childEnv.executeWorkflowInternal(options.workflowType.Name, options.input)
 
 	return nil
 }

--- a/internal_workflow_testsuite_test.go
+++ b/internal_workflow_testsuite_test.go
@@ -834,3 +834,79 @@ func (s *WorkflowTestSuiteUnitTest) Test_MockPanic() {
 	env.AssertExpectations(s.T())
 	s.SetLogger(oldLogger) // restore original logger
 }
+
+func (s *WorkflowTestSuiteUnitTest) Test_ChildWithChild() {
+	childWorkflowFn := func(ctx Context) error {
+		t1 := NewTimer(ctx, time.Hour)
+		cwo := ChildWorkflowOptions{ExecutionStartToCloseTimeout: time.Hour /* this is currently ignored by test suite */}
+		ctx = WithChildWorkflowOptions(ctx, cwo)
+		f1 := ExecuteChildWorkflow(ctx, testWorkflowHello)
+
+		NewSelector(ctx).AddFuture(t1, func(f Future) {
+			// timer fired
+		}).AddFuture(f1, func(f Future) {
+			// child workflow completed
+		}).Select(ctx)
+
+		// either t1 or f1 is ready.
+		if f1.IsReady() {
+			return nil
+		}
+
+		// child workflow takes too long
+		return errors.New("child workflow takes too long")
+	}
+
+	workflowFn := func(ctx Context) error {
+		t1 := NewTimer(ctx, time.Hour)
+		cwo := ChildWorkflowOptions{ExecutionStartToCloseTimeout: time.Hour /* this is currently ignored by test suite */}
+		ctx = WithChildWorkflowOptions(ctx, cwo)
+		f1 := ExecuteChildWorkflow(ctx, childWorkflowFn) // execute child workflow which in turn execute another child workflow
+
+		NewSelector(ctx).AddFuture(t1, func(f Future) {
+			// timer fired
+		}).AddFuture(f1, func(f Future) {
+			// child workflow completed
+		}).Select(ctx)
+
+		// either t1 or f1 is ready.
+		if f1.IsReady() {
+			return f1.Get(ctx, nil)
+		}
+
+		// child workflow takes too long
+		return errors.New("child workflow takes too long")
+	}
+
+	s.RegisterWorkflow(childWorkflowFn)
+
+	// no delay to the mock call, workflow should return no error
+	env := s.NewTestWorkflowEnvironment()
+	env.OnWorkflow(testWorkflowHello, mock.Anything, mock.Anything).Return("hello_mock_delayed", nil).Once()
+	env.ExecuteWorkflow(workflowFn)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	env.AssertExpectations(s.T())
+
+	// delay 10 minutes, which is shorter than the 1 hour timer, so workflow should return no error.
+	env = s.NewTestWorkflowEnvironment()
+	env.OnWorkflow(testWorkflowHello, mock.Anything, mock.Anything).After(time.Minute*10).Return("hello_mock_delayed", nil).Once()
+	env.ExecuteWorkflow(workflowFn)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	env.AssertExpectations(s.T())
+
+	// delay 2 hours, which is longer than the 1 hour timer, and workflow should return error.
+	env = s.NewTestWorkflowEnvironment()
+	env.OnWorkflow(testWorkflowHello, mock.Anything, mock.Anything).After(time.Hour*2).Return("hello_mock_delayed", nil).Once()
+	env.ExecuteWorkflow(workflowFn)
+	s.True(env.IsWorkflowCompleted())
+	s.Error(env.GetWorkflowError())
+	env.AssertExpectations(s.T())
+
+	// no mock
+	env = s.NewTestWorkflowEnvironment()
+	env.ExecuteWorkflow(workflowFn)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+}

--- a/internal_workflow_testsuite_test.go
+++ b/internal_workflow_testsuite_test.go
@@ -710,3 +710,127 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflow_Clock() {
 	s.NoError(env.GetWorkflowError())
 	s.Equal(expected, history)
 }
+
+func (s *WorkflowTestSuiteUnitTest) Test_MockActivityWait() {
+	workflowFn := func(ctx Context) error {
+		t1 := NewTimer(ctx, time.Hour)
+		ctx = WithActivityOptions(ctx, s.activityOptions)
+		f1 := ExecuteActivity(ctx, testActivityHello, "mock_delay")
+
+		NewSelector(ctx).AddFuture(t1, func(f Future) {
+			// timer fired
+		}).AddFuture(f1, func(f Future) {
+			// activity completed
+		}).Select(ctx)
+
+		// either t1 or f1 is ready.
+		if f1.IsReady() {
+			return nil
+		}
+
+		// activity takes too long
+		return errors.New("activity takes too long")
+	}
+
+	// no delay to the mock call, workflow should return no error
+	env := s.NewTestWorkflowEnvironment()
+	env.OnActivity(testActivityHello, mock.Anything, mock.Anything).Return("hello_mock_delayed", nil).Once()
+	env.ExecuteWorkflow(workflowFn)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	env.AssertExpectations(s.T())
+
+	// delay 10 minutes, which is shorter than the 1 hour timer, so workflow should return no error.
+	env = s.NewTestWorkflowEnvironment()
+	env.OnActivity(testActivityHello, mock.Anything, mock.Anything).After(time.Minute*10).Return("hello_mock_delayed", nil).Once()
+	env.ExecuteWorkflow(workflowFn)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	env.AssertExpectations(s.T())
+
+	// delay 2 hours, which is longer than the 1 hour timer, and workflow should return error.
+	env = s.NewTestWorkflowEnvironment()
+	env.OnActivity(testActivityHello, mock.Anything, mock.Anything).After(time.Hour*2).Return("hello_mock_delayed", nil).Once()
+	env.ExecuteWorkflow(workflowFn)
+	s.True(env.IsWorkflowCompleted())
+	s.Error(env.GetWorkflowError())
+	env.AssertExpectations(s.T())
+
+	// no mock
+	env = s.NewTestWorkflowEnvironment()
+	env.ExecuteWorkflow(workflowFn)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+}
+
+func (s *WorkflowTestSuiteUnitTest) Test_MockWorkflowWait() {
+	workflowFn := func(ctx Context) error {
+		t1 := NewTimer(ctx, time.Hour)
+		cwo := ChildWorkflowOptions{ExecutionStartToCloseTimeout: time.Hour /* this is currently ignored by test suite */}
+		ctx = WithChildWorkflowOptions(ctx, cwo)
+		f1 := ExecuteChildWorkflow(ctx, testWorkflowHello)
+
+		NewSelector(ctx).AddFuture(t1, func(f Future) {
+			// timer fired
+		}).AddFuture(f1, func(f Future) {
+			// child workflow completed
+		}).Select(ctx)
+
+		// either t1 or f1 is ready.
+		if f1.IsReady() {
+			return nil
+		}
+
+		// child workflow takes too long
+		return errors.New("child workflow takes too long")
+	}
+
+	// no delay to the mock call, workflow should return no error
+	env := s.NewTestWorkflowEnvironment()
+	env.OnWorkflow(testWorkflowHello, mock.Anything, mock.Anything).Return("hello_mock_delayed", nil).Once()
+	env.ExecuteWorkflow(workflowFn)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	env.AssertExpectations(s.T())
+
+	// delay 10 minutes, which is shorter than the 1 hour timer, so workflow should return no error.
+	env = s.NewTestWorkflowEnvironment()
+	env.OnWorkflow(testWorkflowHello, mock.Anything, mock.Anything).After(time.Minute*10).Return("hello_mock_delayed", nil).Once()
+	env.ExecuteWorkflow(workflowFn)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	env.AssertExpectations(s.T())
+
+	// delay 2 hours, which is longer than the 1 hour timer, and workflow should return error.
+	env = s.NewTestWorkflowEnvironment()
+	env.OnWorkflow(testWorkflowHello, mock.Anything, mock.Anything).After(time.Hour*2).Return("hello_mock_delayed", nil).Once()
+	env.ExecuteWorkflow(workflowFn)
+	s.True(env.IsWorkflowCompleted())
+	s.Error(env.GetWorkflowError())
+	env.AssertExpectations(s.T())
+
+	// no mock
+	env = s.NewTestWorkflowEnvironment()
+	env.ExecuteWorkflow(workflowFn)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+}
+
+func (s *WorkflowTestSuiteUnitTest) Test_MockPanic() {
+	// mock panic, verify that the panic won't be swallowed by our panic handler to detect unexpected mock call.
+	oldLogger := s.GetLogger()
+	s.SetLogger(zap.NewNop()) // use no-op logger to avoid noisy logging by panic
+	env := s.NewTestWorkflowEnvironment()
+	env.OnActivity(testActivityHello, mock.Anything, mock.Anything).
+		Return("hello_mock_panic", nil).
+		Run(func(args mock.Arguments) {
+			panic("mock-panic")
+		})
+	env.ExecuteWorkflow(testWorkflowHello)
+	s.True(env.IsWorkflowCompleted())
+	err := env.GetWorkflowError()
+	s.Error(err)
+	s.Contains(err.Error(), "mock-panic")
+	env.AssertExpectations(s.T())
+	s.SetLogger(oldLogger) // restore original logger
+}


### PR DESCRIPTION
We originally thought that we could make use of the mock.Call.WaitUntil() method. And what we need was just to define a new method on our test environment to return a channel that wait on our internal workflow's mock clock. That approach doesn't work. Here is the reason: when the mock is waiting on the workflow clock, we need to mark the activity as not running, otherwise we won't be able to move forward clock and the mock will wait forever. The mock could be blocked within mock.MethodCalled(), but we don't know if it will be blocked or not before we call it because we don't have insight into the mock call object. There is no place where we could detect that mock call is about to be blocked and we need to reduce the runningCount.

In order to make this work, we need a hook method that will be called before mock call is waiting on our workflow clock. This is achieved by setup a run function for the mock call via *mock.Call.Run(fn), and define our MockCallWrapper struct and intercept the .After()  and .Run() method on the mock call object.
