### PR TITLE
wrap metrics scope for workflow code

### DIFF
--- a/common/metrics/scope.go
+++ b/common/metrics/scope.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package metrics
 
 import (

--- a/common/metrics/scope.go
+++ b/common/metrics/scope.go
@@ -71,7 +71,9 @@ type (
 	}
 )
 
-// WrapScope wraps a scope and skip recording metrics when isReplay is true
+// WrapScope wraps a scope and skip recording metrics when isReplay is true.
+// This is designed to be used by only by workflowEnvironmentImpl so we suppress metrics while replaying history events.
+// Parameter isReplay is a pointer to workflowEnvironmentImpl.isReplay which will be updated when replaying history events.
 func WrapScope(isReplay *bool, scope tally.Scope, clock Clock) tally.Scope {
 	return &replayAwareScope{isReplay, scope, clock}
 }

--- a/common/metrics/scope.go
+++ b/common/metrics/scope.go
@@ -1,0 +1,166 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/uber-go/tally"
+)
+
+type (
+	// Clock defines interface used as time source
+	Clock interface {
+		Now() time.Time
+	}
+
+	durationRecorder interface {
+		RecordDuration(duration time.Duration)
+	}
+
+	replayAwareScope struct {
+		isReplay *bool
+		scope    tally.Scope
+		clock    Clock
+	}
+
+	replayAwareCounter struct {
+		isReplay *bool
+		counter  tally.Counter
+	}
+
+	replayAwareGauge struct {
+		isReplay *bool
+		gauge    tally.Gauge
+	}
+
+	replayAwareTimer struct {
+		isReplay *bool
+		timer    tally.Timer
+		clock    Clock
+	}
+
+	replayAwareHistogram struct {
+		isReplay  *bool
+		histogram tally.Histogram
+		clock     Clock
+	}
+
+	replayAwareStopwatchRecorder struct {
+		isReplay *bool
+		recorder durationRecorder
+		clock    Clock
+	}
+)
+
+// WrapScope wraps a scope and skip recording metrics when isReplay is true
+func WrapScope(isReplay *bool, scope tally.Scope, clock Clock) tally.Scope {
+	return &replayAwareScope{isReplay, scope, clock}
+}
+
+// Inc increments the counter by a delta.
+func (c *replayAwareCounter) Inc(delta int64) {
+	if *c.isReplay {
+		return
+	}
+	c.counter.Inc(delta)
+}
+
+// Update sets the gauges absolute value.
+func (g *replayAwareGauge) Update(value float64) {
+	if *g.isReplay {
+		return
+	}
+	g.gauge.Update(value)
+}
+
+// Record a specific duration.
+func (t *replayAwareTimer) Record(value time.Duration) {
+	if *t.isReplay {
+		return
+	}
+	t.timer.Record(value)
+}
+
+// Record a specific duration.
+func (t *replayAwareTimer) RecordDuration(duration time.Duration) {
+	t.Record(duration)
+}
+
+// Start gives you back a specific point in time to report via Stop.
+func (t *replayAwareTimer) Start() tally.Stopwatch {
+	return tally.NewStopwatch(t.clock.Now(), &replayAwareStopwatchRecorder{t.isReplay, t, t.clock})
+}
+
+// RecordValue records a specific value directly. Will use the configured value buckets for the histogram.
+func (h *replayAwareHistogram) RecordValue(value float64) {
+	if *h.isReplay {
+		return
+	}
+	h.histogram.RecordValue(value)
+}
+
+// RecordDuration records a specific duration directly.
+// Will use the configured duration buckets for the histogram.
+func (h *replayAwareHistogram) RecordDuration(value time.Duration) {
+	if *h.isReplay {
+		return
+	}
+	h.histogram.RecordDuration(value)
+}
+
+// Start gives you a specific point in time to then record a duration.
+// Will use the configured duration buckets for the histogram.
+func (h *replayAwareHistogram) Start() tally.Stopwatch {
+	return tally.NewStopwatch(h.clock.Now(), &replayAwareStopwatchRecorder{h.isReplay, h, h.clock})
+}
+
+// StopwatchRecorder is a recorder that is called when a stopwatch is stopped with Stop().
+func (r *replayAwareStopwatchRecorder) RecordStopwatch(stopwatchStart time.Time) {
+	if *r.isReplay {
+		return
+	}
+	d := r.clock.Now().Sub(stopwatchStart)
+	r.recorder.RecordDuration(d)
+}
+
+// Counter returns the Counter object corresponding to the name.
+func (s *replayAwareScope) Counter(name string) tally.Counter {
+	return &replayAwareCounter{s.isReplay, s.scope.Counter(name)}
+}
+
+// Gauge returns the Gauge object corresponding to the name.
+func (s *replayAwareScope) Gauge(name string) tally.Gauge {
+	return &replayAwareGauge{s.isReplay, s.scope.Gauge(name)}
+}
+
+// Timer returns the Timer object corresponding to the name.
+func (s *replayAwareScope) Timer(name string) tally.Timer {
+	return &replayAwareTimer{s.isReplay, s.scope.Timer(name), s.clock}
+}
+
+// Histogram returns the Histogram object corresponding to the name.
+// To use default value and duration buckets configured for the scope
+// simply pass tally.DefaultBuckets or nil.
+// You can use tally.ValueBuckets{x, y, ...} for value buckets.
+// You can use tally.DurationBuckets{x, y, ...} for duration buckets.
+// You can use tally.MustMakeLinearValueBuckets(start, width, count) for linear values.
+// You can use tally.MustMakeLinearDurationBuckets(start, width, count) for linear durations.
+// You can use tally.MustMakeExponentialValueBuckets(start, factor, count) for exponential values.
+// You can use tally.MustMakeExponentialDurationBuckets(start, factor, count) for exponential durations.
+func (s *replayAwareScope) Histogram(name string, buckets tally.Buckets) tally.Histogram {
+	return &replayAwareHistogram{s.isReplay, s.scope.Histogram(name, buckets), s.clock}
+}
+
+// Tagged returns a new child scope with the given tags and current tags.
+func (s *replayAwareScope) Tagged(tags map[string]string) tally.Scope {
+	return &replayAwareScope{s.isReplay, s.scope.Tagged(tags), s.clock}
+}
+
+// SubScope returns a new child scope appending a further name prefix.
+func (s *replayAwareScope) SubScope(name string) tally.Scope {
+	return &replayAwareScope{s.isReplay, s.scope.SubScope(name), s.clock}
+}
+
+// Capabilities returns a description of metrics reporting capabilities.
+func (s *replayAwareScope) Capabilities() tally.Capabilities {
+	return s.scope.Capabilities()
+}

