### PR TITLE
fix flakey unit test

### DIFF
--- a/internal_task_handlers.go
+++ b/internal_task_handlers.go
@@ -85,6 +85,7 @@ type (
 		hostEnv               *hostEnvImpl
 	}
 
+	activityProvider func(name string) activity
 	// activityTaskHandlerImpl is the implementation of ActivityTaskHandler
 	activityTaskHandlerImpl struct {
 		taskListName     string
@@ -94,7 +95,7 @@ type (
 		logger           *zap.Logger
 		userContext      context.Context
 		hostEnv          *hostEnvImpl
-		activityProvider func(name string) activity
+		activityProvider activityProvider
 	}
 
 	// history wrapper method to help information about events.
@@ -818,7 +819,7 @@ func newActivityTaskHandlerWithCustomProvider(
 	service m.TChanWorkflowService,
 	params workerExecutionParameters,
 	env *hostEnvImpl,
-	activityProvider func(name string) activity,
+	activityProvider activityProvider,
 ) ActivityTaskHandler {
 	return &activityTaskHandlerImpl{
 		taskListName:     params.TaskList,

--- a/internal_workflow_testsuite_test.go
+++ b/internal_workflow_testsuite_test.go
@@ -92,10 +92,11 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityMockValues() {
 }
 
 func (s *WorkflowTestSuiteUnitTest) Test_OnActivityStartedListener() {
+	runCount := 100
 	workflowFn := func(ctx Context) error {
 		ctx = WithActivityOptions(ctx, s.activityOptions)
 
-		for i := 1; i <= 3; i++ {
+		for i := 1; i <= runCount; i++ {
 			err := ExecuteActivity(ctx, testActivityHello, fmt.Sprintf("msg%d", i)).Get(ctx, nil)
 			if err != nil {
 				return err
@@ -113,10 +114,9 @@ func (s *WorkflowTestSuiteUnitTest) Test_OnActivityStartedListener() {
 		s.NoError(args.Get(&input))
 		activityCalls = append(activityCalls, fmt.Sprintf("%s:%s", activityInfo.ActivityType.Name, input))
 	})
-	expectedCalls := []string{
-		"testActivityHello:msg1",
-		"testActivityHello:msg2",
-		"testActivityHello:msg3",
+	expectedCalls := []string{}
+	for i := 1; i <= runCount; i++ {
+		expectedCalls = append(expectedCalls, fmt.Sprintf("testActivityHello:msg%v", i))
 	}
 
 	env.ExecuteWorkflow(workflowFn)


### PR DESCRIPTION
This is to fix https://github.com/uber-go/cadence-client/issues/236

The bug is a regression introduced in https://github.com/uber-go/cadence-client/commit/0116f4710cdf2942d11fa5cb7ee731cf2f1dcee1

The test should not modify the global map of activities, before the above commit, the tests created a copy of activities and wrap them with test wrapper for activity handler, the above mentioned commit change to directly modify the global map.

This fix only fix part of the issue that currently is exposed. The deeper issue is the way we lock the global map. If we have multiple threads doing RegisterActivity(), then there will be race condition. The RegisterActivity() will check if activity is registered and add to the map only if it is not already registered. However, the RegisterActivity() does not use a lock. This needs to be fixed but it should be in its own CR. File new issue for that: https://github.com/uber-go/cadence-client/issues/237

