### PR TITLE
fix unit test race condition

### DIFF
--- a/internal_workflow_testsuite.go
+++ b/internal_workflow_testsuite.go
@@ -667,8 +667,8 @@ func (env *testWorkflowEnvironmentImpl) ExecuteActivity(parameters executeActivi
 		// post activity result to workflow dispatcher
 		env.postCallback(func() {
 			env.handleActivityResult(activityInfo.activityID, result, parameters.ActivityType.Name)
+			env.runningCount.Dec()
 		}, false /* do not auto schedule decision task, because activity might be still pending */)
-		env.runningCount.Dec()
 	}()
 
 	return activityInfo


### PR DESCRIPTION
fix unit test race condition
we reduce the runningCount so the mock clock could move forward. we should only reduce that count after activity result is handled.