### PR TITLE
Fix cadence-client repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Make sure you clone this repo into the correct location.
 
 ```bash
-git clone git@github.com:uber/cadence.git $GOPATH/src/go.uber.org/cadence
+git clone git@github.com:uber-go/cadence-client.git $GOPATH/src/go.uber.org/cadence
 ```
 
 or

--- a/README.md
+++ b/README.md
@@ -165,14 +165,11 @@ func buildCadenceClient() workflowserviceclient.Interface {
 				CadenceService: {Unary: ch.NewSingleOutbound(HostPort)},
 			},
 		})
-	if err := b.dispatcher.Start(); err != nil {
+	if err := dispatcher.Start(); err != nil {
 		panic("Failed to start dispatcher")
 	}
-	client, err := workflowserviceclient.New(dispatcher.ClientConfig(CadenceService))
-	if err != nil {
-		panic("Failed to setup workflowserviceclient")
-	}
-	return client
+
+	return workflowserviceclient.New(dispatcher.ClientConfig(CadenceService))
 }
 
 func startWorker(logger *zap.Logger, service workflowserviceclient.Interface) {


### PR DESCRIPTION
Fix repo name from `cadence` server to `cadence-client`:

repo `git@github.com:uber/cadence.git` points to cadence server repo, but inside `$GOPATH/src/go.uber.org/cadence` should be `github.com/uber-go/cadence-client` one.