### PR TITLE
handle ErrActivityResultPending in TestActivityEnvironment

### DIFF
--- a/internal_task_pollers.go
+++ b/internal_task_pollers.go
@@ -499,7 +499,7 @@ func (atp *activityTaskPoller) ProcessTask(task interface{}) error {
 	}
 	atp.metricsScope.Timer(metrics.ActivityExecutionLatency).Record(time.Now().Sub(executionStartTime))
 
-	if request == nil {
+	if request == ErrActivityResultPending {
 		// this could be true when activity returns ErrActivityResultPending.
 		return nil
 	}
@@ -603,7 +603,7 @@ func convertActivityResultToRespondRequest(identity string, taskToken, result []
 	if err == ErrActivityResultPending {
 		// activity result is pending and will be completed asynchronously.
 		// nothing to report at this point
-		return nil
+		return ErrActivityResultPending
 	}
 
 	if err == nil {

--- a/internal_task_pollers.go
+++ b/internal_task_pollers.go
@@ -500,7 +500,6 @@ func (atp *activityTaskPoller) ProcessTask(task interface{}) error {
 	atp.metricsScope.Timer(metrics.ActivityExecutionLatency).Record(time.Now().Sub(executionStartTime))
 
 	if request == ErrActivityResultPending {
-		// this could be true when activity returns ErrActivityResultPending.
 		return nil
 	}
 

--- a/internal_workflow_testsuite.go
+++ b/internal_workflow_testsuite.go
@@ -383,6 +383,8 @@ func (env *testWorkflowEnvironmentImpl) executeActivity(
 		return nil, constructError(request.GetReason(), request.Details)
 	case *shared.RespondActivityTaskCompletedRequest:
 		return EncodedValue(request.Result), nil
+	case nil: // when activity returns ErrActivityResultPending
+		return nil, nil
 	default:
 		// will never happen
 		return nil, fmt.Errorf("unsupported respond type %T", result)

--- a/internal_workflow_testsuite_test.go
+++ b/internal_workflow_testsuite_test.go
@@ -343,7 +343,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityReturnsErrActivityResultPending
 	}
 	RegisterActivity(activityFn)
 	_, err := env.ExecuteActivity(activityFn)
-	s.NoError(err)
+	s.Equal(ErrActivityResultPending, err)
 }
 
 func (s *WorkflowTestSuiteUnitTest) Test_WorkflowCancellation() {

--- a/internal_workflow_testsuite_test.go
+++ b/internal_workflow_testsuite_test.go
@@ -326,9 +326,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_CompleteActivity() {
 	}
 
 	env.OnActivity(testActivityHello, mock.Anything, mock.Anything).Return(mockActivity).Once()
-	env.SetTestTimeout(time.Second * 2) // don't waist time waiting
-
-	env.ExecuteWorkflow(testWorkflowHello) // workflow won't complete, as the fakeActivity returns ErrActivityResultPending
+	env.ExecuteWorkflow(testWorkflowHello)
 	s.True(env.IsWorkflowCompleted())
 	s.NoError(env.GetWorkflowError())
 	env.AssertExpectations(s.T())
@@ -336,6 +334,16 @@ func (s *WorkflowTestSuiteUnitTest) Test_CompleteActivity() {
 	var result string
 	env.GetWorkflowResult(&result)
 	s.Equal("async_complete", result)
+}
+
+func (s *WorkflowTestSuiteUnitTest) Test_ActivityReturnsErrActivityResultPending() {
+	env := s.NewTestActivityEnvironment()
+	activityFn := func(ctx context.Context) (string, error) {
+		return "", ErrActivityResultPending
+	}
+	RegisterActivity(activityFn)
+	_, err := env.ExecuteActivity(activityFn)
+	s.NoError(err)
 }
 
 func (s *WorkflowTestSuiteUnitTest) Test_WorkflowCancellation() {


### PR DESCRIPTION
When using TestActivityEnvironment to test activity and activity returns ErrActivityResultPending, it should not be treated as error.