### PR TITLE
test support for local activity

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -116,10 +116,11 @@ type (
 		callbackChannel chan testCallbackHandle
 		testTimeout     time.Duration
 
-		counterID      int
-		activities     map[string]*testActivityHandle
-		timers         map[string]*testTimerHandle
-		childWorkflows map[string]*testChildWorkflowHandle
+		counterID       int
+		activities      map[string]*testActivityHandle
+		localActivities map[string]*localActivityTask
+		timers          map[string]*testTimerHandle
+		childWorkflows  map[string]*testChildWorkflowHandle
 
 		runningCount int
 
@@ -128,6 +129,9 @@ type (
 		onActivityStartedListener        func(activityInfo *ActivityInfo, ctx context.Context, args encoded.Values)
 		onActivityCompletedListener      func(activityInfo *ActivityInfo, result encoded.Value, err error)
 		onActivityCanceledListener       func(activityInfo *ActivityInfo)
+		onLocalActivityStartedListener   func(activityInfo *ActivityInfo, ctx context.Context, args []interface{})
+		onLocalActivityCompletedListener func(activityInfo *ActivityInfo, result encoded.Value, err error)
+		onLocalActivityCanceledListener  func(activityInfo *ActivityInfo)
 		onActivityHeartbeatListener      func(activityInfo *ActivityInfo, details encoded.Values)
 		onChildWorkflowStartedListener   func(workflowInfo *WorkflowInfo, ctx Context, args encoded.Values)
 		onChildWorkflowCompletedListener func(workflowInfo *WorkflowInfo, result encoded.Value, err error)
@@ -169,6 +173,7 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite) *testWorkflowEnvironme
 			wallClock:       clock.New(),
 			timers:          make(map[string]*testTimerHandle),
 			activities:      make(map[string]*testActivityHandle),
+			localActivities: make(map[string]*localActivityTask),
 			childWorkflows:  make(map[string]*testChildWorkflowHandle),
 			callbackChannel: make(chan testCallbackHandle, 1000),
 			testTimeout:     time.Second * 3,
@@ -667,11 +672,60 @@ func (env *testWorkflowEnvironmentImpl) ExecuteActivity(parameters executeActivi
 }
 
 func (env *testWorkflowEnvironmentImpl) ExecuteLocalActivity(params executeLocalActivityParams, callback resultHandler) *localActivityInfo {
-	panic("not implemented yet, coming soon")
+	activityID := getStringID(env.nextID())
+	wOptions := fillWorkerOptionsDefaults(env.workerOptions)
+	ae := &activityExecutor{name: getFunctionName(params.ActivityFn), fn: params.ActivityFn}
+	if at, _, _ := getValidatedActivityFunction(params.ActivityFn, params.InputArgs); at != nil {
+		// local activity could be registered, if so use the registered name. This name is only used to find a mock.
+		ae.name = at.Name
+	}
+	aew := &activityExecutorWrapper{activityExecutor: ae, env: env}
+
+	// substitute the local activity function so we could replace with mock if it is supplied.
+	params.ActivityFn = func(ctx context.Context, inputArgs ...interface{}) ([]byte, error) {
+		return aew.ExecuteWithActualArgs(ctx, params.InputArgs)
+	}
+
+	task := &localActivityTask{
+		activityID: activityID,
+		params:     &params,
+		callback:   callback,
+	}
+	taskHandler := localActivityTaskHandler{
+		userContext:  wOptions.BackgroundActivityContext,
+		metricsScope: wOptions.MetricsScope,
+		logger:       wOptions.Logger,
+	}
+
+	env.localActivities[activityID] = task
+	env.runningCount++
+
+	go func() {
+		result := taskHandler.executeLocalActivityTask(task)
+		env.postCallback(func() {
+			env.handleLocalActivityResult(result)
+			env.runningCount--
+		}, false)
+	}()
+
+	return &localActivityInfo{activityID: activityID}
 }
 
 func (env *testWorkflowEnvironmentImpl) RequestCancelLocalActivity(activityID string) {
-	panic("not implemented yet, coming soon")
+	task, ok := env.localActivities[activityID]
+	if !ok {
+		env.logger.Debug("RequestCancelLocalActivity failed, LocalActivity not exists or already completed.", zap.String(tagActivityID, activityID))
+		return
+	}
+	activityInfo := env.getActivityInfo(activityID, getFunctionName(task.params.ActivityFn))
+	env.logger.Debug("RequestCancelLocalActivity", zap.String(tagActivityID, activityID))
+	delete(env.localActivities, activityID)
+	env.postCallback(func() {
+		task.callback(nil, NewCanceledError())
+		if env.onLocalActivityCanceledListener != nil {
+			env.onLocalActivityCanceledListener(activityInfo)
+		}
+	}, true)
 }
 
 func (env *testWorkflowEnvironmentImpl) handleActivityResult(activityID string, result interface{}, activityType string) {
@@ -721,6 +775,29 @@ func (env *testWorkflowEnvironmentImpl) handleActivityResult(activityID string, 
 	env.startDecisionTask()
 }
 
+func (env *testWorkflowEnvironmentImpl) handleLocalActivityResult(result *localActivityResult) {
+	activityID := result.task.activityID
+	activityType := getFunctionName(result.task.params.ActivityFn)
+	env.logger.Debug(fmt.Sprintf("handleLocalActivityResult: Err: %v, Result: %v.", result.err, string(result.result)),
+		zap.String(tagActivityID, activityID), zap.String(tagActivityType, activityType))
+
+	activityInfo := env.getActivityInfo(activityID, activityType)
+	task, ok := env.localActivities[activityID]
+	if !ok {
+		env.logger.Debug("handleLocalActivityResult: ActivityID not exists, could be already completed or cancelled.",
+			zap.String(tagActivityID, activityID))
+		return
+	}
+
+	delete(env.localActivities, activityID)
+	task.callback(result.result, result.err)
+	if env.onLocalActivityCompletedListener != nil {
+		env.onLocalActivityCompletedListener(activityInfo, EncodedValue(result.result), result.err)
+	}
+
+	env.startDecisionTask()
+}
+
 // runBeforeMockCallReturns is registered as mock call's RunFn by *mock.Call.Run(fn). It will be called by testify's
 // mock.MethodCalled() before it returns.
 func (env *testWorkflowEnvironmentImpl) runBeforeMockCallReturns(call *MockCallWrapper, args mock.Arguments) {
@@ -760,6 +837,23 @@ func (a *activityExecutorWrapper) Execute(ctx context.Context, input []byte) ([]
 	}
 
 	return a.activityExecutor.Execute(ctx, input)
+}
+
+// Execute executes the activity code.
+func (a *activityExecutorWrapper) ExecuteWithActualArgs(ctx context.Context, inputArgs []interface{}) ([]byte, error) {
+	activityInfo := GetActivityInfo(ctx)
+	if a.env.onLocalActivityStartedListener != nil {
+		a.env.postCallback(func() {
+			a.env.onLocalActivityStartedListener(&activityInfo, ctx, inputArgs)
+		}, false)
+	}
+
+	m := &mockWrapper{env: a.env, name: a.name, fn: a.fn, isWorkflow: false}
+	if mockRet := m.getMockReturnWithActualArgs(ctx, inputArgs); mockRet != nil {
+		return m.executeMockWithActualArgs(ctx, inputArgs, mockRet)
+	}
+
+	return a.activityExecutor.ExecuteWithActualArgs(ctx, inputArgs)
 }
 
 // Execute executes the workflow code.
@@ -810,6 +904,17 @@ func (w *workflowExecutorWrapper) Execute(ctx Context, input []byte) (result []b
 	return w.workflowExecutor.Execute(ctx, input)
 }
 
+func (m *mockWrapper) getCtxArg(ctx interface{}) []interface{} {
+	fnType := reflect.TypeOf(m.fn)
+	if fnType.NumIn() > 0 {
+		if (!m.isWorkflow && isActivityContext(fnType.In(0))) ||
+			(m.isWorkflow && isWorkflowContext(fnType.In(0))) {
+			return []interface{}{ctx}
+		}
+	}
+	return nil
+}
+
 func (m *mockWrapper) getMockReturn(ctx interface{}, input []byte) (retArgs mock.Arguments) {
 	if _, ok := m.env.expectedMockCalls[m.name]; !ok {
 		// no mock
@@ -821,13 +926,7 @@ func (m *mockWrapper) getMockReturn(ctx interface{}, input []byte) (retArgs mock
 	if err != nil {
 		panic(err)
 	}
-	realArgs := []interface{}{}
-	if fnType.NumIn() > 0 {
-		if (!m.isWorkflow && isActivityContext(fnType.In(0))) ||
-			(m.isWorkflow && isWorkflowContext(fnType.In(0))) {
-			realArgs = append(realArgs, ctx)
-		}
-	}
+	realArgs := m.getCtxArg(ctx)
 	for _, arg := range reflectArgs {
 		realArgs = append(realArgs, arg.Interface())
 	}
@@ -835,7 +934,18 @@ func (m *mockWrapper) getMockReturn(ctx interface{}, input []byte) (retArgs mock
 	return m.env.mock.MethodCalled(m.name, realArgs...)
 }
 
-func (m *mockWrapper) executeMock(ctx interface{}, input []byte, mockRet mock.Arguments) ([]byte, error) {
+func (m *mockWrapper) getMockReturnWithActualArgs(ctx interface{}, inputArgs []interface{}) (retArgs mock.Arguments) {
+	if _, ok := m.env.expectedMockCalls[m.name]; !ok {
+		// no mock
+		return nil
+	}
+
+	realArgs := m.getCtxArg(ctx)
+	realArgs = append(realArgs, inputArgs...)
+	return m.env.mock.MethodCalled(m.name, realArgs...)
+}
+
+func (m *mockWrapper) getMockFn(mockRet mock.Arguments) interface{} {
 	fnName := m.name
 	mockRetLen := len(mockRet)
 	if mockRetLen == 0 {
@@ -851,16 +961,15 @@ func (m *mockWrapper) executeMock(ctx interface{}, input []byte, mockRet mock.Ar
 			panic(fmt.Sprintf("mock of %v has incorrect return function, expected %v, but actual is %v",
 				fnName, fnType, mockFnType))
 		}
-		// we found a mock function that matches to actual function, so call that mockFn
-		if m.isWorkflow {
-			executor := &workflowExecutor{name: fnName, fn: mockFn}
-			return executor.Execute(ctx.(Context), input)
-		}
-
-		executor := &activityExecutor{name: fnName, fn: mockFn}
-		return executor.Execute(ctx.(context.Context), input)
+		return mockFn
 	}
+	return nil
+}
 
+func (m *mockWrapper) getMockValue(mockRet mock.Arguments) ([]byte, error) {
+	fnName := m.name
+	mockRetLen := len(mockRet)
+	fnType := reflect.TypeOf(m.fn)
 	// check if mockRet have same types as function's return types
 	if mockRetLen != fnType.NumOut() {
 		panic(fmt.Sprintf("mock of %v has incorrect number of returns, expected %d, but actual is %d",
@@ -908,6 +1017,33 @@ func (m *mockWrapper) executeMock(ctx interface{}, input []byte, mockRet mock.Ar
 		// this will never happen, panic just in case
 		panic("mock should either have 1 return value (error) or 2 return values (result, error)")
 	}
+}
+
+func (m *mockWrapper) executeMock(ctx interface{}, input []byte, mockRet mock.Arguments) ([]byte, error) {
+	fnName := m.name
+	// check if mock returns function which must match to the actual function.
+	if mockFn := m.getMockFn(mockRet); mockFn != nil {
+		// we found a mock function that matches to actual function, so call that mockFn
+		if m.isWorkflow {
+			executor := &workflowExecutor{name: fnName, fn: mockFn}
+			return executor.Execute(ctx.(Context), input)
+		}
+		executor := &activityExecutor{name: fnName, fn: mockFn}
+		return executor.Execute(ctx.(context.Context), input)
+	}
+
+	return m.getMockValue(mockRet)
+}
+
+func (m *mockWrapper) executeMockWithActualArgs(ctx interface{}, inputArgs []interface{}, mockRet mock.Arguments) ([]byte, error) {
+	fnName := m.name
+	// check if mock returns function which must match to the actual function.
+	if mockFn := m.getMockFn(mockRet); mockFn != nil {
+		executor := &activityExecutor{name: fnName, fn: mockFn}
+		return executor.ExecuteWithActualArgs(ctx.(context.Context), inputArgs)
+	}
+
+	return m.getMockValue(mockRet)
 }
 
 func (env *testWorkflowEnvironmentImpl) newTestActivityTaskHandler(taskList string) ActivityTaskHandler {

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -328,6 +328,27 @@ func (t *TestWorkflowEnvironment) SetOnTimerCancelledListener(listener func(time
 	return t
 }
 
+// SetOnLocalActivityStartedListener sets a listener that will be called before local activity starts execution.
+func (t *TestWorkflowEnvironment) SetOnLocalActivityStartedListener(
+	listener func(activityInfo *ActivityInfo, ctx context.Context, args []interface{})) *TestWorkflowEnvironment {
+	t.impl.onLocalActivityStartedListener = listener
+	return t
+}
+
+// SetOnLocalActivityCompletedListener sets a listener that will be called after local activity is completed.
+func (t *TestWorkflowEnvironment) SetOnLocalActivityCompletedListener(
+	listener func(activityInfo *ActivityInfo, result encoded.Value, err error)) *TestWorkflowEnvironment {
+	t.impl.onLocalActivityCompletedListener = listener
+	return t
+}
+
+// SetOnLocalActivityCanceledListener sets a listener that will be called after local activity is canceled.
+func (t *TestWorkflowEnvironment) SetOnLocalActivityCanceledListener(
+	listener func(activityInfo *ActivityInfo)) *TestWorkflowEnvironment {
+	t.impl.onLocalActivityCanceledListener = listener
+	return t
+}
+
 // IsWorkflowCompleted check if test is completed or not
 func (t *TestWorkflowEnvironment) IsWorkflowCompleted() bool {
 	return t.impl.isTestCompleted

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -103,6 +103,12 @@ func (t *TestActivityEnvironment) ExecuteActivity(activityFn interface{}, args .
 	return t.impl.executeActivity(activityFn, args...)
 }
 
+// ExecuteLocalActivity executes a local activity. The tested activity will be executed synchronously in the calling goroutinue.
+// Caller should use encoded.Value.Get() to extract strong typed result value.
+func (t *TestActivityEnvironment) ExecuteLocalActivity(activityFn interface{}, args ...interface{}) (encoded.Value, error) {
+	return t.impl.executeLocalActivity(activityFn, args...)
+}
+
 // SetWorkerOptions sets the WorkerOptions that will be use by TestActivityEnvironment. TestActivityEnvironment will
 // use options of Identity, MetricsScope and BackgroundActivityContext on the WorkerOptions. Other options are ignored.
 // Note: WorkerOptions is defined in internal package, use public type worker.Options instead.
@@ -329,6 +335,7 @@ func (t *TestWorkflowEnvironment) SetOnTimerCancelledListener(listener func(time
 }
 
 // SetOnLocalActivityStartedListener sets a listener that will be called before local activity starts execution.
+// Note: ActivityInfo is defined in internal package, use public type activity.Info instead.
 func (t *TestWorkflowEnvironment) SetOnLocalActivityStartedListener(
 	listener func(activityInfo *ActivityInfo, ctx context.Context, args []interface{})) *TestWorkflowEnvironment {
 	t.impl.onLocalActivityStartedListener = listener
@@ -336,6 +343,7 @@ func (t *TestWorkflowEnvironment) SetOnLocalActivityStartedListener(
 }
 
 // SetOnLocalActivityCompletedListener sets a listener that will be called after local activity is completed.
+// Note: ActivityInfo is defined in internal package, use public type activity.Info instead.
 func (t *TestWorkflowEnvironment) SetOnLocalActivityCompletedListener(
 	listener func(activityInfo *ActivityInfo, result encoded.Value, err error)) *TestWorkflowEnvironment {
 	t.impl.onLocalActivityCompletedListener = listener
@@ -343,6 +351,7 @@ func (t *TestWorkflowEnvironment) SetOnLocalActivityCompletedListener(
 }
 
 // SetOnLocalActivityCanceledListener sets a listener that will be called after local activity is canceled.
+// Note: ActivityInfo is defined in internal package, use public type activity.Info instead.
 func (t *TestWorkflowEnvironment) SetOnLocalActivityCanceledListener(
 	listener func(activityInfo *ActivityInfo)) *TestWorkflowEnvironment {
 	t.impl.onLocalActivityCanceledListener = listener


### PR DESCRIPTION
test support for local activity. Mock local activity works the same way as regular activity by using 
env.OnActivity(...)
So, in the test code, user don't have to mock differently for a regular activity or a local activity. If an activity mock is set, the mock should be used no matter if it is called as regular activity or as a local activity.