### PR TITLE
separate library version from feature version

### DIFF
--- a/internal/activity_test.go
+++ b/internal/activity_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"fmt"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/cadence/.gen/go/cadence/workflowservicetest"
@@ -35,6 +36,9 @@ import (
 	"go.uber.org/yarpc"
 )
 
+// this is the mock for yarpcCallOptions, make sure length are the same
+var callOptions = []interface{}{gomock.Any(), gomock.Any(), gomock.Any()}
+
 func TestActivityHeartbeat(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	service := workflowservicetest.NewMockClient(mockCtrl)
@@ -43,7 +47,7 @@ func TestActivityHeartbeat(t *testing.T) {
 	invoker := newServiceInvoker([]byte("task-token"), "identity", service, cancel, 1)
 	ctx = context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{serviceInvoker: invoker})
 
-	service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+	service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), callOptions...).
 		Return(&s.RecordActivityTaskHeartbeatResponse{}, nil).Times(1)
 
 	RecordActivityHeartbeat(ctx, "testDetails")
@@ -63,7 +67,7 @@ func TestActivityHeartbeat_InternalError(t *testing.T) {
 		serviceInvoker: invoker,
 		logger:         getLogger()})
 
-	service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+	service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), callOptions...).
 		Return(nil, &s.InternalServiceError{}).
 		Do(func(ctx context.Context, request *s.RecordActivityTaskHeartbeatRequest, opts ...yarpc.CallOption) {
 			fmt.Println("MOCK RecordActivityTaskHeartbeat executed")
@@ -82,7 +86,7 @@ func TestActivityHeartbeat_CancelRequested(t *testing.T) {
 		serviceInvoker: invoker,
 		logger:         getLogger()})
 
-	service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+	service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), callOptions...).
 		Return(&s.RecordActivityTaskHeartbeatResponse{CancelRequested: common.BoolPtr(true)}, nil).Times(1)
 
 	RecordActivityHeartbeat(ctx, "testDetails")
@@ -100,7 +104,7 @@ func TestActivityHeartbeat_EntityNotExist(t *testing.T) {
 		serviceInvoker: invoker,
 		logger:         getLogger()})
 
-	service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+	service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), callOptions...).
 		Return(&s.RecordActivityTaskHeartbeatResponse{}, &s.EntityNotExistsError{}).Times(1)
 
 	RecordActivityHeartbeat(ctx, "testDetails")
@@ -119,7 +123,7 @@ func TestActivityHeartbeat_SuppressContinousInvokes(t *testing.T) {
 		logger:         getLogger()})
 
 	// Multiple calls but only one call is made.
-	service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+	service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), callOptions...).
 		Return(&s.RecordActivityTaskHeartbeatResponse{}, nil).Times(1)
 	RecordActivityHeartbeat(ctx, "testDetails")
 	RecordActivityHeartbeat(ctx, "testDetails")
@@ -132,7 +136,7 @@ func TestActivityHeartbeat_SuppressContinousInvokes(t *testing.T) {
 	ctx = context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{
 		serviceInvoker: invoker2,
 		logger:         getLogger()})
-	service2.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+	service2.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), callOptions...).
 		Return(&s.RecordActivityTaskHeartbeatResponse{}, nil).Times(1)
 	RecordActivityHeartbeat(ctx, "testDetails")
 	RecordActivityHeartbeat(ctx, "testDetails")
@@ -145,10 +149,10 @@ func TestActivityHeartbeat_SuppressContinousInvokes(t *testing.T) {
 	ctx = context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{
 		serviceInvoker: invoker3,
 		logger:         getLogger()})
-	service3.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+	service3.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), callOptions...).
 		Return(&s.RecordActivityTaskHeartbeatResponse{}, nil).Times(1)
 
-	service3.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+	service3.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), callOptions...).
 		Return(&s.RecordActivityTaskHeartbeatResponse{}, nil).
 		Do(func(ctx context.Context, request *s.RecordActivityTaskHeartbeatRequest, opts ...yarpc.CallOption) {
 			ev := EncodedValues(request.Details)
@@ -175,9 +179,9 @@ func TestActivityHeartbeat_SuppressContinousInvokes(t *testing.T) {
 	ctx = context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{
 		serviceInvoker: invoker4,
 		logger:         getLogger()})
-	service4.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+	service4.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), callOptions...).
 		Return(&s.RecordActivityTaskHeartbeatResponse{}, nil).Times(1)
