### PR TITLE
validate domain existence at worker start time

### DIFF
--- a/internal_worker.go
+++ b/internal_worker.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/uber-go/tally"
 	m "go.uber.org/cadence/.gen/go/cadence"
+	"go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -160,6 +161,31 @@ func ensureRequiredParams(params *workerExecutionParameters) {
 	}
 }
 
+// verifyDomainExist does a DescribeDomain operation on the specified domain
+// It returns an error, if the server returns an EntityNotExist or BadRequest error
+// On any other transient error, this method will just return success
+func verifyDomainExist(client m.TChanWorkflowService, domain string, logger *zap.Logger) error {
+
+	ctx, cancel := newTChannelContext()
+	defer cancel()
+
+	_, err := client.DescribeDomain(ctx, &shared.DescribeDomainRequest{Name: &domain})
+	if err != nil {
+		if _, ok := err.(*shared.EntityNotExistsError); ok {
+			logger.Error("domain does not exist", zap.String("domain", domain), zap.Error(err))
+			return err
+		}
+		if _, ok := err.(*shared.BadRequestError); ok {
+			logger.Error("domain does not exist", zap.String("domain", domain), zap.Error(err))
+			return err
+		}
+		// on any other error, just return true
+		logger.Warn("unable to verify if domain exist", zap.String("domain", domain), zap.Error(err))
+	}
+
+	return nil
+}
+
 func newWorkflowWorkerInternal(
 	factory workflowDefinitionFactory,
 	service m.TChanWorkflowService,
@@ -214,12 +240,21 @@ func newWorkflowTaskWorkerInternal(
 
 // Start the worker.
 func (ww *workflowWorker) Start() error {
+	err := verifyDomainExist(ww.workflowService, ww.domain, ww.worker.logger)
+	if err != nil {
+		return err
+	}
 	ww.worker.Start()
 	return nil // TODO: propagate error
 }
 
-func (ww *workflowWorker) Run() {
+func (ww *workflowWorker) Run() error {
+	err := verifyDomainExist(ww.workflowService, ww.domain, ww.worker.logger)
+	if err != nil {
+		return err
+	}
 	ww.worker.Run()
+	return nil
 }
 
 // Shutdown the worker.
@@ -281,13 +316,22 @@ func newActivityTaskWorker(
 
 // Start the worker.
 func (aw *activityWorker) Start() error {
+	err := verifyDomainExist(aw.workflowService, aw.domain, aw.worker.logger)
+	if err != nil {
+		return err
+	}
 	aw.worker.Start()
 	return nil // TODO: propagate errors
 }
 
 // Run the worker.
-func (aw *activityWorker) Run() {
+func (aw *activityWorker) Run() error {
+	err := verifyDomainExist(aw.workflowService, aw.domain, aw.worker.logger)
+	if err != nil {
+		return err
+	}
 	aw.worker.Run()
+	return nil
 }
 
 // Shutdown the worker.
@@ -753,11 +797,14 @@ func (aw *aggregatedWorker) Start() error {
 	return nil
 }
 
-func (aw *aggregatedWorker) Run() {
-	aw.Start()
+func (aw *aggregatedWorker) Run() error {
+	if err := aw.Start(); err != nil {
+		return err
+	}
 	d := <-getKillSignal()
 	aw.logger.Info("Worker has been killed", zap.String("Signal", d.String()))
 	aw.Stop()
+	return nil
 }
 
 func (aw *aggregatedWorker) Stop() {

--- a/internal_worker_interfaces_test.go
+++ b/internal_worker_interfaces_test.go
@@ -129,7 +129,16 @@ func (s *InterfacesTestSuite) TestInterface() {
 	// Create service endpoint
 	service := new(mocks.TChanWorkflowService)
 
+	domainStatus := m.DomainStatus_REGISTERED
+	domainDesc := &m.DescribeDomainResponse{
+		DomainInfo: &m.DomainInfo{
+			Name:   &domain,
+			Status: &domainStatus,
+		},
+	}
+
 	// mocks
+	service.On("DescribeDomain", mock.Anything, mock.Anything).Return(domainDesc, nil)
 	service.On("PollForActivityTask", mock.Anything, mock.Anything).Return(&m.PollForActivityTaskResponse{}, nil)
 	service.On("RespondActivityTaskCompleted", mock.Anything, mock.Anything).Return(nil)
 	service.On("PollForDecisionTask", mock.Anything, mock.Anything).Return(&m.PollForDecisionTaskResponse{}, nil)

--- a/internal_workers_test.go
+++ b/internal_workers_test.go
@@ -55,6 +55,7 @@ func (s *WorkersTestSuite) TestWorkflowWorker() {
 	// mocks
 	logger, _ := zap.NewDevelopment()
 	service := new(mocks.TChanWorkflowService)
+	service.On("DescribeDomain", mock.Anything, mock.Anything).Return(nil, nil)
 	service.On("PollForDecisionTask", mock.Anything, mock.Anything).Return(&m.PollForDecisionTaskResponse{}, nil)
 	service.On("RespondDecisionTaskCompleted", mock.Anything, mock.Anything).Return(nil)
 
@@ -74,6 +75,7 @@ func (s *WorkersTestSuite) TestActivityWorker() {
 	// mocks
 	logger, _ := zap.NewDevelopment()
 	service := new(mocks.TChanWorkflowService)
+	service.On("DescribeDomain", mock.Anything, mock.Anything).Return(nil, nil)
 	service.On("PollForActivityTask", mock.Anything, mock.Anything).Return(&m.PollForActivityTaskResponse{}, nil)
 	service.On("RespondActivityTaskCompleted", mock.Anything, mock.Anything).Return(nil)
 
@@ -92,6 +94,7 @@ func (s *WorkersTestSuite) TestPollForDecisionTask_InternalServiceError() {
 	domain := "testDomain"
 	// mocks
 	service := new(mocks.TChanWorkflowService)
+	service.On("DescribeDomain", mock.Anything, mock.Anything).Return(nil, nil)
 	service.On("PollForDecisionTask", mock.Anything, mock.Anything).Return(&m.PollForDecisionTaskResponse{}, &m.InternalServiceError{})
 
 	executionParameters := workerExecutionParameters{

--- a/worker.go
+++ b/worker.go
@@ -37,7 +37,8 @@ type (
 		// Start starts the worker in a non-blocking fashion
 		Start() error
 		// Run is a blocking start and cleans up resources when killed
-		Run()
+		// returns error only if it fails to start the worker
+		Run() error
 		// Stop cleans up any resources opened by worker
 		Stop()
 	}


### PR DESCRIPTION
This patch adds validation for domain existence at worker start time. If the server throws either one of EntityNotExist (or) BadRequest errors, then worker.Start() will fail immediately. If the server throws any other transient error, we ignore the error and continue. 