### PR TITLE
Reorder history slice to make copy instead of pointing to underlying slice

### DIFF
--- a/internal_task_handlers.go
+++ b/internal_task_handlers.go
@@ -274,7 +274,8 @@ OrderEvents:
 
 	// First are events that correspond to the previous task decisions
 	if lastDecisionIndex >= 0 {
-		reorderedEvents = decisionCompletionToStartEvents[:lastDecisionIndex+1]
+		// Make a copy of the slice.
+		reorderedEvents = append(reorderedEvents, decisionCompletionToStartEvents[:lastDecisionIndex+1]...)
 	}
 	// Second are events that were added during previous task execution
 	reorderedEvents = append(reorderedEvents, decisionStartToCompletionEvents...)


### PR DESCRIPTION

The way the re-order stitches the events from decisionCompletionToStartEvents, can cause it to overwrite the rest of the part because of the first copy contains a pointer to underlying slice, appending to that will overwrite the event, this can have unexpected behavior like replaying same event twice.
#187 