### PR TITLE
remove private hostEnv from test suite

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -47,7 +47,7 @@ func Test_ActivityError(t *testing.T) {
 	errorActivityFn := func(i int) error {
 		return errs[i][0]
 	}
-	s := newWorkflowTestSuite()
+	s := &WorkflowTestSuite{}
 	for i := 0; i < len(errs); i++ {
 		env := s.NewTestActivityEnvironment()
 		_, err := env.ExecuteActivity(errorActivityFn, i)
@@ -61,7 +61,7 @@ func Test_ActivityPanic(t *testing.T) {
 	panicActivityFn := func() error {
 		panic("panic-blabla")
 	}
-	s := newWorkflowTestSuite()
+	s := &WorkflowTestSuite{}
 	s.SetLogger(zap.NewNop())
 	env := s.NewTestActivityEnvironment()
 	_, err := env.ExecuteActivity(panicActivityFn)
@@ -76,7 +76,7 @@ func Test_WorkflowError(t *testing.T) {
 	errorWorkflowFn := func(ctx Context, i int) error {
 		return errs[i][0]
 	}
-	s := newWorkflowTestSuite()
+	s := &WorkflowTestSuite{}
 	for i := 0; i < len(errs); i++ {
 		wfEnv := s.NewTestWorkflowEnvironment()
 		wfEnv.ExecuteWorkflow(errorWorkflowFn, i)

--- a/internal_worker_test.go
+++ b/internal_worker_test.go
@@ -41,27 +41,40 @@ import (
 	"go.uber.org/zap"
 )
 
-// Used to test registration listeners
-var registeredActivities []string
-var registeredWorkflows []string
-
 func init() {
-	registerWithSample(getHostEnvironment())
-}
-
-func registerWithSample(hostEnv *hostEnvImpl) {
-	hostEnv.RegisterWorkflowWithOptions(
+	RegisterWorkflowWithOptions(
 		sampleWorkflowExecute,
 		RegisterWorkflowOptions{Name: "sampleWorkflowExecute"},
 	)
-	hostEnv.AddWorkflowRegistrationInterceptor(
-		func(workflowName string, workflow interface{}) (string, interface{}) {
-			registeredWorkflows = append(registeredWorkflows, workflowName)
-			return workflowName, workflow
-		},
-	)
-	hostEnv.RegisterWorkflow(testReplayWorkflow)
+	RegisterWorkflow(testReplayWorkflow)
 
+	RegisterActivityWithOptions(
+		testActivity,
+		RegisterActivityOptions{Name: "testActivity"},
+	)
+	RegisterActivity(testActivityByteArgs)
+	RegisterActivityWithOptions(
+		testActivityMultipleArgs,
+		RegisterActivityOptions{Name: "testActivityMultipleArgs"},
+	)
+	RegisterActivity(testActivityReturnString)
+	RegisterActivity(testActivityReturnEmptyString)
+	RegisterActivity(testActivityReturnEmptyStruct)
+
+	RegisterActivity(testActivityNoResult)
+	RegisterActivity(testActivityNoContextArg)
+	RegisterActivity(testActivityReturnByteArray)
+	RegisterActivity(testActivityReturnInt)
+	RegisterActivity(testActivityReturnNilStructPtr)
+	RegisterActivity(testActivityReturnStructPtr)
+	RegisterActivity(testActivityReturnNilStructPtrPtr)
+	RegisterActivity(testActivityReturnStructPtrPtr)
+}
+
+func TestActivityRegistrationListener(t *testing.T) {
+	// Used to test registration listeners
+	var registeredActivities []string
+	hostEnv := newHostEnvironment()
 	hostEnv.RegisterActivityWithOptions(
 		testActivity,
 		RegisterActivityOptions{Name: "testActivity"},
@@ -77,54 +90,39 @@ func registerWithSample(hostEnv *hostEnvImpl) {
 		testActivityMultipleArgs,
 		RegisterActivityOptions{Name: "testActivityMultipleArgs"},
 	)
-	hostEnv.RegisterActivity(testActivityReturnString)
-	hostEnv.RegisterActivity(testActivityReturnEmptyString)
-	hostEnv.RegisterActivity(testActivityReturnEmptyStruct)
 
-	hostEnv.RegisterActivity(testActivityNoResult)
-	hostEnv.RegisterActivity(testActivityNoContextArg)
-	hostEnv.RegisterActivity(testActivityReturnByteArray)
-	hostEnv.RegisterActivity(testActivityReturnInt)
-	hostEnv.RegisterActivity(testActivityReturnNilStructPtr)
-	hostEnv.RegisterActivity(testActivityReturnStructPtr)
-	hostEnv.RegisterActivity(testActivityReturnNilStructPtrPtr)
-	hostEnv.RegisterActivity(testActivityReturnStructPtrPtr)
-}
-
-func TestActivityRegistrationListener(t *testing.T) {
 	expectedActivities := []string{
 		"testActivity",
 		"testActivityMultipleArgs",
 		"go.uber.org/cadence.testActivityByteArgs",
-		"go.uber.org/cadence.testActivityReturnString",
-		"go.uber.org/cadence.testActivityReturnEmptyString",
-		"go.uber.org/cadence.testActivityReturnEmptyStruct",
-		"go.uber.org/cadence.testActivityNoResult",
-		"go.uber.org/cadence.testActivityNoContextArg",
-		"go.uber.org/cadence.testActivityReturnByteArray",
-		"go.uber.org/cadence.testActivityReturnInt",
-		"go.uber.org/cadence.testActivityReturnNilStructPtr",
-		"go.uber.org/cadence.testActivityReturnStructPtr",
-		"go.uber.org/cadence.testActivityReturnNilStructPtrPtr",
-		"go.uber.org/cadence.testActivityReturnStructPtrPtr",
 	}
 	sort.Strings(registeredActivities)
-	registered := strings.Join(registeredActivities, ",")
-	for _, a := range expectedActivities {
-		require.Contains(t, registered, a)
-	}
+	sort.Strings(expectedActivities)
+	require.Equal(t, strings.Join(expectedActivities, ","), strings.Join(registeredActivities, ","))
 }
 
 func TestWorkflowRegistrationListener(t *testing.T) {
+	var registeredWorkflows []string
+	hostEnv := newHostEnvironment()
+	hostEnv.RegisterWorkflowWithOptions(
+		sampleWorkflowExecute,
+		RegisterWorkflowOptions{Name: "sampleWorkflowExecute"},
+	)
+	hostEnv.AddWorkflowRegistrationInterceptor(
+		func(workflowName string, workflow interface{}) (string, interface{}) {
+			registeredWorkflows = append(registeredWorkflows, workflowName)
+			return workflowName, workflow
+		},
+	)
+	hostEnv.RegisterWorkflow(testReplayWorkflow)
+
 	expectedWorkflows := []string{
 		"sampleWorkflowExecute",
 		"go.uber.org/cadence.testReplayWorkflow",
 	}
 	sort.Strings(registeredWorkflows)
-	registered := strings.Join(registeredWorkflows, ",")
-	for _, w := range expectedWorkflows {
-		require.Contains(t, registered, w)
-	}
+	sort.Strings(expectedWorkflows)
+	require.Equal(t, strings.Join(expectedWorkflows, ","), strings.Join(registeredWorkflows, ","))
 }
 
 func getLogger() *zap.Logger {

--- a/internal_worker_test.go
+++ b/internal_worker_test.go
@@ -607,7 +607,7 @@ func testActivityReturnStructPtrPtr() (**testActivityResult, error) {
 }
 
 func TestVariousActivitySchedulingOption(t *testing.T) {
-	ts := newWorkflowTestSuite()
+	ts := &WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 	w := &activitiesCallingOptionsWorkflow{t: t}
 	env.ExecuteWorkflow(w.Execute, []byte{1, 2})

--- a/internal_workflow_test.go
+++ b/internal_workflow_test.go
@@ -41,7 +41,6 @@ type WorkflowUnitTest struct {
 }
 
 func (s *WorkflowUnitTest) SetupSuite() {
-	s.hostEnv = getHostEnvironment()
 	s.activityOptions = ActivityOptions{
 		ScheduleToStartTimeout: time.Minute,
 		StartToCloseTimeout:    time.Minute,
@@ -148,7 +147,6 @@ func splitJoinActivityWorkflow(ctx Context, testPanic bool) (result string, err 
 
 func (s *WorkflowUnitTest) Test_SplitJoinActivityWorkflow() {
 	env := s.NewTestWorkflowEnvironment()
-	registerWithSample(env.impl.getHostEnv())
 	env.OnActivity(testAct, mock.Anything).Return(func(ctx context.Context) (string, error) {
 		activityID := GetActivityInfo(ctx).ActivityID
 		switch activityID {
@@ -170,7 +168,7 @@ func (s *WorkflowUnitTest) Test_SplitJoinActivityWorkflow() {
 }
 
 func TestWorkflowPanic(t *testing.T) {
-	ts := newWorkflowTestSuite()
+	ts := &WorkflowTestSuite{}
 	ts.SetLogger(zap.NewNop()) // this test simulate panic, use nop logger to avoid logging noise
 	env := ts.NewTestWorkflowEnvironment()
 	env.ExecuteWorkflow(splitJoinActivityWorkflow, true)
@@ -242,7 +240,7 @@ func (w *testTimerWorkflow) Execute(ctx Context, input []byte) (result []byte, e
 }
 
 func TestTimerWorkflow(t *testing.T) {
-	ts := newWorkflowTestSuite()
+	ts := &WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 	w := &testTimerWorkflow{t: t}
 	env.ExecuteWorkflow(w.Execute, []byte{1, 2})
@@ -292,7 +290,7 @@ func (w *testActivityCancelWorkflow) Execute(ctx Context, input []byte) (result 
 }
 
 func TestActivityCancellation(t *testing.T) {
-	ts := newWorkflowTestSuite()
+	ts := &WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 	w := &testActivityCancelWorkflow{t: t}
 	env.ExecuteWorkflow(w.Execute, []byte{1, 2})

--- a/internal_workflow_testsuite_test.go
+++ b/internal_workflow_testsuite_test.go
@@ -49,7 +49,6 @@ func (s *WorkflowTestSuiteUnitTest) SetupSuite() {
 		StartToCloseTimeout:    time.Minute,
 		HeartbeatTimeout:       20 * time.Second,
 	}
-	s.hostEnv = getHostEnvironment()
 	RegisterWorkflowWithOptions(testWorkflowHello, RegisterWorkflowOptions{Name: "testWorkflowHello"})
 	RegisterWorkflow(testWorkflowHeartbeat)
 	RegisterActivity(testActivityHello)

--- a/workflow_testsuite.go
+++ b/workflow_testsuite.go
@@ -23,7 +23,6 @@ package cadence
 import (
 	"context"
 	"reflect"
-	"sync"
 	"time"
 
 	"github.com/stretchr/testify/mock"
@@ -37,10 +36,8 @@ type (
 
 	// WorkflowTestSuite is the test suite to run unit tests for workflow/activity.
 	WorkflowTestSuite struct {
-		logger  *zap.Logger
-		scope   tally.Scope
-		hostEnv *hostEnvImpl
-		locker  sync.Mutex
+		logger *zap.Logger
+		scope  tally.Scope
 	}
 
 	// TestWorkflowEnvironment is the environment that you use to test workflow
@@ -63,10 +60,6 @@ type (
 		waitDuration time.Duration
 	}
 )
-
-func newWorkflowTestSuite() *WorkflowTestSuite {
-	return &WorkflowTestSuite{hostEnv: getHostEnvironment()}
-}
 
 // Get extract data from encoded data to desired value type. valuePtr is pointer to the actual value type.
 func (b EncodedValues) Get(valuePtr ...interface{}) error {
@@ -365,8 +358,6 @@ func (t *TestWorkflowEnvironment) RegisterDelayedCallback(callback func(), delay
 // SetActivityTaskList set the affinity between activity and tasklist. By default, activity can be invoked by any tasklist
 // in this test environment. You can use this SetActivityTaskList() to set affinity between activity and a tasklist. Once
 // activity is set to a particular tasklist, that activity will only be available to that tasklist.
-func (t *TestWorkflowEnvironment) SetActivityTaskList(
-	tasklist string, ao RegisterActivityOptions, activityFn ...interface{},
-) {
-	t.impl.setActivityTaskList(tasklist, ao, activityFn...)
+func (t *TestWorkflowEnvironment) SetActivityTaskList(tasklist string, activityFn ...interface{}) {
+	t.impl.setActivityTaskList(tasklist, activityFn...)
 }


### PR DESCRIPTION
We added the private hostEnv to test suite before we were able to mock activity/workflow. Now with mock, we don't really need this separate hostEnv. 