-	service4.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+	service4.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), callOptions...).
 		Return(&s.RecordActivityTaskHeartbeatResponse{}, nil).
 		Do(func(ctx context.Context, request *s.RecordActivityTaskHeartbeatRequest, opts ...yarpc.CallOption) {
 			require.Nil(t, request.Details)

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -460,7 +460,7 @@ func (t *TaskHandlersTestSuite) TestHeartBeat_NoError() {
 
 	cancelRequested := false
 	heartbeatResponse := s.RecordActivityTaskHeartbeatResponse{CancelRequested: &cancelRequested}
-	mockService.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).Return(&heartbeatResponse, nil)
+	mockService.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), callOptions...).Return(&heartbeatResponse, nil)
 
 	cadenceInvoker := &cadenceInvoker{
 		identity:  "Test_Cadence_Invoker",
@@ -478,7 +478,7 @@ func (t *TaskHandlersTestSuite) TestHeartBeat_NilResponseWithError() {
 	mockService := workflowservicetest.NewMockClient(mockCtrl)
 
 	entityNotExistsError := &s.EntityNotExistsError{}
-	mockService.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, entityNotExistsError)
+	mockService.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), callOptions...).Return(nil, entityNotExistsError)
 
 	cadenceInvoker := newServiceInvoker(
 		nil,

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -38,23 +38,45 @@ import (
 	"golang.org/x/net/context"
 )
 
-// versionHeaderName refers to the name of the
-// tchannel / http header that contains the client
-// library version
-const versionHeaderName = "cadence-client-version"
+const (
+	// libraryVersionHeaderName refers to the name of the
+	// tchannel / http header that contains the client
+	// library version
+	libraryVersionHeaderName = "cadence-client-library-version"
 
-// defaultRPCTimeout is the default tchannel rpc call timeout
-const defaultRPCTimeout = 10 * time.Second
+	// featureVersionHeaderName refers to the name of the
+	// tchannel / http header that contains the client
+	// feature version
+	featureVersionHeaderName = "cadence-client-feature-version"
 
-// retryNeverOptions - Never retry the connection
-var retryNeverOptions = &tchannel.RetryOptions{
-	RetryOn: tchannel.RetryNever,
-}
+	// languageHeaderName refers to the name of the
+	// tchannel / http header that contains the client
+	// language
+	languageHeaderName  = "cadence-client-language"
+	languageHeaderValue = "go"
 
-// retryDefaultOptions - retry with default options.
-var retryDefaultOptions = &tchannel.RetryOptions{
-	RetryOn: tchannel.RetryDefault,
-}
+	// defaultRPCTimeout is the default tchannel rpc call timeout
+	defaultRPCTimeout = 10 * time.Second
+)
+
+var (
+	// retryNeverOptions - Never retry the connection
+	retryNeverOptions = &tchannel.RetryOptions{
+		RetryOn: tchannel.RetryNever,
+	}
+
+	// retryDefaultOptions - retry with default options.
+	retryDefaultOptions = &tchannel.RetryOptions{
+		RetryOn: tchannel.RetryDefault,
+	}
+
+	// call header to cadence server
+	yarpcCallOptions = []yarpc.CallOption{
+		yarpc.WithHeader(libraryVersionHeaderName, LibraryVersion),
+		yarpc.WithHeader(featureVersionHeaderName, FeatureVersion),
+		yarpc.WithHeader(languageHeaderName, languageHeaderValue),
+	}
+)
 
 // ContextBuilder stores all Channel-specific parameters that will
 // be stored inside of a context.
@@ -94,10 +116,7 @@ func newChannelContext(ctx context.Context, options ...func(builder *contextBuil
 	}
 	ctx, cancelFn := builder.Build()
 
-	callOptions := []yarpc.CallOption{
-		yarpc.WithHeader(versionHeaderName, LibraryVersion)}
-
-	return ctx, cancelFn, callOptions
+	return ctx, cancelFn, yarpcCallOptions
 }
 
 // GetWorkerIdentity gets a default identity for the worker.

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -49,11 +49,10 @@ const (
 	// feature version
 	featureVersionHeaderName = "cadence-client-feature-version"
 
-	// languageHeaderName refers to the name of the
-	// tchannel / http header that contains the client
-	// language
-	languageHeaderName  = "cadence-client-language"
-	languageHeaderValue = "go"
+	// clientImplHeaderName refers to the name of the
+	// header that contains the client implementation
+	clientImplHeaderName  = "cadence-client-name"
+	clientImplHeaderValue = "uber-go"
 
 	// defaultRPCTimeout is the default tchannel rpc call timeout
 	defaultRPCTimeout = 10 * time.Second
@@ -74,7 +73,7 @@ var (
 	yarpcCallOptions = []yarpc.CallOption{
 		yarpc.WithHeader(libraryVersionHeaderName, LibraryVersion),
 		yarpc.WithHeader(featureVersionHeaderName, FeatureVersion),
-		yarpc.WithHeader(languageHeaderName, languageHeaderValue),
+		yarpc.WithHeader(clientImplHeaderName, clientImplHeaderValue),
 	}
 )
 

--- a/internal/internal_worker_interfaces_test.go
+++ b/internal/internal_worker_interfaces_test.go
@@ -146,12 +146,12 @@ func (s *InterfacesTestSuite) TestInterface() {
 	}
 
 	// mocks
-	service.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), gomock.Any()).Return(domainDesc, nil).AnyTimes()
-	service.EXPECT().PollForActivityTask(gomock.Any(), gomock.Any(), gomock.Any()).Return(&m.PollForActivityTaskResponse{}, nil).AnyTimes()
-	service.EXPECT().RespondActivityTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	service.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), gomock.Any()).Return(&m.PollForDecisionTaskResponse{}, nil).AnyTimes()
-	service.EXPECT().RespondDecisionTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	service.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).Return(&m.StartWorkflowExecutionResponse{}, nil).AnyTimes()
+	service.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), callOptions...).Return(domainDesc, nil).AnyTimes()
+	service.EXPECT().PollForActivityTask(gomock.Any(), gomock.Any(), callOptions...).Return(&m.PollForActivityTaskResponse{}, nil).AnyTimes()
+	service.EXPECT().RespondActivityTaskCompleted(gomock.Any(), gomock.Any(), callOptions...).Return(nil).AnyTimes()
+	service.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), callOptions...).Return(&m.PollForDecisionTaskResponse{}, nil).AnyTimes()
+	service.EXPECT().RespondDecisionTaskCompleted(gomock.Any(), gomock.Any(), callOptions...).Return(nil).AnyTimes()
+	service.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any(), callOptions...).Return(&m.StartWorkflowExecutionResponse{}, nil).AnyTimes()
 
 	env := getHostEnvironment()
 	// Launch worker.

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -268,7 +268,7 @@ func TestWorkerStartFailsWithInvalidDomain(t *testing.T) {
 
 	for _, tc := range testCases {
 		service := workflowservicetest.NewMockClient(mockCtrl)
-		service.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, tc.domainErr).Do(
+		service.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), callOptions...).Return(nil, tc.domainErr).Do(
 			func(ctx context.Context, request *s.DescribeDomainRequest, opts ...yarpc.CallOption) {
 				// log
 			}).Times(2)
