### PR TITLE
Add worker method for blocking start to enable clean exit

### DIFF
--- a/internal_utils.go
+++ b/internal_utils.go
@@ -171,7 +171,7 @@ func awaitWaitGroup(wg *sync.WaitGroup, timeout time.Duration) bool {
 	}
 }
 
-func isProcessKilled() <-chan os.Signal {
+func getKillSignal() <-chan os.Signal {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	return c

--- a/internal_utils.go
+++ b/internal_utils.go
@@ -25,7 +25,9 @@ package cadence
 import (
 	"fmt"
 	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/uber/tchannel-go"
@@ -167,4 +169,10 @@ func awaitWaitGroup(wg *sync.WaitGroup, timeout time.Duration) bool {
 	case <-time.After(timeout):
 		return false
 	}
+}
+
+func isProcessKilled() <-chan os.Signal {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	return c
 }

--- a/internal_worker.go
+++ b/internal_worker.go
@@ -739,10 +739,10 @@ func (aw *aggregatedWorker) Start() error {
 }
 
 func (aw *aggregatedWorker) Run() {
-	Start()
-	d := <-Done()
+	aw.Start()
+	d := <-aw.Done()
 	bw.logger.Info("Worker has been killed: %s", d.String())
-	Stop()
+	aw.Stop()
 }
 
 func (aw *aggregatedWorker) Stop() {

--- a/internal_worker.go
+++ b/internal_worker.go
@@ -731,7 +731,7 @@ func (aw *aggregatedWorker) Start() error {
 
 func (aw *aggregatedWorker) Run() {
 	aw.Start()
-	d := <-isProcessKilled()
+	d := <-getKillSignal()
 	aw.logger.Info("Worker has been killed", zap.String("Signal", d.String()))
 	aw.Stop()
 }

--- a/internal_worker.go
+++ b/internal_worker.go
@@ -740,8 +740,7 @@ func (aw *aggregatedWorker) Start() error {
 
 func (aw *aggregatedWorker) Run() {
 	aw.Start()
-	d := <-aw.Done()
-	bw.logger.Info("Worker has been killed: %s", d.String())
+	<-aw.Done()
 	aw.Stop()
 }
 
@@ -760,7 +759,7 @@ func (aw *aggregatedWorker) Done() <-chan os.Signal {
 	case w := <-aw.workflowWorker.Done():
 		c <- w
 	case a := <-aw.activityWorker.Done():
-		c <= a
+		c <- a
 	}
 	return c
 }

--- a/internal_worker.go
+++ b/internal_worker.go
@@ -720,6 +720,7 @@ func (ae *activityExecutor) Execute(ctx context.Context, input []byte) ([]byte, 
 type aggregatedWorker struct {
 	workflowWorker Worker
 	activityWorker Worker
+	logger         *zap.Logger
 }
 
 func (aw *aggregatedWorker) Start() error {
@@ -740,7 +741,8 @@ func (aw *aggregatedWorker) Start() error {
 
 func (aw *aggregatedWorker) Run() {
 	aw.Start()
-	<-aw.Done()
+	d := <-aw.Done()
+	aw.logger.Info("Worker has been killed", zap.String("Signal", d.String()))
 	aw.Stop()
 }
 
@@ -837,7 +839,11 @@ func newAggregatedWorker(
 			logger.Warn("Activity worker is enabled but no activity is registered. Use cadence.RegisterActivity() to register your activity.")
 		}
 	}
-	return &aggregatedWorker{workflowWorker: workflowWorker, activityWorker: activityWorker}
+	return &aggregatedWorker{
+		workflowWorker: workflowWorker,
+		activityWorker: activityWorker,
+		logger:         logger,
+	}
 }
 
 func (th *hostEnvImpl) newRegisteredWorkflowFactory() workflowFactory {

--- a/internal_worker.go
+++ b/internal_worker.go
@@ -278,7 +278,7 @@ func (aw *activityWorker) Stop() {
 }
 
 // Done returns the exit channel
-func (aw *activityWorker) Done() chan os.Signal {
+func (aw *activityWorker) Done() <-chan os.Signal {
 	return aw.worker.Done()
 }
 
@@ -754,7 +754,7 @@ func (aw *aggregatedWorker) Stop() {
 	}
 }
 
-func (aw *aggregatedWorker) Done() chan os.Signal {
+func (aw *aggregatedWorker) Done() <-chan os.Signal {
 	c := make(chan os.Signal, 1)
 	select {
 	case w := <-aw.workflowWorker.Done():

--- a/internal_worker_base.go
+++ b/internal_worker_base.go
@@ -23,10 +23,7 @@ package cadence
 // All code in this file is private to the package.
 
 import (
-	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
 	m "go.uber.org/cadence/.gen/go/cadence"
@@ -135,7 +132,7 @@ func (bw *baseWorker) Start() {
 
 func (bw *baseWorker) Run() {
 	bw.Start()
-	d := <-bw.Done()
+	d := <-isProcessKilled()
 	bw.logger.Info("Worker has been killed", zap.String("Signal", d.String()))
 	bw.Stop()
 }
@@ -153,12 +150,6 @@ func (bw *baseWorker) Stop() {
 	if success := awaitWaitGroup(&bw.shutdownWG, 2*time.Second); !success {
 		bw.logger.Info("Worker timed out on waiting for shutdown.")
 	}
-}
-
-func (bw *baseWorker) Done() <-chan os.Signal {
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-	return c
 }
 
 // execute handler wraps call to process a task.

--- a/internal_worker_base.go
+++ b/internal_worker_base.go
@@ -137,7 +137,7 @@ func (bw *baseWorker) Start() {
 func (bw *baseWorker) Run() {
 	bw.Start()
 	d := <-bw.Done()
-	bw.logger.Info("Worker has been killed: %s", d.String())
+	bw.logger.Info("Worker has been killed", zap.String("Signal", d.String()))
 	bw.Stop()
 }
 

--- a/internal_worker_base.go
+++ b/internal_worker_base.go
@@ -163,10 +163,10 @@ func (bw *baseWorker) Done() <-chan os.Signal {
 
 // execute handler wraps call to process a task.
 func (bw *baseWorker) execute(routineID int) {
-	ch := make(chan struct{})
-	defer close(ch)
 	for {
+		ch := make(chan struct{})
 		go func() {
+			defer close(ch)
 			// Check if we have to backoff.
 			// TODO: Check if this is needed concurrent retires (or) per connection retrier.
 			bw.retrier.Throttle()

--- a/internal_worker_base.go
+++ b/internal_worker_base.go
@@ -135,10 +135,10 @@ func (bw *baseWorker) Start() {
 }
 
 func (bw *baseWorker) Run() {
-	Start()
-	d := <-Done()
+	bw.Start()
+	d := <-bw.Done()
 	bw.logger.Info("Worker has been killed: %s", d.String())
-	Stop()
+	bw.Stop()
 }
 
 // Shutdown is a blocking call and cleans up all the resources assosciated with worker.

--- a/internal_worker_base.go
+++ b/internal_worker_base.go
@@ -122,11 +122,10 @@ func (bw *baseWorker) Start() {
 	if bw.isWorkerStarted {
 		return
 	}
-	// Add the total number of routines to the wait group
-	bw.shutdownWG.Add(bw.options.routineCount)
 
 	// Launch the routines to do work
 	for i := 0; i < bw.options.routineCount; i++ {
+		bw.shutdownWG.Add(1)
 		go bw.execute(i)
 	}
 

--- a/internal_worker_test.go
+++ b/internal_worker_test.go
@@ -251,7 +251,7 @@ func createWorker(t *testing.T, service *mocks.TChanWorkflowService) Worker {
 	service.On("RespondDecisionTaskCompleted", mock.Anything, mock.Anything).Return(nil)
 
 	// Configure worker options.
-	workerOptions := WorkerOptions{logger: zap.New}
+	workerOptions := WorkerOptions{}
 	workerOptions.MaxActivityExecutionRate = 20
 
 	// Start Worker.

--- a/internal_worker_test.go
+++ b/internal_worker_test.go
@@ -24,12 +24,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	s "go.uber.org/cadence/.gen/go/shared"
@@ -174,6 +177,33 @@ func testActivityMultipleArgs(ctx context.Context, arg1 int, arg2 string, arg3 b
 func TestCreateWorker(t *testing.T) {
 	// Create service endpoint
 	service := new(mocks.TChanWorkflowService)
+	worker := createWorker(t, service)
+	err := worker.Start()
+	require.NoError(t, err)
+	time.Sleep(time.Millisecond * 200)
+	worker.Stop()
+	service.AssertExpectations(t)
+}
+
+func TestCreateWorkerRun(t *testing.T) {
+	// Create service endpoint
+	service := new(mocks.TChanWorkflowService)
+	worker := createWorker(t, service)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		worker.Run()
+	}()
+	time.Sleep(time.Millisecond * 200)
+	p, err := os.FindProcess(os.Getpid())
+	assert.NoError(t, err)
+	p.Signal(os.Interrupt)
+	wg.Wait()
+	service.AssertExpectations(t)
+}
+
+func createWorker(t *testing.T, service *mocks.TChanWorkflowService) Worker {
 	//logger := getLogger()
 
 	domain := "testDomain"
@@ -221,7 +251,7 @@ func TestCreateWorker(t *testing.T) {
 	service.On("RespondDecisionTaskCompleted", mock.Anything, mock.Anything).Return(nil)
 
 	// Configure worker options.
-	workerOptions := WorkerOptions{}
+	workerOptions := WorkerOptions{logger: zap.New}
 	workerOptions.MaxActivityExecutionRate = 20
 
 	// Start Worker.
@@ -230,11 +260,7 @@ func TestCreateWorker(t *testing.T) {
 		domain,
 		"testGroupName2",
 		workerOptions)
-	err = worker.Start()
-	require.NoError(t, err)
-	time.Sleep(time.Millisecond * 200)
-	worker.Stop()
-	service.AssertExpectations(t)
+	return worker
 }
 
 func TestCompleteActivity(t *testing.T) {

--- a/internal_worker_test.go
+++ b/internal_worker_test.go
@@ -198,7 +198,7 @@ func TestCreateWorkerRun(t *testing.T) {
 	time.Sleep(time.Millisecond * 200)
 	p, err := os.FindProcess(os.Getpid())
 	assert.NoError(t, err)
-	p.Signal(os.Interrupt)
+	assert.NoError(t, p.Signal(os.Interrupt))
 	wg.Wait()
 	service.AssertExpectations(t)
 }

--- a/worker.go
+++ b/worker.go
@@ -22,6 +22,7 @@ package cadence
 
 import (
 	"context"
+	"os"
 
 	"github.com/uber-go/tally"
 	m "go.uber.org/cadence/.gen/go/cadence"
@@ -31,8 +32,14 @@ import (
 type (
 	// Worker represents objects that can be started and stopped.
 	Worker interface {
-		Stop()
+		// Start starts the worker in a non-blocking fashion
 		Start() error
+		// Run is a blocking start and cleans up resources when killed
+		Run()
+		// Stop cleans up any resources opened by worker
+		Stop()
+		// Done returns a channel that is sent a message when the process has been killed
+		Done() <-chan os.Signal
 	}
 
 	// WorkerOptions is to configure a worker instance,

--- a/worker.go
+++ b/worker.go
@@ -39,7 +39,7 @@ type (
 		// Stop cleans up any resources opened by worker
 		Stop()
 		// Done returns a channel that is sent a message when the process has been killed
-		Done() chan os.Signal
+		Done() <-chan os.Signal
 	}
 
 	// WorkerOptions is to configure a worker instance,

--- a/worker.go
+++ b/worker.go
@@ -39,7 +39,7 @@ type (
 		// Stop cleans up any resources opened by worker
 		Stop()
 		// Done returns a channel that is sent a message when the process has been killed
-		Done() <-chan os.Signal
+		Done() chan os.Signal
 	}
 
 	// WorkerOptions is to configure a worker instance,

--- a/worker.go
+++ b/worker.go
@@ -22,7 +22,6 @@ package cadence
 
 import (
 	"context"
-	"os"
 
 	"github.com/uber-go/tally"
 	m "go.uber.org/cadence/.gen/go/cadence"
@@ -38,8 +37,6 @@ type (
 		Run()
 		// Stop cleans up any resources opened by worker
 		Stop()
-		// Done returns a channel that is sent a message when the process has been killed
-		Done() <-chan os.Signal
 	}
 
 	// WorkerOptions is to configure a worker instance,


### PR DESCRIPTION
Fixes https://github.com/uber/cadence/issues/254. Today client is killed, defer functions do not get called. The context does not get cancelled and in turn the server is not notified.

This adds a blocking Run method that cadence users can use that takes care of clean exit. Users that don't want a blocking call can use Start, wait on Done channel for exit and call Stop explicitly.

Also fixes a waitgroup bug in Stop.