### PR TITLE
fix race candition in test framework

### DIFF
--- a/internal_workflow_testsuite.go
+++ b/internal_workflow_testsuite.go
@@ -667,8 +667,8 @@ func (env *testWorkflowEnvironmentImpl) ExecuteActivity(parameters executeActivi
 		// post activity result to workflow dispatcher
 		env.postCallback(func() {
 			env.handleActivityResult(activityInfo.activityID, result, parameters.ActivityType.Name)
+			env.runningCount.Dec()
 		}, false /* do not auto schedule decision task, because activity might be still pending */)
-		env.runningCount.Dec()
 	}()
 
 	return activityInfo


### PR DESCRIPTION
we use runningCount to track if there is still something running to avoid mock clock auto fire timer.
we should only decrease runningCount when the activity's result is processed (aka send over via channel).

This is to fix https://github.com/uber-go/cadence-client/issues/272