@@ -303,18 +303,18 @@ func createWorker(t *testing.T, service *workflowservicetest.MockClient) Worker 
 		},
 	}
 	// mocks
-	service.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), gomock.Any()).Return(domainDesc, nil).Do(
+	service.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), callOptions...).Return(domainDesc, nil).Do(
 		func(ctx context.Context, request *s.DescribeDomainRequest, opts ...yarpc.CallOption) {
 			// log
 		}).AnyTimes()
 
 	activityTask := &s.PollForActivityTaskResponse{}
-	service.EXPECT().PollForActivityTask(gomock.Any(), gomock.Any(), gomock.Any()).Return(activityTask, nil).AnyTimes()
-	service.EXPECT().RespondActivityTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	service.EXPECT().PollForActivityTask(gomock.Any(), gomock.Any(), callOptions...).Return(activityTask, nil).AnyTimes()
+	service.EXPECT().RespondActivityTaskCompleted(gomock.Any(), gomock.Any(), callOptions...).Return(nil).AnyTimes()
 
 	decisionTask := &s.PollForDecisionTaskResponse{}
-	service.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), gomock.Any()).Return(decisionTask, nil).AnyTimes()
-	service.EXPECT().RespondDecisionTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	service.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), callOptions...).Return(decisionTask, nil).AnyTimes()
+	service.EXPECT().RespondDecisionTaskCompleted(gomock.Any(), gomock.Any(), callOptions...).Return(nil).AnyTimes()
 
 	// Configure worker options.
 	workerOptions := WorkerOptions{}