--- a/common/metrics/scope_test.go
+++ b/common/metrics/scope_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package metrics
 
 import (

--- a/common/metrics/scope_test.go
+++ b/common/metrics/scope_test.go
@@ -1,0 +1,213 @@
+package metrics
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+)
+
+func Test_Counter(t *testing.T) {
+	isReplay := true
+	scope, closer, reporter := newMetricsScope(&isReplay)
+	scope.Counter("test-name").Inc(1)
+	closer.Close()
+	require.Equal(t, 0, len(reporter.counts))
+
+	isReplay = false
+	scope, closer, reporter = newMetricsScope(&isReplay)
+	scope.Counter("test-name").Inc(3)
+	closer.Close()
+	require.Equal(t, 1, len(reporter.counts))
+	require.Equal(t, int64(3), reporter.counts[0].value)
+}
+
+func Test_Gauge(t *testing.T) {
+	isReplay := true
+	scope, closer, reporter := newMetricsScope(&isReplay)
+	scope.Gauge("test-name").Update(1)
+	closer.Close()
+	require.Equal(t, 0, len(reporter.gauges))
+
+	isReplay = false
+	scope, closer, reporter = newMetricsScope(&isReplay)
+	scope.Gauge("test-name").Update(3)
+	closer.Close()
+	require.Equal(t, 1, len(reporter.gauges))
+	require.Equal(t, float64(3), reporter.gauges[0].value)
+}
+
+func Test_Timer(t *testing.T) {
+	isReplay := true
+	scope, closer, reporter := newMetricsScope(&isReplay)
+	scope.Timer("test-name").Record(time.Second)
+	sw := scope.Timer("test-stopwatch").Start()
+	sw.Stop()
+	closer.Close()
+	require.Equal(t, 0, len(reporter.timers))
+
+	isReplay = false
+	scope, closer, reporter = newMetricsScope(&isReplay)
+	scope.Timer("test-name").Record(time.Second)
+	sw = scope.Timer("test-stopwatch").Start()
+	sw.Stop()
+	closer.Close()
+	require.Equal(t, 2, len(reporter.timers))
+	require.Equal(t, time.Second, reporter.timers[0].value)
+}
+
+func Test_Histogram(t *testing.T) {
+	isReplay := true
+	scope, closer, reporter := newMetricsScope(&isReplay)
+	valueBuckets := tally.MustMakeLinearValueBuckets(0, 10, 10)
+	scope.Histogram("test-hist-1", valueBuckets).RecordValue(5)
+	scope.Histogram("test-hist-2", valueBuckets).RecordValue(15)
+	closer.Close()
+	require.Equal(t, 0, len(reporter.histogramValueSamples))
+	require.Equal(t, 0, len(reporter.histogramDurationSamples))
+
+	isReplay = false
+	scope, closer, reporter = newMetricsScope(&isReplay)
+	valueBuckets = tally.MustMakeLinearValueBuckets(0, 10, 10)
+	scope.Histogram("test-hist-1", valueBuckets).RecordValue(5)
+	scope.Histogram("test-hist-2", valueBuckets).RecordValue(15)
+	closer.Close()
+	require.Equal(t, 2, len(reporter.histogramValueSamples))
+
+	scope, closer, reporter = newMetricsScope(&isReplay)
+	durationBuckets := tally.MustMakeLinearDurationBuckets(0, time.Hour, 10)
+	scope.Histogram("test-hist-1", durationBuckets).RecordDuration(time.Minute)
+	scope.Histogram("test-hist-2", durationBuckets).RecordDuration(time.Minute * 61)
+	sw := scope.Histogram("test-hist-3", durationBuckets).Start()
+	sw.Stop()
+	closer.Close()
+	require.Equal(t, 3, len(reporter.histogramDurationSamples))
+}
+
+func newMetricsScope(isReplay *bool) (tally.Scope, io.Closer, *capturingStatsReporter) {
+	reporter := &capturingStatsReporter{}
+	opts := tally.ScopeOptions{Reporter: reporter}
+	scope, closer := tally.NewRootScope(opts, time.Second)
+	return WrapScope(isReplay, scope, &realClock{}), closer, reporter
+}
+
+type realClock struct {
+}
+
+func (c *realClock) Now() time.Time {
+	return time.Now()
+}
+
+// capturingStatsReporter is a reporter used by tests to capture the metric so we can verify our tests.
+type capturingStatsReporter struct {
+	counts                   []capturedCount
+	gauges                   []capturedGauge
+	timers                   []capturedTimer
+	histogramValueSamples    []capturedHistogramValueSamples
+	histogramDurationSamples []capturedHistogramDurationSamples
+	capabilities             int
+	flush                    int
+}
+
+type capturedCount struct {
+	name  string
+	tags  map[string]string
+	value int64
+}
+
+type capturedGauge struct {
+	name  string
+	tags  map[string]string
+	value float64
+}
+
+type capturedTimer struct {
+	name  string
+	tags  map[string]string
+	value time.Duration
+}
+
+type capturedHistogramValueSamples struct {
+	name             string
+	tags             map[string]string
+	bucketLowerBound float64
+	bucketUpperBound float64
+	samples          int64
+}
+
+type capturedHistogramDurationSamples struct {
+	name             string
+	tags             map[string]string
+	bucketLowerBound time.Duration
+	bucketUpperBound time.Duration
+	samples          int64
+}
+
+func (r *capturingStatsReporter) ReportCounter(
+	name string,
+	tags map[string]string,
+	value int64,
+) {
+	r.counts = append(r.counts, capturedCount{name, tags, value})
+}
+
+func (r *capturingStatsReporter) ReportGauge(
+	name string,
+	tags map[string]string,
+	value float64,
+) {
+	r.gauges = append(r.gauges, capturedGauge{name, tags, value})
+}
+
+func (r *capturingStatsReporter) ReportTimer(
+	name string,
+	tags map[string]string,
+	value time.Duration,
+) {
+	r.timers = append(r.timers, capturedTimer{name, tags, value})
+}
+
+func (r *capturingStatsReporter) ReportHistogramValueSamples(
+	name string,
+	tags map[string]string,
+	buckets tally.Buckets,
+	bucketLowerBound,
+	bucketUpperBound float64,
+	samples int64,
+) {
+	elem := capturedHistogramValueSamples{name, tags,
+		bucketLowerBound, bucketUpperBound, samples}
+	r.histogramValueSamples = append(r.histogramValueSamples, elem)
+}
+
+func (r *capturingStatsReporter) ReportHistogramDurationSamples(
+	name string,
+	tags map[string]string,
+	buckets tally.Buckets,
+	bucketLowerBound,
+	bucketUpperBound time.Duration,
+	samples int64,
+) {
+	elem := capturedHistogramDurationSamples{name, tags,
+		bucketLowerBound, bucketUpperBound, samples}
+	r.histogramDurationSamples = append(r.histogramDurationSamples, elem)
+}
+
+func (r *capturingStatsReporter) Capabilities() tally.Capabilities {
+	r.capabilities++
+	return r
+}
+
+func (r *capturingStatsReporter) Reporting() bool {
+	return true
+}
+
+func (r *capturingStatsReporter) Tagging() bool {
+	return true
+}
+
+func (r *capturingStatsReporter) Flush() {
+	r.flush++
+}

