### PR TITLE
lookup friendly name when invoking

### DIFF
--- a/internal_activity.go
+++ b/internal_activity.go
@@ -215,6 +215,10 @@ func getValidatedActivityFunction(f interface{}, args []interface{}) (*ActivityT
 			"Invalid type 'f' parameter provided, it can be either activity function or name of the activity: %v", f)
 	}
 
+	if alias, ok := getHostEnvironment().getActivityAlias(fnName); ok {
+		fnName = alias
+	}
+
 	input, err := getHostEnvironment().encodeArgs(args)
 	if err != nil {
 		return nil, nil, err

--- a/internal_workflow.go
+++ b/internal_workflow.go
@@ -935,6 +935,10 @@ func getValidatedWorkerFunction(workflowFunc interface{}, args []interface{}) (*
 			workflowFunc)
 	}
 
+	if alias, ok := getHostEnvironment().getWorkflowAlias(fnName); ok {
+		fnName = alias
+	}
+
 	input, err := getHostEnvironment().encodeArgs(args)
 	if err != nil {
 		return nil, nil, err

--- a/internal_workflow_testsuite_test.go
+++ b/internal_workflow_testsuite_test.go
@@ -580,7 +580,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflow_Listener() {
 	s.NoError(env.GetWorkflowResult(&actualResult))
 	s.Equal("hello_activity hello_world", actualResult)
 	s.Equal("hello_world", childWorkflowResult)
-	s.Equal(getFunctionName(testWorkflowHello), childWorkflowName)
+	s.Equal("testWorkflowHello", childWorkflowName)
 }
 
 func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflow_Clock() {
@@ -732,7 +732,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_MockWorkflowWait() {
 
 	// no delay to the mock call, workflow should return no error
 	env := s.NewTestWorkflowEnvironment()
-	env.OnWorkflow(testWorkflowHello, mock.Anything, mock.Anything).Return("hello_mock_delayed", nil).Once()
+	env.OnWorkflow(testWorkflowHello, mock.Anything).Return("hello_mock_delayed", nil).Once()
 	env.ExecuteWorkflow(workflowFn)
 	s.True(env.IsWorkflowCompleted())
 	s.NoError(env.GetWorkflowError())
@@ -740,7 +740,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_MockWorkflowWait() {
 
 	// delay 10 minutes, which is shorter than the 1 hour timer, so workflow should return no error.
 	env = s.NewTestWorkflowEnvironment()
-	env.OnWorkflow(testWorkflowHello, mock.Anything, mock.Anything).After(time.Minute*10).Return("hello_mock_delayed", nil).Once()
+	env.OnWorkflow(testWorkflowHello, mock.Anything).After(time.Minute*10).Return("hello_mock_delayed", nil).Once()
 	env.ExecuteWorkflow(workflowFn)
 	s.True(env.IsWorkflowCompleted())
 	s.NoError(env.GetWorkflowError())
@@ -748,7 +748,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_MockWorkflowWait() {
 
 	// delay 2 hours, which is longer than the 1 hour timer, and workflow should return error.
 	env = s.NewTestWorkflowEnvironment()
-	env.OnWorkflow(testWorkflowHello, mock.Anything, mock.Anything).After(time.Hour*2).Return("hello_mock_delayed", nil).Once()
+	env.OnWorkflow(testWorkflowHello, mock.Anything).After(time.Hour*2).Return("hello_mock_delayed", nil).Once()
 	env.ExecuteWorkflow(workflowFn)
 	s.True(env.IsWorkflowCompleted())
 	s.Error(env.GetWorkflowError())
@@ -827,7 +827,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWithChild() {
 
 	// no delay to the mock call, workflow should return no error
 	env := s.NewTestWorkflowEnvironment()
-	env.OnWorkflow(testWorkflowHello, mock.Anything, mock.Anything).Return("hello_mock_delayed", nil).Once()
+	env.OnWorkflow(testWorkflowHello, mock.Anything).Return("hello_mock_delayed", nil).Once()
 	env.ExecuteWorkflow(workflowFn)
 	s.True(env.IsWorkflowCompleted())
 	s.NoError(env.GetWorkflowError())
@@ -835,7 +835,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWithChild() {
 
 	// delay 10 minutes, which is shorter than the 1 hour timer, so workflow should return no error.
 	env = s.NewTestWorkflowEnvironment()
-	env.OnWorkflow(testWorkflowHello, mock.Anything, mock.Anything).After(time.Minute*10).Return("hello_mock_delayed", nil).Once()
+	env.OnWorkflow(testWorkflowHello, mock.Anything).After(time.Minute*10).Return("hello_mock_delayed", nil).Once()
 	env.ExecuteWorkflow(workflowFn)
 	s.True(env.IsWorkflowCompleted())
 	s.NoError(env.GetWorkflowError())
@@ -843,7 +843,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWithChild() {
 
 	// delay 2 hours, which is longer than the 1 hour timer, and workflow should return error.
 	env = s.NewTestWorkflowEnvironment()
-	env.OnWorkflow(testWorkflowHello, mock.Anything, mock.Anything).After(time.Hour*2).Return("hello_mock_delayed", nil).Once()
+	env.OnWorkflow(testWorkflowHello, mock.Anything).After(time.Hour*2).Return("hello_mock_delayed", nil).Once()
 	env.ExecuteWorkflow(workflowFn)
 	s.True(env.IsWorkflowCompleted())
 	s.Error(env.GetWorkflowError())

--- a/workflow_testsuite.go
+++ b/workflow_testsuite.go
@@ -130,7 +130,11 @@ func (t *TestWorkflowEnvironment) OnActivity(activity interface{}, args ...inter
 		if err := validateFnFormat(fnType, false); err != nil {
 			panic(err)
 		}
-		call = t.Mock.On(getFunctionName(activity), args...)
+		fnName := getFunctionName(activity)
+		if alias, ok := getHostEnvironment().getActivityAlias(fnName); ok {
+			fnName = alias
+		}
+		call = t.Mock.On(fnName, args...)
 
 	case reflect.String:
 		call = t.Mock.On(activity.(string), args...)
@@ -163,7 +167,11 @@ func (t *TestWorkflowEnvironment) OnWorkflow(workflow interface{}, args ...inter
 		if err := validateFnFormat(fnType, true); err != nil {
 			panic(err)
 		}
-		call = t.Mock.On(getFunctionName(workflow), args...)
+		fnName := getFunctionName(workflow)
+		if alias, ok := getHostEnvironment().getWorkflowAlias(fnName); ok {
+			fnName = alias
+		}
+		call = t.Mock.On(fnName, args...)
 	case reflect.String:
 		call = t.Mock.On(workflow.(string), args...)
 	default:


### PR DESCRIPTION
We want the activity to appear as the registered friendly name (if it is present). 