### PR TITLE
Select Future stale registered callback can modify state

### DIFF
--- a/internal_coroutines_test.go
+++ b/internal_coroutines_test.go
@@ -1044,24 +1044,24 @@ func TestSelectFuture_WithBatchSets(t *testing.T) {
 
 		s := NewSelector(ctx)
 		s.
-		AddFuture(future1, func(f Future) {
-			var v string
-			err := f.Get(ctx, &v)
-			assert.Nil(t, err)
-			history = append(history, fmt.Sprintf("c1-%v", v))
-		}).
+			AddFuture(future1, func(f Future) {
+				var v string
+				err := f.Get(ctx, &v)
+				assert.Nil(t, err)
+				history = append(history, fmt.Sprintf("c1-%v", v))
+			}).
 			AddFuture(future2, func(f Future) {
-			var v string
-			err := f.Get(ctx, &v)
-			assert.Nil(t, err)
-			history = append(history, fmt.Sprintf("c2-%v", v))
-		}).
+				var v string
+				err := f.Get(ctx, &v)
+				assert.Nil(t, err)
+				history = append(history, fmt.Sprintf("c2-%v", v))
+			}).
 			AddFuture(future3, func(f Future) {
-			var v string
-			err := f.Get(ctx, &v)
-			assert.Nil(t, err)
-			history = append(history, fmt.Sprintf("c3-%v", v))
-		})
+				var v string
+				err := f.Get(ctx, &v)
+				assert.Nil(t, err)
+				history = append(history, fmt.Sprintf("c3-%v", v))
+			})
 
 		settable2.Set("two", nil)
 		s.Select(ctx)
@@ -1083,4 +1083,3 @@ func TestSelectFuture_WithBatchSets(t *testing.T) {
 	}
 	require.EqualValues(t, expected, history)
 }
-

--- a/internal_coroutines_test.go
+++ b/internal_coroutines_test.go
@@ -1034,3 +1034,53 @@ func TestDecodeFutureChain(t *testing.T) {
 	}
 	require.EqualValues(t, expected, history)
 }
+
+func TestSelectFuture_WithBatchSets(t *testing.T) {
+	var history []string
+	d := newDispatcher(background, func(ctx Context) {
+		future1, settable1 := NewFuture(ctx)
+		future2, settable2 := NewFuture(ctx)
+		future3, settable3 := NewFuture(ctx)
+
+		s := NewSelector(ctx)
+		s.
+		AddFuture(future1, func(f Future) {
+			var v string
+			err := f.Get(ctx, &v)
+			assert.Nil(t, err)
+			history = append(history, fmt.Sprintf("c1-%v", v))
+		}).
+			AddFuture(future2, func(f Future) {
+			var v string
+			err := f.Get(ctx, &v)
+			assert.Nil(t, err)
+			history = append(history, fmt.Sprintf("c2-%v", v))
+		}).
+			AddFuture(future3, func(f Future) {
+			var v string
+			err := f.Get(ctx, &v)
+			assert.Nil(t, err)
+			history = append(history, fmt.Sprintf("c3-%v", v))
+		})
+
+		settable2.Set("two", nil)
+		s.Select(ctx)
+		settable3.Set("three", nil)
+		settable1.Set("one", nil)
+		s.Select(ctx)
+		s.Select(ctx)
+	})
+	err := d.ExecuteUntilAllBlocked()
+	if err != nil {
+		require.NoError(t, err, err.StackTrace())
+	}
+	require.True(t, d.IsDone())
+
+	expected := []string{
+		"c2-two",
+		"c1-one",
+		"c3-three",
+	}
+	require.EqualValues(t, expected, history)
+}
+

--- a/internal_workflow.go
+++ b/internal_workflow.go
@@ -888,8 +888,8 @@ func (s *selectorImpl) Select(ctx Context) {
 				if readyBranch != nil {
 					return false
 				}
-				p.futureFunc = nil
 				readyBranch = func() {
+					p.futureFunc = nil
 					f(p.future)
 				}
 				return true


### PR DESCRIPTION
Selector future can have many callbacks registered with the channel for receiving notifications on each ask. One of the stale callback getting executed while closing the channel(after getting a value on the future) can modify the current state that indicates that we have processed this future for the select. This with batch replay can end loosing notifying select.