@@ -336,15 +336,15 @@ func TestCompleteActivity(t *testing.T) {
 	domain := "testDomain"
 	wfClient := NewClient(mockService, domain, nil)
 	var completedRequest, canceledRequest, failedRequest interface{}
-	mockService.EXPECT().RespondActivityTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(
+	mockService.EXPECT().RespondActivityTaskCompleted(gomock.Any(), gomock.Any(), callOptions...).Return(nil).Do(
 		func(ctx context.Context, request *s.RespondActivityTaskCompletedRequest, opts ...yarpc.CallOption) {
 			completedRequest = request
 		})
-	mockService.EXPECT().RespondActivityTaskCanceled(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(
+	mockService.EXPECT().RespondActivityTaskCanceled(gomock.Any(), gomock.Any(), callOptions...).Return(nil).Do(
 		func(ctx context.Context, request *s.RespondActivityTaskCanceledRequest, opts ...yarpc.CallOption) {
 			canceledRequest = request
 		})
-	mockService.EXPECT().RespondActivityTaskFailed(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(
+	mockService.EXPECT().RespondActivityTaskFailed(gomock.Any(), gomock.Any(), callOptions...).Return(nil).Do(
 		func(ctx context.Context, request *s.RespondActivityTaskFailedRequest, opts ...yarpc.CallOption) {
 			failedRequest = request
 		})
@@ -366,15 +366,15 @@ func TestCompleteActivityById(t *testing.T) {
 	domain := "testDomain"
 	wfClient := NewClient(mockService, domain, nil)
 	var completedRequest, canceledRequest, failedRequest interface{}
-	mockService.EXPECT().RespondActivityTaskCompletedByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(
+	mockService.EXPECT().RespondActivityTaskCompletedByID(gomock.Any(), gomock.Any(), callOptions...).Return(nil).Do(
 		func(ctx context.Context, request *s.RespondActivityTaskCompletedByIDRequest, opts ...yarpc.CallOption) {
 			completedRequest = request
 		})
-	mockService.EXPECT().RespondActivityTaskCanceledByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(
+	mockService.EXPECT().RespondActivityTaskCanceledByID(gomock.Any(), gomock.Any(), callOptions...).Return(nil).Do(
 		func(ctx context.Context, request *s.RespondActivityTaskCanceledByIDRequest, opts ...yarpc.CallOption) {
 			canceledRequest = request
 		})
-	mockService.EXPECT().RespondActivityTaskFailedByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(
+	mockService.EXPECT().RespondActivityTaskFailedByID(gomock.Any(), gomock.Any(), callOptions...).Return(nil).Do(
 		func(ctx context.Context, request *s.RespondActivityTaskFailedByIDRequest, opts ...yarpc.CallOption) {
 			failedRequest = request
 		})
@@ -403,7 +403,7 @@ func TestRecordActivityHeartbeat(t *testing.T) {
 	var heartbeatRequest *s.RecordActivityTaskHeartbeatRequest
 	cancelRequested := false
 	heartbeatResponse := s.RecordActivityTaskHeartbeatResponse{CancelRequested: &cancelRequested}
-	mockService.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).Return(&heartbeatResponse, nil).
+	mockService.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), callOptions...).Return(&heartbeatResponse, nil).
 		Do(func(ctx context.Context, request *s.RecordActivityTaskHeartbeatRequest, opts ...yarpc.CallOption) {
 			heartbeatRequest = request
 		}).Times(2)

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -57,9 +57,9 @@ func (s *WorkersTestSuite) TestWorkflowWorker() {
 	mockCtrl := gomock.NewController(s.T())
 	service := workflowservicetest.NewMockClient(mockCtrl)
 
-	service.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	service.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), gomock.Any()).Return(&m.PollForDecisionTaskResponse{}, nil)
-	service.EXPECT().RespondDecisionTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	service.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), callOptions...).Return(nil, nil)
+	service.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), callOptions...).Return(&m.PollForDecisionTaskResponse{}, nil)
+	service.EXPECT().RespondDecisionTaskCompleted(gomock.Any(), gomock.Any(), callOptions...).Return(nil)
 
 	executionParameters := workerExecutionParameters{
 		TaskList:                  "testTaskList",
@@ -81,9 +81,9 @@ func (s *WorkersTestSuite) TestActivityWorker() {
 	mockCtrl := gomock.NewController(s.T())
 	service := workflowservicetest.NewMockClient(mockCtrl)
 
-	service.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	service.EXPECT().PollForActivityTask(gomock.Any(), gomock.Any(), gomock.Any()).Return(&m.PollForActivityTaskResponse{}, nil)
-	service.EXPECT().RespondActivityTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	service.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), callOptions...).Return(nil, nil)
+	service.EXPECT().PollForActivityTask(gomock.Any(), gomock.Any(), callOptions...).Return(&m.PollForActivityTaskResponse{}, nil)
+	service.EXPECT().RespondActivityTaskCompleted(gomock.Any(), gomock.Any(), callOptions...).Return(nil)
 
 	executionParameters := workerExecutionParameters{
 		TaskList:                  "testTaskList",
@@ -107,8 +107,8 @@ func (s *WorkersTestSuite) TestPollForDecisionTask_InternalServiceError() {
 	mockCtrl := gomock.NewController(s.T())
 	service := workflowservicetest.NewMockClient(mockCtrl)
 
-	service.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	service.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), gomock.Any()).Return(&m.PollForDecisionTaskResponse{}, &m.InternalServiceError{})
+	service.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), callOptions...).Return(nil, nil)
+	service.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), callOptions...).Return(&m.PollForDecisionTaskResponse{}, &m.InternalServiceError{})
 
 	executionParameters := workerExecutionParameters{
 		TaskList:                  "testDecisionTaskList",

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -225,7 +225,7 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite) *testWorkflowEnvironme
 		return nil
 	}
 
