### PR TITLE
add service wrapper that emit metrics automatically

### DIFF
--- a/client.go
+++ b/client.go
@@ -26,6 +26,7 @@ import (
 	"github.com/uber-go/tally"
 	m "go.uber.org/cadence/.gen/go/cadence"
 	s "go.uber.org/cadence/.gen/go/shared"
+	"go.uber.org/cadence/common/metrics"
 )
 
 type (
@@ -204,7 +205,7 @@ func NewClient(service m.TChanWorkflowService, domain string, options *ClientOpt
 		metricScope = tally.NoopScope
 	}
 	return &workflowClient{
-		workflowService: service,
+		workflowService: metrics.NewWorkflowServiceWrapper(service, metricScope),
 		domain:          domain,
 		metricsScope:    metricScope,
 		identity:        identity,
@@ -223,8 +224,11 @@ func NewDomainClient(service m.TChanWorkflowService, options *ClientOptions) Dom
 	if options != nil {
 		metricScope = options.MetricsScope
 	}
+	if metricScope == nil {
+		metricScope = tally.NoopScope
+	}
 	return &domainClient{
-		workflowService: service,
+		workflowService: metrics.NewWorkflowServiceWrapper(service, metricScope),
 		metricsScope:    metricScope,
 		identity:        identity,
 	}

--- a/common/metrics/constants.go
+++ b/common/metrics/constants.go
@@ -63,4 +63,8 @@ const (
 	ActivityTaskCanceledCounter    = "activity-task-canceled"
 
 	UnhandledSignalsCounter = "unhandled-signals"
+
+	CadenceRequest = "cadence-request"
+	CadenceError   = "cadence-error"
+	CadenceLatency = "cadence-latency"
 )

--- a/common/metrics/constants.go
+++ b/common/metrics/constants.go
@@ -64,7 +64,8 @@ const (
 
 	UnhandledSignalsCounter = "unhandled-signals"
 
-	CadenceRequest = "cadence-request"
-	CadenceError   = "cadence-error"
-	CadenceLatency = "cadence-latency"
+	CadenceRequest        = "cadence-request"
+	CadenceError          = "cadence-error"
+	CadenceLatency        = "cadence-latency"
+	CadenceInvalidRequest = "cadence-invalid-request"
 )

--- a/common/metrics/service_wrapper.go
+++ b/common/metrics/service_wrapper.go
@@ -37,6 +37,27 @@ type workflowServiceMetricsWrapper struct {
 	mutex       sync.Mutex
 }
 
+const (
+	scopeNameDeprecateDomain                = "DeprecateDomain"
+	scopeNameDescribeDomain                 = "DescribeDomain"
+	scopeNameGetWorkflowExecutionHistory    = "GetWorkflowExecutionHistory"
+	scopeNameListClosedWorkflowExecutions   = "ListClosedWorkflowExecutions"
+	scopeNameListOpenWorkflowExecutions     = "ListOpenWorkflowExecutions"
+	scopeNamePollForActivityTask            = "PollForActivityTask"
+	scopeNamePollForDecisionTask            = "PollForDecisionTask"
+	scopeNameRecordActivityTaskHeartbeat    = "RecordActivityTaskHeartbeat"
+	scopeNameRegisterDomain                 = "RegisterDomain"
+	scopeNameRequestCancelWorkflowExecution = "RequestCancelWorkflowExecution"
+	scopeNameRespondActivityTaskCanceled    = "RespondActivityTaskCanceled"
+	scopeNameRespondActivityTaskCompleted   = "RespondActivityTaskCompleted"
+	scopeNameRespondActivityTaskFailed      = "RespondActivityTaskFailed"
+	scopeNameRespondDecisionTaskCompleted   = "RespondDecisionTaskCompleted"
+	scopeNameSignalWorkflowExecution        = "SignalWorkflowExecution"
+	scopeNameStartWorkflowExecution         = "StartWorkflowExecution"
+	scopeNameTerminateWorkflowExecution     = "TerminateWorkflowExecution"
+	scopeNameUpdateDomain                   = "UpdateDomain"
+)
+
 // NewWorkflowServiceWrapper creates a new wrapper to WorkflowService that will emit metrics for each service call.
 func NewWorkflowServiceWrapper(service m.TChanWorkflowService, scope tally.Scope) m.TChanWorkflowService {
 	return &workflowServiceMetricsWrapper{service: service, scope: scope, childScopes: make(map[string]tally.Scope)}
@@ -56,7 +77,7 @@ func (w *workflowServiceMetricsWrapper) getScope(scopeName string) tally.Scope {
 }
 
 func (w *workflowServiceMetricsWrapper) DeprecateDomain(ctx thrift.Context, request *shared.DeprecateDomainRequest) error {
-	scope := w.getScope("DeprecateDomain")
+	scope := w.getScope(scopeNameDeprecateDomain)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	err := w.service.DeprecateDomain(ctx, request)
@@ -68,7 +89,7 @@ func (w *workflowServiceMetricsWrapper) DeprecateDomain(ctx thrift.Context, requ
 }
 
 func (w *workflowServiceMetricsWrapper) DescribeDomain(ctx thrift.Context, request *shared.DescribeDomainRequest) (*shared.DescribeDomainResponse, error) {
-	scope := w.getScope("DescribeDomain")
+	scope := w.getScope(scopeNameDescribeDomain)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	result, err := w.service.DescribeDomain(ctx, request)
@@ -80,7 +101,7 @@ func (w *workflowServiceMetricsWrapper) DescribeDomain(ctx thrift.Context, reque
 }
 
 func (w *workflowServiceMetricsWrapper) GetWorkflowExecutionHistory(ctx thrift.Context, request *shared.GetWorkflowExecutionHistoryRequest) (*shared.GetWorkflowExecutionHistoryResponse, error) {
-	scope := w.getScope("GetWorkflowExecutionHistory")
+	scope := w.getScope(scopeNameGetWorkflowExecutionHistory)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	result, err := w.service.GetWorkflowExecutionHistory(ctx, request)
@@ -92,7 +113,7 @@ func (w *workflowServiceMetricsWrapper) GetWorkflowExecutionHistory(ctx thrift.C
 }
 
 func (w *workflowServiceMetricsWrapper) ListClosedWorkflowExecutions(ctx thrift.Context, request *shared.ListClosedWorkflowExecutionsRequest) (*shared.ListClosedWorkflowExecutionsResponse, error) {
-	scope := w.getScope("ListClosedWorkflowExecutions")
+	scope := w.getScope(scopeNameListClosedWorkflowExecutions)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	result, err := w.service.ListClosedWorkflowExecutions(ctx, request)
@@ -104,7 +125,7 @@ func (w *workflowServiceMetricsWrapper) ListClosedWorkflowExecutions(ctx thrift.
 }
 
 func (w *workflowServiceMetricsWrapper) ListOpenWorkflowExecutions(ctx thrift.Context, request *shared.ListOpenWorkflowExecutionsRequest) (*shared.ListOpenWorkflowExecutionsResponse, error) {
-	scope := w.getScope("ListOpenWorkflowExecutions")
+	scope := w.getScope(scopeNameListOpenWorkflowExecutions)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	result, err := w.service.ListOpenWorkflowExecutions(ctx, request)
@@ -116,7 +137,7 @@ func (w *workflowServiceMetricsWrapper) ListOpenWorkflowExecutions(ctx thrift.Co
 }
 
 func (w *workflowServiceMetricsWrapper) PollForActivityTask(ctx thrift.Context, request *shared.PollForActivityTaskRequest) (*shared.PollForActivityTaskResponse, error) {
-	scope := w.getScope("PollForActivityTask")
+	scope := w.getScope(scopeNamePollForActivityTask)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	result, err := w.service.PollForActivityTask(ctx, request)
@@ -128,7 +149,7 @@ func (w *workflowServiceMetricsWrapper) PollForActivityTask(ctx thrift.Context, 
 }
 
 func (w *workflowServiceMetricsWrapper) PollForDecisionTask(ctx thrift.Context, request *shared.PollForDecisionTaskRequest) (*shared.PollForDecisionTaskResponse, error) {
-	scope := w.getScope("PollForDecisionTask")
+	scope := w.getScope(scopeNamePollForDecisionTask)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	result, err := w.service.PollForDecisionTask(ctx, request)
@@ -140,7 +161,7 @@ func (w *workflowServiceMetricsWrapper) PollForDecisionTask(ctx thrift.Context, 
 }
 
 func (w *workflowServiceMetricsWrapper) RecordActivityTaskHeartbeat(ctx thrift.Context, request *shared.RecordActivityTaskHeartbeatRequest) (*shared.RecordActivityTaskHeartbeatResponse, error) {
-	scope := w.getScope("RecordActivityTaskHeartbeat")
+	scope := w.getScope(scopeNameRecordActivityTaskHeartbeat)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	result, err := w.service.RecordActivityTaskHeartbeat(ctx, request)
@@ -152,7 +173,7 @@ func (w *workflowServiceMetricsWrapper) RecordActivityTaskHeartbeat(ctx thrift.C
 }
 
 func (w *workflowServiceMetricsWrapper) RegisterDomain(ctx thrift.Context, request *shared.RegisterDomainRequest) error {
-	scope := w.getScope("RegisterDomain")
+	scope := w.getScope(scopeNameRegisterDomain)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	err := w.service.RegisterDomain(ctx, request)
@@ -164,7 +185,7 @@ func (w *workflowServiceMetricsWrapper) RegisterDomain(ctx thrift.Context, reque
 }
 
 func (w *workflowServiceMetricsWrapper) RequestCancelWorkflowExecution(ctx thrift.Context, request *shared.RequestCancelWorkflowExecutionRequest) error {
-	scope := w.getScope("RequestCancelWorkflowExecution")
+	scope := w.getScope(scopeNameRequestCancelWorkflowExecution)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	err := w.service.RequestCancelWorkflowExecution(ctx, request)
@@ -176,7 +197,7 @@ func (w *workflowServiceMetricsWrapper) RequestCancelWorkflowExecution(ctx thrif
 }
 
 func (w *workflowServiceMetricsWrapper) RespondActivityTaskCanceled(ctx thrift.Context, request *shared.RespondActivityTaskCanceledRequest) error {
-	scope := w.getScope("RespondActivityTaskCanceled")
+	scope := w.getScope(scopeNameRespondActivityTaskCanceled)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	err := w.service.RespondActivityTaskCanceled(ctx, request)
@@ -188,7 +209,7 @@ func (w *workflowServiceMetricsWrapper) RespondActivityTaskCanceled(ctx thrift.C
 }
 
 func (w *workflowServiceMetricsWrapper) RespondActivityTaskCompleted(ctx thrift.Context, request *shared.RespondActivityTaskCompletedRequest) error {
-	scope := w.getScope("RespondActivityTaskCompleted")
+	scope := w.getScope(scopeNameRespondActivityTaskCompleted)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	err := w.service.RespondActivityTaskCompleted(ctx, request)
@@ -200,7 +221,7 @@ func (w *workflowServiceMetricsWrapper) RespondActivityTaskCompleted(ctx thrift.
 }
 
 func (w *workflowServiceMetricsWrapper) RespondActivityTaskFailed(ctx thrift.Context, request *shared.RespondActivityTaskFailedRequest) error {
-	scope := w.getScope("RespondActivityTaskFailed")
+	scope := w.getScope(scopeNameRespondActivityTaskFailed)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	err := w.service.RespondActivityTaskFailed(ctx, request)
@@ -212,7 +233,7 @@ func (w *workflowServiceMetricsWrapper) RespondActivityTaskFailed(ctx thrift.Con
 }
 
 func (w *workflowServiceMetricsWrapper) RespondDecisionTaskCompleted(ctx thrift.Context, request *shared.RespondDecisionTaskCompletedRequest) error {
-	scope := w.getScope("RespondDecisionTaskCompleted")
+	scope := w.getScope(scopeNameRespondDecisionTaskCompleted)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	err := w.service.RespondDecisionTaskCompleted(ctx, request)
@@ -224,7 +245,7 @@ func (w *workflowServiceMetricsWrapper) RespondDecisionTaskCompleted(ctx thrift.
 }
 
 func (w *workflowServiceMetricsWrapper) SignalWorkflowExecution(ctx thrift.Context, request *shared.SignalWorkflowExecutionRequest) error {
-	scope := w.getScope("SignalWorkflowExecution")
+	scope := w.getScope(scopeNameSignalWorkflowExecution)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	err := w.service.SignalWorkflowExecution(ctx, request)
@@ -236,7 +257,7 @@ func (w *workflowServiceMetricsWrapper) SignalWorkflowExecution(ctx thrift.Conte
 }
 
 func (w *workflowServiceMetricsWrapper) StartWorkflowExecution(ctx thrift.Context, request *shared.StartWorkflowExecutionRequest) (*shared.StartWorkflowExecutionResponse, error) {
-	scope := w.getScope("StartWorkflowExecution")
+	scope := w.getScope(scopeNameStartWorkflowExecution)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	result, err := w.service.StartWorkflowExecution(ctx, request)
@@ -248,7 +269,7 @@ func (w *workflowServiceMetricsWrapper) StartWorkflowExecution(ctx thrift.Contex
 }
 
 func (w *workflowServiceMetricsWrapper) TerminateWorkflowExecution(ctx thrift.Context, request *shared.TerminateWorkflowExecutionRequest) error {
-	scope := w.getScope("TerminateWorkflowExecution")
+	scope := w.getScope(scopeNameTerminateWorkflowExecution)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	err := w.service.TerminateWorkflowExecution(ctx, request)
@@ -260,7 +281,7 @@ func (w *workflowServiceMetricsWrapper) TerminateWorkflowExecution(ctx thrift.Co
 }
 
 func (w *workflowServiceMetricsWrapper) UpdateDomain(ctx thrift.Context, request *shared.UpdateDomainRequest) (*shared.UpdateDomainResponse, error) {
-	scope := w.getScope("UpdateDomain")
+	scope := w.getScope(scopeNameUpdateDomain)
 	scope.Counter(CadenceRequest).Inc(1)
 	startTime := time.Now()
 	result, err := w.service.UpdateDomain(ctx, request)

--- a/common/metrics/service_wrapper.go
+++ b/common/metrics/service_wrapper.go
@@ -1,0 +1,272 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/uber-go/tally"
+	"github.com/uber/tchannel-go/thrift"
+	m "go.uber.org/cadence/.gen/go/cadence"
+	"go.uber.org/cadence/.gen/go/shared"
+)
+
+type workflowServiceMetricsWrapper struct {
+	service     m.TChanWorkflowService
+	scope       tally.Scope
+	childScopes map[string]tally.Scope
+	mutex       sync.Mutex
+}
+
+// NewWorkflowServiceWrapper creates a new wrapper to WorkflowService that will emit metrics for each service call.
+func NewWorkflowServiceWrapper(service m.TChanWorkflowService, scope tally.Scope) m.TChanWorkflowService {
+	return &workflowServiceMetricsWrapper{service: service, scope: scope, childScopes: make(map[string]tally.Scope)}
+}
+
+func (w *workflowServiceMetricsWrapper) getScope(scopeName string) tally.Scope {
+	w.mutex.Lock()
+	scope, ok := w.childScopes[scopeName]
+	if ok {
+		w.mutex.Unlock()
+		return scope
+	}
+	scope = w.scope.SubScope(scopeName)
+	w.childScopes[scopeName] = scope
+	w.mutex.Unlock()
+	return scope
+}
+
+func (w *workflowServiceMetricsWrapper) DeprecateDomain(ctx thrift.Context, request *shared.DeprecateDomainRequest) error {
+	scope := w.getScope("DeprecateDomain")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	err := w.service.DeprecateDomain(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return err
+}
+
+func (w *workflowServiceMetricsWrapper) DescribeDomain(ctx thrift.Context, request *shared.DescribeDomainRequest) (*shared.DescribeDomainResponse, error) {
+	scope := w.getScope("DescribeDomain")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	result, err := w.service.DescribeDomain(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return result, err
+}
+
+func (w *workflowServiceMetricsWrapper) GetWorkflowExecutionHistory(ctx thrift.Context, request *shared.GetWorkflowExecutionHistoryRequest) (*shared.GetWorkflowExecutionHistoryResponse, error) {
+	scope := w.getScope("GetWorkflowExecutionHistory")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	result, err := w.service.GetWorkflowExecutionHistory(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return result, err
+}
+
+func (w *workflowServiceMetricsWrapper) ListClosedWorkflowExecutions(ctx thrift.Context, request *shared.ListClosedWorkflowExecutionsRequest) (*shared.ListClosedWorkflowExecutionsResponse, error) {
+	scope := w.getScope("ListClosedWorkflowExecutions")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	result, err := w.service.ListClosedWorkflowExecutions(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return result, err
+}
+
+func (w *workflowServiceMetricsWrapper) ListOpenWorkflowExecutions(ctx thrift.Context, request *shared.ListOpenWorkflowExecutionsRequest) (*shared.ListOpenWorkflowExecutionsResponse, error) {
+	scope := w.getScope("ListOpenWorkflowExecutions")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	result, err := w.service.ListOpenWorkflowExecutions(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return result, err
+}
+
+func (w *workflowServiceMetricsWrapper) PollForActivityTask(ctx thrift.Context, request *shared.PollForActivityTaskRequest) (*shared.PollForActivityTaskResponse, error) {
+	scope := w.getScope("PollForActivityTask")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	result, err := w.service.PollForActivityTask(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return result, err
+}
+
+func (w *workflowServiceMetricsWrapper) PollForDecisionTask(ctx thrift.Context, request *shared.PollForDecisionTaskRequest) (*shared.PollForDecisionTaskResponse, error) {
+	scope := w.getScope("PollForDecisionTask")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	result, err := w.service.PollForDecisionTask(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return result, err
+}
+
+func (w *workflowServiceMetricsWrapper) RecordActivityTaskHeartbeat(ctx thrift.Context, request *shared.RecordActivityTaskHeartbeatRequest) (*shared.RecordActivityTaskHeartbeatResponse, error) {
+	scope := w.getScope("RecordActivityTaskHeartbeat")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	result, err := w.service.RecordActivityTaskHeartbeat(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return result, err
+}
+
+func (w *workflowServiceMetricsWrapper) RegisterDomain(ctx thrift.Context, request *shared.RegisterDomainRequest) error {
+	scope := w.getScope("RegisterDomain")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	err := w.service.RegisterDomain(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return err
+}
+
+func (w *workflowServiceMetricsWrapper) RequestCancelWorkflowExecution(ctx thrift.Context, request *shared.RequestCancelWorkflowExecutionRequest) error {
+	scope := w.getScope("RequestCancelWorkflowExecution")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	err := w.service.RequestCancelWorkflowExecution(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return err
+}
+
+func (w *workflowServiceMetricsWrapper) RespondActivityTaskCanceled(ctx thrift.Context, request *shared.RespondActivityTaskCanceledRequest) error {
+	scope := w.getScope("RespondActivityTaskCanceled")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	err := w.service.RespondActivityTaskCanceled(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return err
+}
+
+func (w *workflowServiceMetricsWrapper) RespondActivityTaskCompleted(ctx thrift.Context, request *shared.RespondActivityTaskCompletedRequest) error {
+	scope := w.getScope("RespondActivityTaskCompleted")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	err := w.service.RespondActivityTaskCompleted(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return err
+}
+
+func (w *workflowServiceMetricsWrapper) RespondActivityTaskFailed(ctx thrift.Context, request *shared.RespondActivityTaskFailedRequest) error {
+	scope := w.getScope("RespondActivityTaskFailed")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	err := w.service.RespondActivityTaskFailed(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return err
+}
+
+func (w *workflowServiceMetricsWrapper) RespondDecisionTaskCompleted(ctx thrift.Context, request *shared.RespondDecisionTaskCompletedRequest) error {
+	scope := w.getScope("RespondDecisionTaskCompleted")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	err := w.service.RespondDecisionTaskCompleted(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return err
+}
+
+func (w *workflowServiceMetricsWrapper) SignalWorkflowExecution(ctx thrift.Context, request *shared.SignalWorkflowExecutionRequest) error {
+	scope := w.getScope("SignalWorkflowExecution")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	err := w.service.SignalWorkflowExecution(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return err
+}
+
+func (w *workflowServiceMetricsWrapper) StartWorkflowExecution(ctx thrift.Context, request *shared.StartWorkflowExecutionRequest) (*shared.StartWorkflowExecutionResponse, error) {
+	scope := w.getScope("StartWorkflowExecution")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	result, err := w.service.StartWorkflowExecution(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return result, err
+}
+
+func (w *workflowServiceMetricsWrapper) TerminateWorkflowExecution(ctx thrift.Context, request *shared.TerminateWorkflowExecutionRequest) error {
+	scope := w.getScope("TerminateWorkflowExecution")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	err := w.service.TerminateWorkflowExecution(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return err
+}
+
+func (w *workflowServiceMetricsWrapper) UpdateDomain(ctx thrift.Context, request *shared.UpdateDomainRequest) (*shared.UpdateDomainResponse, error) {
+	scope := w.getScope("UpdateDomain")
+	scope.Counter(CadenceRequest).Inc(1)
+	startTime := time.Now()
+	result, err := w.service.UpdateDomain(ctx, request)
+	scope.Timer(CadenceLatency).Record(time.Now().Sub(startTime))
+	if err != nil {
+		scope.Counter(CadenceError).Inc(1)
+	}
+	return result, err
+}

--- a/common/metrics/service_wrapper_test.go
+++ b/common/metrics/service_wrapper_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package metrics
 
 import (

--- a/common/metrics/service_wrapper_test.go
+++ b/common/metrics/service_wrapper_test.go
@@ -85,8 +85,17 @@ func Test_Wrapper(t *testing.T) {
 
 func assertMetrics(t *testing.T, reporter *capturingStatsReporter, scopeName string, counterNames []string) {
 	require.Equal(t, len(counterNames), len(reporter.counts))
-	for i, counterName := range counterNames {
-		require.Equal(t, scopeName+"."+counterName, reporter.counts[i].name)
+	for _, name := range counterNames {
+		counterName := scopeName + "." + name
+		find := false
+		// counters are not in order
+		for _, counter := range reporter.counts {
+			if counterName == counter.name {
+				find = true
+				break
+			}
+		}
+		require.True(t, find)
 	}
 	require.Equal(t, 1, len(reporter.timers))
 	require.Equal(t, scopeName+"."+CadenceLatency, reporter.timers[0].name)

--- a/common/metrics/service_wrapper_test.go
+++ b/common/metrics/service_wrapper_test.go
@@ -1,0 +1,85 @@
+package metrics
+
+import (
+	"io"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go/thrift"
+	m "go.uber.org/cadence/.gen/go/cadence"
+	s "go.uber.org/cadence/.gen/go/shared"
+	"go.uber.org/cadence/mocks"
+)
+
+type testCase struct {
+	serviceMethod    string
+	callArgs         []interface{}
+	mockReturns      []interface{}
+	expectedCounters []string
+}
+
+func Test_Wrapper(t *testing.T) {
+	ctx, _ := thrift.NewContext(time.Minute)
+	tests := []testCase{
+		// one case for each service call
+		{"DeprecateDomain", []interface{}{ctx, &s.DeprecateDomainRequest{}}, []interface{}{nil}, []string{CadenceRequest}},
+		{"DescribeDomain", []interface{}{ctx, &s.DescribeDomainRequest{}}, []interface{}{&s.DescribeDomainResponse{}, nil}, []string{CadenceRequest}},
+		{"GetWorkflowExecutionHistory", []interface{}{ctx, &s.GetWorkflowExecutionHistoryRequest{}}, []interface{}{&s.GetWorkflowExecutionHistoryResponse{}, nil}, []string{CadenceRequest}},
+		{"ListClosedWorkflowExecutions", []interface{}{ctx, &s.ListClosedWorkflowExecutionsRequest{}}, []interface{}{&s.ListClosedWorkflowExecutionsResponse{}, nil}, []string{CadenceRequest}},
+		{"ListOpenWorkflowExecutions", []interface{}{ctx, &s.ListOpenWorkflowExecutionsRequest{}}, []interface{}{&s.ListOpenWorkflowExecutionsResponse{}, nil}, []string{CadenceRequest}},
+		{"PollForActivityTask", []interface{}{ctx, &s.PollForActivityTaskRequest{}}, []interface{}{&s.PollForActivityTaskResponse{}, nil}, []string{CadenceRequest}},
+		{"PollForDecisionTask", []interface{}{ctx, &s.PollForDecisionTaskRequest{}}, []interface{}{&s.PollForDecisionTaskResponse{}, nil}, []string{CadenceRequest}},
+		{"RecordActivityTaskHeartbeat", []interface{}{ctx, &s.RecordActivityTaskHeartbeatRequest{}}, []interface{}{&s.RecordActivityTaskHeartbeatResponse{}, nil}, []string{CadenceRequest}},
+		{"RegisterDomain", []interface{}{ctx, &s.RegisterDomainRequest{}}, []interface{}{nil}, []string{CadenceRequest}},
+		{"RequestCancelWorkflowExecution", []interface{}{ctx, &s.RequestCancelWorkflowExecutionRequest{}}, []interface{}{nil}, []string{CadenceRequest}},
+		{"RespondActivityTaskCanceled", []interface{}{ctx, &s.RespondActivityTaskCanceledRequest{}}, []interface{}{nil}, []string{CadenceRequest}},
+		{"RespondActivityTaskCompleted", []interface{}{ctx, &s.RespondActivityTaskCompletedRequest{}}, []interface{}{nil}, []string{CadenceRequest}},
+		{"RespondActivityTaskFailed", []interface{}{ctx, &s.RespondActivityTaskFailedRequest{}}, []interface{}{nil}, []string{CadenceRequest}},
+		{"RespondDecisionTaskCompleted", []interface{}{ctx, &s.RespondDecisionTaskCompletedRequest{}}, []interface{}{nil}, []string{CadenceRequest}},
+		{"SignalWorkflowExecution", []interface{}{ctx, &s.SignalWorkflowExecutionRequest{}}, []interface{}{nil}, []string{CadenceRequest}},
+		{"StartWorkflowExecution", []interface{}{ctx, &s.StartWorkflowExecutionRequest{}}, []interface{}{&s.StartWorkflowExecutionResponse{}, nil}, []string{CadenceRequest}},
+		{"TerminateWorkflowExecution", []interface{}{ctx, &s.TerminateWorkflowExecutionRequest{}}, []interface{}{nil}, []string{CadenceRequest}},
+		{"UpdateDomain", []interface{}{ctx, &s.UpdateDomainRequest{}}, []interface{}{&s.UpdateDomainResponse{}, nil}, []string{CadenceRequest}},
+		// one case of invalid request
+		{"PollForActivityTask", []interface{}{ctx, &s.PollForActivityTaskRequest{}}, []interface{}{nil, &s.EntityNotExistsError{}}, []string{CadenceRequest, CadenceInvalidRequest}},
+		// one case of server error
+		{"PollForActivityTask", []interface{}{ctx, &s.PollForActivityTaskRequest{}}, []interface{}{nil, &s.InternalServiceError{}}, []string{CadenceRequest, CadenceError}},
+	}
+
+	for _, test := range tests {
+		mockService, wrapperService, closer, reporter := newService()
+		mockService.On(test.serviceMethod, mock.Anything, mock.Anything).Return(test.mockReturns...)
+		inputs := make([]reflect.Value, len(test.callArgs))
+		for i, arg := range test.callArgs {
+			inputs[i] = reflect.ValueOf(arg)
+		}
+		method := reflect.ValueOf(wrapperService).MethodByName(test.serviceMethod)
+		method.Call(inputs)
+		closer.Close()
+		assertMetrics(t, reporter, test.serviceMethod, test.expectedCounters)
+	}
+}
+
+func assertMetrics(t *testing.T, reporter *capturingStatsReporter, scopeName string, counterNames []string) {
+	require.Equal(t, len(counterNames), len(reporter.counts))
+	for i, counterName := range counterNames {
+		require.Equal(t, scopeName+"."+counterName, reporter.counts[i].name)
+	}
+	require.Equal(t, 1, len(reporter.timers))
+	require.Equal(t, scopeName+"."+CadenceLatency, reporter.timers[0].name)
+}
+
+func newService() (mockService *mocks.TChanWorkflowService,
+	wrapperService m.TChanWorkflowService,
+	closer io.Closer,
+	reporter *capturingStatsReporter,
+) {
+	mockService = &mocks.TChanWorkflowService{}
+	isReplay := false
+	scope, closer, reporter := newMetricsScope(&isReplay)
+	wrapperService = NewWorkflowServiceWrapper(mockService, scope)
+	return
+}

--- a/internal_task_pollers.go
+++ b/internal_task_pollers.go
@@ -117,7 +117,7 @@ func isClientSideError(err error) bool {
 func newWorkflowTaskPoller(taskHandler WorkflowTaskHandler, service m.TChanWorkflowService,
 	domain string, params workerExecutionParameters) *workflowTaskPoller {
 	return &workflowTaskPoller{
-		service:      service,
+		service:      metrics.NewWorkflowServiceWrapper(service, params.MetricsScope),
 		domain:       domain,
 		taskListName: params.TaskList,
 		identity:     params.Identity,
@@ -272,7 +272,7 @@ func newActivityTaskPoller(taskHandler ActivityTaskHandler, service m.TChanWorkf
 	domain string, params workerExecutionParameters) *activityTaskPoller {
 	return &activityTaskPoller{
 		taskHandler:  taskHandler,
-		service:      service,
+		service:      metrics.NewWorkflowServiceWrapper(service, params.MetricsScope),
 		domain:       domain,
 		taskListName: params.TaskList,
 		identity:     params.Identity,

--- a/internal_worker.go
+++ b/internal_worker.go
@@ -229,7 +229,6 @@ func newWorkflowTaskWorkerInternal(
 		maxTaskRate:                defaultMaxWorkflowExecutionRate,
 		maxTaskRateRefreshDuration: time.Second,
 		taskWorker:                 poller,
-		workflowService:            service,
 		identity:                   params.Identity,
 		workerType:                 "DecisionWorker"},
 		params.Logger)
@@ -304,7 +303,6 @@ func newActivityTaskWorker(
 		maxTaskRate:                workerParams.MaxActivityExecutionRate,
 		maxTaskRateRefreshDuration: workerParams.MaxActivityExecutionRateRefreshDuration,
 		taskWorker:                 poller,
-		workflowService:            service,
 		identity:                   workerParams.Identity,
 		workerType:                 "ActivityWorker"},
 		workerParams.Logger)

--- a/internal_worker_base.go
+++ b/internal_worker_base.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/uber-go/tally"
-	m "go.uber.org/cadence/.gen/go/cadence"
 	"go.uber.org/cadence/common/backoff"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -87,7 +86,6 @@ type (
 		maxTaskRate                int
 		maxTaskRateRefreshDuration time.Duration
 		taskWorker                 taskPoller
-		workflowService            m.TChanWorkflowService
 		identity                   string
 		workerType                 string
 	}


### PR DESCRIPTION
add tchannel service wrapper that automatically emit metrics on all service calls.

This will emit metrics like:
PollForActivityTask.cadence-request
RespondDecisionTaskCompleted.cadence-latency
....