### PR TITLE
remove GetWorkflowStackTrack from client API

### DIFF
--- a/client.go
+++ b/client.go
@@ -87,16 +87,6 @@ type (
 		//	- InternalServiceError
 		GetWorkflowHistory(ctx context.Context, workflowID string, runID string) (*s.History, error)
 
-		// GetWorkflowStackTrace gets a stack trace of all goroutines of a particular workflow.
-		// atDecisionTaskCompletedEventID is the eventID of the CompleteDecisionTask event at which stack trace should be taken.
-		// It allows to look at the past states of a workflow.
-		// 0 value indicates that the whole existing history should be used.
-		// The errors it can return:
-		//	- EntityNotExistsError
-		//	- BadRequestError
-		//	- InternalServiceError
-		GetWorkflowStackTrace(ctx context.Context, workflowID string, runID string, atDecisionTaskCompletedEventID int64) (string, error)
-
 		// CompleteActivity reports activity completed.
 		// activity Execute method can return cadence.ErrActivityResultPending to
 		// indicate the activity is not completed when it's Execute method returns. In that case, this CompleteActivity() method

--- a/worker.go
+++ b/worker.go
@@ -27,7 +27,6 @@ import (
 	"github.com/uber-go/tally"
 
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
-	s "go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/zap"
 )
 
@@ -125,17 +124,4 @@ func NewWorker(
 	options WorkerOptions,
 ) Worker {
 	return newAggregatedWorker(service, domain, taskList, options)
-}
-
-// GetWorkflowStackTrace returns a stack trace of all goroutines of a workflow given its current history.
-// It requires workflow function that was used to create the history to be registered
-// through RegisterWorkflow.
-// Use Client.GetWorkflowStackTrace to get a stack trace given workflowID and runID.
-func GetWorkflowStackTrace(h *s.History) (string, error) {
-	historyIterator := &historyIteratorImpl{
-		iteratorFunc: func(nextPageToken []byte) (*s.History, []byte, error) {
-			return h, nil, nil
-		},
-	}
-	return getWorkflowStackTraceImpl("unknown", "unknown", historyIterator)
 }


### PR DESCRIPTION
created task to make it possible to run a given history locally (so you can run it in debugger)
https://github.com/uber-go/cadence-client/issues/274