-	em := mockService.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+	em := mockService.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), callOptions...).
 		Return(&shared.RecordActivityTaskHeartbeatResponse{CancelRequested: common.BoolPtr(false)}, nil)
 	em.Do(func(ctx context.Context, r *shared.RecordActivityTaskHeartbeatRequest, opts ...yarpc.CallOption) {
 		// TODO: The following will hit a data race in the gomock code where the Do() action is executed outside

--- a/internal/version.go
+++ b/internal/version.go
@@ -28,12 +28,18 @@ package internal
 // by the cadence team as part of a major feature or
 // behavior change
 
-// LibraryVersion is a semver string that represents
-// the version of this cadence client library
-const LibraryVersion = "v0.5.0"
+// LibraryVersion is a semver that represents
+// the version of this cadence client library.
+// This represent API changes visibile to Cadence
+// client side library consumers. I.e. developers
+// that are writing workflows. So every time we change API
+// that can affect them we have to change this number.
+// Format: MAJOR.MINOR.PATCH
+const LibraryVersion = "0.5.0"
 
-// FeatureVersion is a int that represents the
+// FeatureVersion is a semver that represents the
 // feature set of this cadence client library support.
-// This can be used for client capibility check, for
-// backward compatibility
-const FeatureVersion = "1"
+// This can be used for client capibility check, on
+// Cadence server, for backward compatibility
+// Format: MAJOR.MINOR.PATCH
+const FeatureVersion = "1.0.0"

--- a/internal/version.go
+++ b/internal/version.go
@@ -20,13 +20,20 @@
 
 package internal
 
-// LibraryVersion is a semver string that represents
-// the version of this cadence client library
-// it will be embedded as a "version" header in every
-// rpc call made by this client to cadence server.
-// In addition, the version string will be used by
-// the server to enforce compatibility checks
-// Update to this version number is typically done
+// below are the metadata which will be embedded as part
+// of headers in every rpc call made by this client to
+// cadence server.
+
+// Update to the metadata below is typically done
 // by the cadence team as part of a major feature or
 // behavior change
+
+// LibraryVersion is a semver string that represents
+// the version of this cadence client library
 const LibraryVersion = "v0.5.0"
+
+// FeatureVersion is a int that represents the
+// feature set of this cadence client library support.
+// This can be used for client capibility check, for
+// backward compatibility
+const FeatureVersion = "1"


### PR DESCRIPTION
separate the library version from feature version, also include the client lang in the rpc call to service.