### PR TITLE
GetVersion implementation

### DIFF
--- a/internal_decision_state_machine.go
+++ b/internal_decision_state_machine.go
@@ -23,9 +23,6 @@ package cadence
 import (
 	"fmt"
 
-	"bytes"
-	"encoding/gob"
-
 	s "go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/common"
 	"go.uber.org/cadence/common/util"
@@ -686,15 +683,10 @@ func (h *decisionsHelper) getActivityID(event *s.HistoryEvent) string {
 
 func (h *decisionsHelper) recordVersionMarker(changeID string, version Version) decisionStateMachine {
 	markerID := fmt.Sprintf("%v_%v", versionMarkerName, changeID)
-	var buf bytes.Buffer
-	enc := gob.NewEncoder(&buf)
-	if err := enc.Encode(changeID); err != nil {
-		panic(fmt.Sprintf("Failure encoding changeID name: %v", err))
+	details, err := getHostEnvironment().encodeArgs([]interface{}{changeID, version})
+	if err != nil {
+		panic(err)
 	}
-	if err := enc.Encode(version); err != nil {
-		panic(fmt.Sprintf("Failure encoding version value: %v", err))
-	}
-	details := buf.Bytes()
 
 	recordMarker := &s.RecordMarkerDecisionAttributes{
 		MarkerName: common.StringPtr(versionMarkerName),

--- a/internal_logging_tags.go
+++ b/internal_logging_tags.go
@@ -36,5 +36,7 @@ const (
 	tagWorkerType      = "WorkerType"
 	tagSideEffectID    = "SideEffectID"
 	tagMarkerName      = "MarkerName"
+	tagChangeID        = "ChangeID"
+	tagVersion         = "Version"
 	tagChildWorkflowID = "ChildWorkflowID"
 )

--- a/internal_worker_base.go
+++ b/internal_worker_base.go
@@ -53,7 +53,7 @@ type (
 		asyncActivityClient
 		workflowTimerClient
 		SideEffect(f func() ([]byte, error), callback resultHandler)
-		GetVersion(changeID string, maxSupported, minSupported Version) Version
+		GetVersion(changeID string, minSupported, maxSupported Version) Version
 		WorkflowInfo() *WorkflowInfo
 		Complete(result []byte, err error)
 		RegisterCancelHandler(handler func())

--- a/internal_worker_base.go
+++ b/internal_worker_base.go
@@ -53,6 +53,7 @@ type (
 		asyncActivityClient
 		workflowTimerClient
 		SideEffect(f func() ([]byte, error), callback resultHandler)
+		GetVersion(changeID string, maxSupported, minSupported Version) Version
 		WorkflowInfo() *WorkflowInfo
 		Complete(result []byte, err error)
 		RegisterCancelHandler(handler func())

--- a/internal_workflow.go
+++ b/internal_workflow.go
@@ -196,6 +196,7 @@ const (
 	workflowResultContextKey      = "workflowResult"
 	coroutinesContextKey          = "coroutines"
 	workflowEnvOptionsContextKey  = "wfEnvOptions"
+	changeVersionsContextKey      = "changeVersions"
 )
 
 // Assert that structs do indeed implement the interfaces
@@ -327,6 +328,7 @@ func (d *syncWorkflowDefinition) Execute(env workflowEnvironment, input []byte) 
 	d.rootCtx = WithValue(background, workflowEnvironmentContextKey, env)
 	var resultPtr *workflowResult
 	d.rootCtx = WithValue(d.rootCtx, workflowResultContextKey, &resultPtr)
+	d.rootCtx = WithValue(d.rootCtx, changeVersionsContextKey, make(map[string]Version))
 
 	// Set default values for the workflow execution.
 	wInfo := env.WorkflowInfo()

--- a/internal_workflow.go
+++ b/internal_workflow.go
@@ -196,7 +196,6 @@ const (
 	workflowResultContextKey      = "workflowResult"
 	coroutinesContextKey          = "coroutines"
 	workflowEnvOptionsContextKey  = "wfEnvOptions"
-	changeVersionsContextKey      = "changeVersions"
 )
 
 // Assert that structs do indeed implement the interfaces
@@ -328,7 +327,6 @@ func (d *syncWorkflowDefinition) Execute(env workflowEnvironment, input []byte) 
 	d.rootCtx = WithValue(background, workflowEnvironmentContextKey, env)
 	var resultPtr *workflowResult
 	d.rootCtx = WithValue(d.rootCtx, workflowResultContextKey, &resultPtr)
-	d.rootCtx = WithValue(d.rootCtx, changeVersionsContextKey, make(map[string]Version))
 
 	// Set default values for the workflow execution.
 	wInfo := env.WorkflowInfo()

--- a/internal_workflow_testsuite.go
+++ b/internal_workflow_testsuite.go
@@ -1086,6 +1086,10 @@ func (env *testWorkflowEnvironmentImpl) SideEffect(f func() ([]byte, error), cal
 	callback(f())
 }
 
+func (env *testWorkflowEnvironmentImpl) GetVersion(changeID string, minSupported, maxSupported Version) Version {
+	return maxSupported
+}
+
 func (env *testWorkflowEnvironmentImpl) nextID() int {
 	activityID := env.counterID
 	env.counterID++

--- a/internal_workflow_testsuite.go
+++ b/internal_workflow_testsuite.go
@@ -142,8 +142,9 @@ type (
 		*testWorkflowEnvironmentShared
 		parentEnv *testWorkflowEnvironmentImpl
 
-		workflowInfo *WorkflowInfo
-		workflowDef  workflowDefinition
+		workflowInfo   *WorkflowInfo
+		workflowDef    workflowDefinition
+		changeVersions map[string]Version
 
 		workflowCancelHandler func()
 		signalHandler         func(name string, input []byte)
@@ -184,6 +185,8 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite) *testWorkflowEnvironme
 			ExecutionStartToCloseTimeoutSeconds: 1,
 			TaskStartToCloseTimeoutSeconds:      1,
 		},
+
+		changeVersions: make(map[string]Version),
 
 		doneChannel: make(chan struct{}),
 	}
@@ -1087,6 +1090,11 @@ func (env *testWorkflowEnvironmentImpl) SideEffect(f func() ([]byte, error), cal
 }
 
 func (env *testWorkflowEnvironmentImpl) GetVersion(changeID string, minSupported, maxSupported Version) Version {
+	if version, ok := env.changeVersions[changeID]; ok {
+		validateVersion(changeID, version, minSupported, maxSupported)
+		return version
+	}
+	env.changeVersions[changeID] = maxSupported
 	return maxSupported
 }
 

--- a/workflow.go
+++ b/workflow.go
@@ -108,6 +108,9 @@ type (
 	// EncodedValue is type alias used to encapsulate/extract encoded result from workflow/activity.
 	EncodedValue []byte
 
+	// Version represents a change version. See GetVersion call.
+	Version int
+
 	// ChildWorkflowOptions stores all child workflow specific parameters that will be stored inside of a Context.
 	ChildWorkflowOptions struct {
 		// Domain of the child workflow.
@@ -539,4 +542,66 @@ func SideEffect(ctx Context, f func(ctx Context) interface{}) EncodedValue {
 		panic(err)
 	}
 	return encoded
+}
+
+// DefaultVersion is a version returned by GetVersion for code that wasn't versioned before
+const DefaultVersion Version = -1
+
+// GetVersion is used to safely perform backwards incompatible changes to workflow definitions.
+// It is not allowed to update workflow code while there are workflows running as it is going to break
+// determinism. The solution is to have both old code that is used to replay existing workflows
+// as well as the new one that is used when it is executed for the first time.
+// GetVersion returns maxSupported version when is executed for the first time. This version is recorded into the
+// workflow history as a marker event. Even if maxSupported version is changed the version that was recorded is
+// returned on replay. DefaultVersion constant contains version of code that wasn't versioned before.
+// For example initially workflow has the following code:
+// err = cadence.ExecuteActivity(ctx, foo).Get(ctx, nil)
+// it should be updated to
+// err = cadence.ExecuteActivity(ctx, bar).Get(ctx, nil)
+// The backwards compatible way to execute the update is
+// v :=  GetVersion(ctx, "fooChange", DefaultVersion, 1)
+// if v  == DefaultVersion {
+//     err = cadence.ExecuteActivity(ctx, foo).Get(ctx, nil)
+// } else {
+//     err = cadence.ExecuteActivity(ctx, bar).Get(ctx, nil)
+// }
+//
+// Then bar has to be changed to baz:
+//
+// v :=  GetVersion(ctx, "fooChange", DefaultVersion, 2)
+// if v  == DefaultVersion {
+//     err = cadence.ExecuteActivity(ctx, foo).Get(ctx, nil)
+// } else if v == 1 {
+//     err = cadence.ExecuteActivity(ctx, bar).Get(ctx, nil)
+// } else {
+//     err = cadence.ExecuteActivity(ctx, baz).Get(ctx, nil)
+// }
+//
+// Later when there are no workflows running DefaultVersion the correspondent branch can be removed:
+//
+// v :=  GetVersion(ctx, "fooChange", 1, 2)
+// if v == 1 {
+//     err = cadence.ExecuteActivity(ctx, bar).Get(ctx, nil)
+// } else {
+//     err = cadence.ExecuteActivity(ctx, baz).Get(ctx, nil)
+// }
+//
+// Currently there is no supported way to completely remove GetVersion call after it was introduced.
+// Keep it even if single branch is left:
+//
+// GetVersion(ctx, "fooChange", 2, 2)
+// err = cadence.ExecuteActivity(ctx, baz).Get(ctx, nil)
+//
+// It is necessary as GetVersion performs validation of a version against a workflow history and fails decisions if
+// a workflow code is not compatible with it.
+func GetVersion(ctx Context, changeID string, minSupported, maxSupported Version) Version {
+	versions := ctx.Value(changeVersionsContextKey).(map[string]Version)
+	cv, ok := versions[changeID]
+	if ok {
+		validateVersion(changeID, cv, minSupported, maxSupported)
+		return cv
+	}
+	version := getWorkflowEnvironment(ctx).GetVersion(changeID, minSupported, maxSupported)
+	versions[changeID] = version
+	return version
 }

--- a/workflow.go
+++ b/workflow.go
@@ -595,13 +595,5 @@ const DefaultVersion Version = -1
 // It is necessary as GetVersion performs validation of a version against a workflow history and fails decisions if
 // a workflow code is not compatible with it.
 func GetVersion(ctx Context, changeID string, minSupported, maxSupported Version) Version {
-	versions := ctx.Value(changeVersionsContextKey).(map[string]Version)
-	cv, ok := versions[changeID]
-	if ok {
-		validateVersion(changeID, cv, minSupported, maxSupported)
-		return cv
-	}
-	version := getWorkflowEnvironment(ctx).GetVersion(changeID, minSupported, maxSupported)
-	versions[changeID] = version
-	return version
+	return getWorkflowEnvironment(ctx).GetVersion(changeID, minSupported, maxSupported)
 }


### PR DESCRIPTION
This is based on https://github.com/uber-go/cadence-client/pull/170, the only change is changing the map that attached to rootCtx from type map[string]*changeVersion to map[string]Version, as a result, also change the cadence.GetVersion() code a little bit.