### PR TITLE
Add type for keys used to attach values to the BackgroundActivity…

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -97,6 +97,10 @@ type (
 		// like common logger for all activities.
 		BackgroundActivityContext context.Context
 	}
+
+	// ActivityContextValueKey is a type to be used as the key for data attached
+	// as values to the BackgroundActivityContext.
+	ActivityContextValueKey int
 )
 
 // NewWorker creates an instance of worker for managing workflow and activity executions.


### PR DESCRIPTION
…Context

go lint rules error out if the type of the key passed to context.WithValue
is a basic type. The official golang documentation for context also provides
an example of using strongly typed keys: https://blog.golang.org/context#TOC_3.2.

This change provides a type in the Cadence client library that can be used to
attach data to the BackgroundActivityContext.