### PR TITLE
fix timer

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -326,7 +326,7 @@ func (wc *workflowEnvironmentImpl) NewTimer(d time.Duration, callback resultHand
 		callback(nil, errors.New("Invalid delayInSeconds provided"))
 		return nil
 	}
-	if d == 0 {
+	if d.Seconds() == 0 {
 		callback(nil, nil)
 		return nil
 	}

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -323,7 +323,7 @@ func (wc *workflowEnvironmentImpl) Now() time.Time {
 
 func (wc *workflowEnvironmentImpl) NewTimer(d time.Duration, callback resultHandler) *timerInfo {
 	if d < 0 {
-		callback(nil, errors.New("Invalid delayInSeconds provided"))
+		callback(nil, fmt.Errorf("negative duration provided %v", d))
 		return nil
 	}
 	if d.Seconds() == 0 {


### PR DESCRIPTION
timer granularity is second. we pass time.Duration's seconds as timer's duration, and server don't like 0 s we should fire it on client immediately. 