### PR TITLE
fix rate limiter bug

### DIFF
--- a/internal_public.go
+++ b/internal_public.go
@@ -94,16 +94,15 @@ func NewActivityTaskWorker(
 ) Worker {
 	wOptions := fillWorkerOptionsDefaults(options)
 	workerParams := workerExecutionParameters{
-		TaskList:                                taskList,
-		ConcurrentPollRoutineSize:               defaultConcurrentPollRoutineSize,
-		ConcurrentActivityExecutionSize:         wOptions.MaxConcurrentActivityExecutionSize,
-		MaxActivityExecutionRate:                wOptions.MaxActivityExecutionRate,
-		MaxActivityExecutionRateRefreshDuration: wOptions.MaxActivityExecutionRateRefreshDuration,
-		Identity:              wOptions.Identity,
-		MetricsScope:          wOptions.MetricsScope,
-		Logger:                wOptions.Logger,
-		EnableLoggingInReplay: wOptions.EnableLoggingInReplay,
-		UserContext:           wOptions.BackgroundActivityContext,
+		TaskList:                        taskList,
+		ConcurrentPollRoutineSize:       defaultConcurrentPollRoutineSize,
+		ConcurrentActivityExecutionSize: wOptions.MaxConcurrentActivityExecutionSize,
+		MaxActivityExecutionPerSecond:   wOptions.MaxActivityExecutionPerSecond,
+		Identity:                        wOptions.Identity,
+		MetricsScope:                    wOptions.MetricsScope,
+		Logger:                          wOptions.Logger,
+		EnableLoggingInReplay:           wOptions.EnableLoggingInReplay,
+		UserContext:                     wOptions.BackgroundActivityContext,
 	}
 
 	processTestTags(&wOptions, &workerParams)

--- a/internal_worker_base.go
+++ b/internal_worker_base.go
@@ -82,13 +82,12 @@ type (
 
 	// baseWorkerOptions options to configure base worker.
 	baseWorkerOptions struct {
-		pollerCount                int
-		maxConcurrentTask          int
-		maxTaskRate                int
-		maxTaskRateRefreshDuration time.Duration
-		taskWorker                 taskPoller
-		identity                   string
-		workerType                 string
+		pollerCount       int
+		maxConcurrentTask int
+		maxTaskPerSecond  float64
+		taskWorker        taskPoller
+		identity          string
+		workerType        string
 	}
 
 	// baseWorker that wraps worker activities.
@@ -127,8 +126,8 @@ func newBaseWorker(options baseWorkerOptions, logger *zap.Logger, metricsScope t
 	return &baseWorker{
 		options:         options,
 		shutdownCh:      make(chan struct{}),
-		pollLimiter:     rate.NewLimiter(rate.Every(time.Millisecond*100), 100),
-		taskLimiter:     rate.NewLimiter(rate.Every(options.maxTaskRateRefreshDuration), options.maxTaskRate),
+		pollLimiter:     rate.NewLimiter(1000, 1),
+		taskLimiter:     rate.NewLimiter(rate.Limit(options.maxTaskPerSecond), 1),
 		retrier:         backoff.NewConcurrentRetrier(pollOperationRetryPolicy),
 		logger:          logger.With(zapcore.Field{Key: tagWorkerType, Type: zapcore.StringType, String: options.workerType}),
 		metricsScope:    tagScope(metricsScope, tagWorkerType, options.workerType),
@@ -160,8 +159,7 @@ func (bw *baseWorker) Start() {
 		bw.logger.Info("Started Worker",
 			zap.Int("PollerCount", bw.options.pollerCount),
 			zap.Int("MaxConcurrentTask", bw.options.maxConcurrentTask),
-			zap.Int("MaxTaskRate", bw.options.maxTaskRate),
-			zap.Duration("MaxTaskRateRefreshDuration", bw.options.maxTaskRateRefreshDuration),
+			zap.Float64("MaxTaskPerSecond", bw.options.maxTaskPerSecond),
 		)
 	})
 }

--- a/internal_worker_base.go
+++ b/internal_worker_base.go
@@ -126,7 +126,7 @@ func newBaseWorker(options baseWorkerOptions, logger *zap.Logger, metricsScope t
 	return &baseWorker{
 		options:         options,
 		shutdownCh:      make(chan struct{}),
-		pollLimiter:     rate.NewLimiter(1000, 1),
+		pollLimiter:     rate.NewLimiter(rate.Limit(1000), 1),
 		taskLimiter:     rate.NewLimiter(rate.Limit(options.maxTaskPerSecond), 1),
 		retrier:         backoff.NewConcurrentRetrier(pollOperationRetryPolicy),
 		logger:          logger.With(zapcore.Field{Key: tagWorkerType, Type: zapcore.StringType, String: options.workerType}),

--- a/internal_worker_test.go
+++ b/internal_worker_test.go
@@ -340,7 +340,7 @@ func createWorker(t *testing.T, service *mocks.TChanWorkflowService) Worker {
 
 	// Configure worker options.
 	workerOptions := WorkerOptions{}
-	workerOptions.MaxActivityExecutionRate = 20
+	workerOptions.MaxActivityExecutionPerSecond = 20
 
 	// Start Worker.
 	worker := NewWorker(

--- a/worker.go
+++ b/worker.go
@@ -22,7 +22,6 @@ package cadence
 
 import (
 	"context"
-	"time"
 
 	"github.com/uber-go/tally"
 
@@ -53,18 +52,12 @@ type (
 		// default: defaultMaxConcurrentActivityExecutionSize(1k)
 		MaxConcurrentActivityExecutionSize int
 
-		// Optional: Sets the rate limiting on number of activities that can be executed per refresh duration.
+		// Optional: Sets the rate limiting on number of activities that can be executed per second.
 		// This can be used to protect down stream services from flooding.
 		// The zero value of this uses the default value.
 		// default: defaultMaxActivityExecutionRate(100k)
 		// Warning: activity's StartToCloseTimeout starts ticking even if a task is blocked due to rate limiting.
-		MaxActivityExecutionRate int
-
-		// Optional: Sets the refresh duration for rate limit. If not specified, it uses 1s as default.
-		// Use this to fine tune your rate limiter. For example, you could set this duration to 10s with max rate set to
-		// 1 which means we rate limit the activity task to at most 1 per every 10s. You could also set this duration to
-		// 100ms with max rate set wo 10 which means rate limit to 10 activity task execution per every 100ms.
-		MaxActivityExecutionRateRefreshDuration time.Duration
+		MaxActivityExecutionPerSecond float64
 
 		// Optional: if the activities need auto heart beating for those activities
 		// by the framework

--- a/worker.go
+++ b/worker.go
@@ -52,8 +52,10 @@ type (
 		// default: defaultMaxConcurrentActivityExecutionSize(1k)
 		MaxConcurrentActivityExecutionSize int
 
-		// Optional: Sets the rate limiting on number of activities that can be executed per second.
-		// This can be used to protect down stream services from flooding.
+		// Optional: Sets the rate limiting on number of activities that can be executed per second. Notice that the
+		// number is represented in float, so that you can set it to less than 1 if needed. For example, set the number
+		// to 0.1 means you want your activity to be executed once for every 10 seconds. This can be used to protect
+		// down stream services from flooding.
 		// The zero value of this uses the default value.
 		// default: defaultMaxActivityExecutionRate(100k)
 		// Warning: activity's StartToCloseTimeout starts ticking even if a task is blocked due to rate limiting.


### PR DESCRIPTION
This is to fix the bug we found in canary alert.
The way we created the RateLimiter is incorrect. Here is the API:
// NewLimiter returns a new Limiter that allows events up to rate r and permits
// bursts of at most b tokens.
func NewLimiter(r Limit, b int) *Limiter

Here is how we use it:
rate.NewLimiter(rate.Every(maxTaskRateRefreshDuration), maxTaskRate)
In canary case, refresh duration is 1s, and the maxTaskRate is 100k. This means no rate limit for first 100K calls, then it will limit to 1 request for every 1s.

The correct usage should be:
rate.NewLimiter(maxTaskPerSecond, 1)
This means allow maxTaskPerSeconds for every 1s, and no burst.
