### PR TITLE
Fix make rules for collecting and reporting code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,3 +106,4 @@ fmt:
 
 clean:
 	rm -rf cadence-client
+	rm -Rf $(BUILD)

--- a/Makefile
+++ b/Makefile
@@ -75,17 +75,14 @@ cover_profile: clean copyright lint glide
 	@for dir in $(TEST_DIRS); do \
 		mkdir -p $(BUILD)/"$$dir"; \
 		go test "$$dir" $(TEST_ARG) -coverprofile=$(BUILD)/"$$dir"/coverage.out || exit 1; \
+		cat $(BUILD)/"$$dir"/coverage.out | grep -v "mode: atomic" >> $(BUILD)/cover.out; \
 	done;
 
 cover: cover_profile
-	@for dir in $(TEST_DIRS); do \
-		go tool cover -html=$(BUILD)/"$$dir"/coverage.out; \
-	done
+	go tool cover -html=$(BUILD)/cover.out;
 
 cover_ci: cover_profile
-	@for dir in $(TEST_DIRS); do \
-		goveralls -coverprofile=$(BUILD)/"$$dir"/coverage.out -service=travis-ci || echo -e "\x1b[31mCoveralls failed\x1b[m"; \
-	done
+	goveralls -coverprofile=$(BUILD)/cover.out -service=travis-ci || echo -e "\x1b[31mCoveralls failed\x1b[m";
 
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,9 @@ bins: glide thriftc copyright lint
 	done;
 
 cover_profile: clean copyright lint glide
+	@mkdir -p $(BUILD)
+	@echo "mode: atomic" > $(BUILD)/cover.out
+
 	@echo Testing packages:
 	@for dir in $(TEST_DIRS); do \
 		mkdir -p $(BUILD)/"$$dir"; \


### PR DESCRIPTION
The current make rules only report code coverage for the last test folder they process.
This change collects all coverage data collected into a central file and reports that
to coveralls.