--- a/internal_activity.go
+++ b/internal_activity.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )
 
@@ -76,6 +77,7 @@ type (
 		activityType      ActivityType
 		serviceInvoker    ServiceInvoker
 		logger            *zap.Logger
+		metricsScope      tally.Scope
 	}
 )
 

--- a/internal_event_handlers.go
+++ b/internal_event_handlers.go
@@ -27,8 +27,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/uber-go/tally"
 	m "go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/common"
+	"go.uber.org/cadence/common/metrics"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -85,6 +87,8 @@ type (
 		logger                *zap.Logger
 		isReplay              bool // flag to indicate if workflow is in replay mode
 		enableLoggingInReplay bool // flag to indicate if workflow should enable logging in replay mode
+
+		metricsScope tally.Scope
 	}
 
 	// wrapper around zapcore.Core that will be aware of replay
@@ -114,7 +118,7 @@ func (c *replayAwareZapCore) With(fields []zapcore.Field) zapcore.Core {
 }
 
 func newWorkflowExecutionEventHandler(workflowInfo *WorkflowInfo, workflowDefinitionFactory workflowDefinitionFactory,
-	completeHandler completionHandler, logger *zap.Logger, enableLoggingInReplay bool) workflowExecutionEventHandler {
+	completeHandler completionHandler, logger *zap.Logger, enableLoggingInReplay bool, scope tally.Scope) workflowExecutionEventHandler {
 	context := &workflowEnvironmentImpl{
 		workflowInfo:              workflowInfo,
 		workflowDefinitionFactory: workflowDefinitionFactory,
@@ -129,6 +133,10 @@ func newWorkflowExecutionEventHandler(workflowInfo *WorkflowInfo, workflowDefini
 		zapcore.Field{Key: tagWorkflowID, Type: zapcore.StringType, String: workflowInfo.WorkflowExecution.ID},
 		zapcore.Field{Key: tagRunID, Type: zapcore.StringType, String: workflowInfo.WorkflowExecution.RunID},
 	).WithOptions(zap.WrapCore(wrapLogger(&context.isReplay, &context.enableLoggingInReplay)))
+
+	if scope != nil {
+		context.metricsScope = metrics.WrapScope(&context.isReplay, scope, context)
+	}
 
 	return &workflowExecutionEventHandlerImpl{context, nil}
 }
@@ -229,6 +237,10 @@ func (wc *workflowEnvironmentImpl) RegisterSignalHandler(handler func(name strin
 
 func (wc *workflowEnvironmentImpl) GetLogger() *zap.Logger {
 	return wc.logger
+}
+
+func (wc *workflowEnvironmentImpl) GetMetricsScope() tally.Scope {
+	return wc.metricsScope
 }
 
 func (wc *workflowEnvironmentImpl) GenerateSequenceID() string {

--- a/internal_task_handlers.go
+++ b/internal_task_handlers.go
@@ -369,7 +369,7 @@ func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 	}
 
 	eventHandler := newWorkflowExecutionEventHandler(
-		workflowInfo, wth.workflowDefFactory, completeHandler, wth.logger, wth.enableLoggingInReplay)
+		workflowInfo, wth.workflowDefFactory, completeHandler, wth.logger, wth.enableLoggingInReplay, wth.metricsScope)
 	defer eventHandler.Close()
 	reorderedHistory := newHistory(&workflowTask{task: task, getHistoryPageFunc: getHistoryPage}, eventHandler.(*workflowExecutionEventHandlerImpl))
 	decisions := []*s.Decision{}
@@ -922,7 +922,7 @@ func (ath *activityTaskHandlerImpl) Execute(t *s.PollForActivityTaskResponse) (r
 	canCtx, cancel := context.WithCancel(rootCtx)
 	invoker := newServiceInvoker(t.TaskToken, ath.identity, ath.service, cancel, t.GetHeartbeatTimeoutSeconds())
 	defer invoker.Close()
-	ctx := WithActivityTask(canCtx, t, invoker, ath.logger)
+	ctx := WithActivityTask(canCtx, t, invoker, ath.logger, ath.metricsScope)
 	activityType := *t.GetActivityType()
 	activityImplementation, ok := ath.implementations[flowActivityTypeFrom(activityType)]
 	if !ok {

--- a/internal_worker.go
+++ b/internal_worker.go
@@ -154,6 +154,10 @@ func ensureRequiredParams(params *workerExecutionParameters) {
 		params.Logger = logger
 		params.Logger.Info("No logger configured for cadence worker. Created default one.")
 	}
+
+	if params.MetricsScope == nil {
+		params.MetricsScope = tally.NoopScope
+	}
 }
 
 func newWorkflowWorkerInternal(

--- a/internal_worker_base.go
+++ b/internal_worker_base.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/uber-go/tally"
 	m "go.uber.org/cadence/.gen/go/cadence"
 	"go.uber.org/cadence/common/backoff"
 	"go.uber.org/zap"
@@ -61,6 +62,7 @@ type (
 		RequestCancelWorkflow(domainName, workflowID, runID string) error
 		ExecuteChildWorkflow(options workflowOptions, callback resultHandler, startedHandler func(r WorkflowExecution, e error)) error
 		GetLogger() *zap.Logger
+		GetMetricsScope() tally.Scope
 		RegisterSignalHandler(handler func(name string, input []byte))
 	}
 

--- a/internal_workflow_testsuite.go
+++ b/internal_workflow_testsuite.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/facebookgo/clock"
 	"github.com/stretchr/testify/mock"
+	"github.com/uber-go/tally"
 	"github.com/uber/tchannel-go/thrift"
 	"go.uber.org/atomic"
 	m "go.uber.org/cadence/.gen/go/cadence"
@@ -226,6 +227,11 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite) *testWorkflowEnvironme
 
 	if env.workerOptions.Logger == nil {
 		env.workerOptions.Logger = env.logger
+	}
+	if s.scope != nil {
+		env.workerOptions.MetricsScope = s.scope
+	} else {
+		env.workerOptions.MetricsScope = tally.NoopScope
 	}
 
 	return env
@@ -630,6 +636,10 @@ func (env *testWorkflowEnvironmentImpl) CompleteActivity(taskToken []byte, resul
 
 func (env *testWorkflowEnvironmentImpl) GetLogger() *zap.Logger {
 	return env.logger
+}
+
+func (env *testWorkflowEnvironmentImpl) GetMetricsScope() tally.Scope {
+	return env.workerOptions.MetricsScope
 }
 
 func (env *testWorkflowEnvironmentImpl) ExecuteActivity(parameters executeActivityParameters, callback resultHandler) *activityInfo {

--- a/workflow.go
+++ b/workflow.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/uber-go/tally"
 	"go.uber.org/cadence/common"
 	"go.uber.org/zap"
 )
@@ -364,6 +365,11 @@ func GetWorkflowInfo(ctx Context) *WorkflowInfo {
 // GetLogger returns a logger to be used in workflow's context
 func GetLogger(ctx Context) *zap.Logger {
 	return getWorkflowEnvironment(ctx).GetLogger()
+}
+
+// GetMetricsScope returns a metrics scope to be used in workflow's context
+func GetMetricsScope(ctx Context) tally.Scope {
+	return getWorkflowEnvironment(ctx).GetMetricsScope()
 }
 
 // Now returns the current time when the decision is started or replayed.

--- a/workflow_testsuite.go
+++ b/workflow_testsuite.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/mock"
+	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )
 
@@ -37,6 +38,7 @@ type (
 	// WorkflowTestSuite is the test suite to run unit tests for workflow/activity.
 	WorkflowTestSuite struct {
 		logger  *zap.Logger
+		scope   tally.Scope
 		hostEnv *hostEnvImpl
 		locker  sync.Mutex
 	}
@@ -134,6 +136,13 @@ func (s *WorkflowTestSuite) SetLogger(logger *zap.Logger) {
 func (s *WorkflowTestSuite) GetLogger() *zap.Logger {
 	s.initIfNotDoneYet()
 	return s.logger
+}
+
+// SetMetricsScope sets the metrics scope for this WorkflowTestSuite. If you don't set scope, test suite will create a test
+// scope using tally.NewTestScope().
+func (s *WorkflowTestSuite) SetMetricsScope(scope tally.Scope) {
+	s.initIfNotDoneYet()
+	s.scope = scope
 }
 
 // ExecuteActivity executes an activity. The tested activity will be executed synchronously in the calling goroutinue.

--- a/workflow_testsuite.go
+++ b/workflow_testsuite.go
@@ -138,8 +138,8 @@ func (s *WorkflowTestSuite) GetLogger() *zap.Logger {
 	return s.logger
 }
 
-// SetMetricsScope sets the metrics scope for this WorkflowTestSuite. If you don't set scope, test suite will create a test
-// scope using tally.NewTestScope().
+// SetMetricsScope sets the metrics scope for this WorkflowTestSuite. If you don't set scope, test suite will use
+// tally.NoopScope
 func (s *WorkflowTestSuite) SetMetricsScope(scope tally.Scope) {
 	s.initIfNotDoneYet()
 	s.scope = scope


### PR DESCRIPTION
added replayAwareScope and other needed wrappers to support it. 
expose the metrics scope to workflow and activity in the same way as logger.