### PR TITLE
Activity options fix for #372

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -214,7 +214,7 @@ type LocalActivityOptions struct {
 	ScheduleToCloseTimeout time.Duration
 }
 
-// WithActivityOptions adds all options to the context.
+// WithActivityOptions adds all options to the copy of the context.
 func WithActivityOptions(ctx Context, options ActivityOptions) Context {
 	ctx1 := setActivityParametersIfNotExist(ctx)
 	eap := getActivityOptions(ctx1)
@@ -229,7 +229,7 @@ func WithActivityOptions(ctx Context, options ActivityOptions) Context {
 	return ctx1
 }
 
-// WithLocalActivityOptions adds local activity options to the context.
+// WithLocalActivityOptions adds local activity options to the copy of the context.
 func WithLocalActivityOptions(ctx Context, options LocalActivityOptions) Context {
 	ctx1 := setLocalActivityParametersIfNotExist(ctx)
 	opts := getLocalActivityOptions(ctx1)
@@ -238,42 +238,42 @@ func WithLocalActivityOptions(ctx Context, options LocalActivityOptions) Context
 	return ctx1
 }
 
-// WithTaskList adds a task list to the context.
+// WithTaskList adds a task list to the copy of the context.
 func WithTaskList(ctx Context, name string) Context {
 	ctx1 := setActivityParametersIfNotExist(ctx)
 	getActivityOptions(ctx1).TaskListName = name
 	return ctx1
 }
 
-// WithScheduleToCloseTimeout adds a timeout to the context.
+// WithScheduleToCloseTimeout adds a timeout to the copy of the context.
 func WithScheduleToCloseTimeout(ctx Context, d time.Duration) Context {
 	ctx1 := setActivityParametersIfNotExist(ctx)
 	getActivityOptions(ctx1).ScheduleToCloseTimeoutSeconds = int32(d.Seconds())
 	return ctx1
 }
 
-// WithScheduleToStartTimeout adds a timeout to the context.
+// WithScheduleToStartTimeout adds a timeout to the copy of the context.
 func WithScheduleToStartTimeout(ctx Context, d time.Duration) Context {
 	ctx1 := setActivityParametersIfNotExist(ctx)
 	getActivityOptions(ctx1).ScheduleToStartTimeoutSeconds = int32(d.Seconds())
 	return ctx1
 }
 
-// WithStartToCloseTimeout adds a timeout to the context.
+// WithStartToCloseTimeout adds a timeout to the copy of the context.
 func WithStartToCloseTimeout(ctx Context, d time.Duration) Context {
 	ctx1 := setActivityParametersIfNotExist(ctx)
 	getActivityOptions(ctx1).StartToCloseTimeoutSeconds = int32(d.Seconds())
 	return ctx1
 }
 
-// WithHeartbeatTimeout adds a timeout to the context.
+// WithHeartbeatTimeout adds a timeout to the copy of the context.
 func WithHeartbeatTimeout(ctx Context, d time.Duration) Context {
 	ctx1 := setActivityParametersIfNotExist(ctx)
 	getActivityOptions(ctx1).HeartbeatTimeoutSeconds = int32(d.Seconds())
 	return ctx1
 }
 
-// WithWaitForCancellation adds wait for the cacellation to the context.
+// WithWaitForCancellation adds wait for the cacellation to the copy of the context.
 func WithWaitForCancellation(ctx Context, wait bool) Context {
 	ctx1 := setActivityParametersIfNotExist(ctx)
 	getActivityOptions(ctx1).WaitForCancellation = wait

--- a/internal/internal_activity.go
+++ b/internal/internal_activity.go
@@ -324,15 +324,19 @@ func deSerializeFunctionResult(f interface{}, result []byte, to interface{}) err
 }
 
 func setActivityParametersIfNotExist(ctx Context) Context {
-	if valCtx := getActivityOptions(ctx); valCtx == nil {
-		return WithValue(ctx, activityOptionsContextKey, &executeActivityParameters{})
+	params := getActivityOptions(ctx)
+	var newParams executeActivityParameters
+	if params != nil {
+		newParams = *params
 	}
-	return ctx
+	return WithValue(ctx, activityOptionsContextKey, &newParams)
 }
 
 func setLocalActivityParametersIfNotExist(ctx Context) Context {
-	if valCtx := getLocalActivityOptions(ctx); valCtx == nil {
-		return WithValue(ctx, localActivityOptionsContextKey, &executeLocalActivityParams{})
+	params := getLocalActivityOptions(ctx)
+	var newParams executeLocalActivityParams
+	if params != nil {
+		newParams = *params
 	}
-	return ctx
+	return WithValue(ctx, localActivityOptionsContextKey, &newParams)
 }

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -997,13 +997,15 @@ func getWorkflowEnvOptions(ctx Context) *workflowOptions {
 }
 
 func setWorkflowEnvOptionsIfNotExist(ctx Context) Context {
-	if valCtx := getWorkflowEnvOptions(ctx); valCtx == nil {
-		return WithValue(ctx, workflowEnvOptionsContextKey, &workflowOptions{
-			signalChannels: make(map[string]Channel),
-			queryHandlers:  make(map[string]func([]byte) ([]byte, error)),
-		})
+	options := getWorkflowEnvOptions(ctx)
+	var newOptions workflowOptions
+	if options != nil {
+		newOptions = *options
+	} else {
+		newOptions.signalChannels = make(map[string]Channel)
+		newOptions.queryHandlers = make(map[string]func([]byte) ([]byte, error))
 	}
-	return ctx
+	return WithValue(ctx, workflowEnvOptionsContextKey, &newOptions)
 }
 
 // getSignalChannel finds the assosciated channel for the signal.

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -536,9 +536,9 @@ func activityOptionsWorkflow(ctx Context) (result string, err error) {
 	ctx1 := WithActivityOptions(ctx, ao1)
 	ctx2 := WithActivityOptions(ctx, ao2)
 
-	ctx1_ao := getActivityOptions(ctx1)
-	ctx2_ao := getActivityOptions(ctx2)
-	return *ctx1_ao.ActivityID + " " + *ctx2_ao.ActivityID, nil
+	ctx1Ao := getActivityOptions(ctx1)
+	ctx2Ao := getActivityOptions(ctx2)
+	return *ctx1Ao.ActivityID + " " + *ctx2Ao.ActivityID, nil
 }
 
 // Test that activity options are correctly spawned with WithActivityOptions is called.

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -50,6 +50,7 @@ func (s *WorkflowUnitTest) SetupSuite() {
 	RegisterWorkflow(cancelWorkflowAfterActivityTest)
 	RegisterWorkflow(signalWorkflowTest)
 	RegisterWorkflow(splitJoinActivityWorkflow)
+	RegisterWorkflow(activityOptionsWorkflow)
 
 	s.activityOptions = ActivityOptions{
 		ScheduleToStartTimeout: time.Minute,
@@ -523,4 +524,31 @@ func (s *WorkflowUnitTest) Test_SignalWorkflow() {
 	var result []byte
 	env.GetWorkflowResult(&result)
 	s.EqualValues(strings.Join(expected, ""), string(result))
+}
+
+func activityOptionsWorkflow(ctx Context) (result string, err error) {
+	ao1 := ActivityOptions{
+		ActivityID: "id1",
+	}
+	ao2 := ActivityOptions{
+		ActivityID: "id2",
+	}
+	ctx1 := WithActivityOptions(ctx, ao1)
+	ctx2 := WithActivityOptions(ctx, ao2)
+
+	ctx1_ao := getActivityOptions(ctx1)
+	ctx2_ao := getActivityOptions(ctx2)
+	return *ctx1_ao.ActivityID + " " + *ctx2_ao.ActivityID, nil
+}
+
+// Test that activity options are correctly spawned with WithActivityOptions is called.
+// See https://github.com/uber-go/cadence-client/issues/372
+func (s *WorkflowUnitTest) Test_ActivityOptionsWorkflow() {
+	env := s.NewTestWorkflowEnvironment()
+	env.ExecuteWorkflow(activityOptionsWorkflow)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	var result string
+	env.GetWorkflowResult(&result)
+	s.Equal("id1 id2", result)
 }

--- a/workflow/activity_options.go
+++ b/workflow/activity_options.go
@@ -32,7 +32,7 @@ type ActivityOptions = internal.ActivityOptions
 // LocalActivityOptions doc
 type LocalActivityOptions = internal.LocalActivityOptions
 
-// WithActivityOptions adds all options to the context.
+// WithActivityOptions adds all options to the copy of the context.
 func WithActivityOptions(ctx Context, options ActivityOptions) Context {
 	return internal.WithActivityOptions(ctx, options)
 }
@@ -42,32 +42,32 @@ func WithLocalActivityOptions(ctx Context, options LocalActivityOptions) Context
 	return internal.WithLocalActivityOptions(ctx, options)
 }
 
-// WithTaskList adds a task list to the context.
+// WithTaskList adds a task list to the copy of the context.
 func WithTaskList(ctx Context, name string) Context {
 	return internal.WithTaskList(ctx, name)
 }
 
-// WithScheduleToCloseTimeout adds a timeout to the context.
+// WithScheduleToCloseTimeout adds a timeout to the copy of the context.
 func WithScheduleToCloseTimeout(ctx Context, d time.Duration) Context {
 	return internal.WithScheduleToCloseTimeout(ctx, d)
 }
 
-// WithScheduleToStartTimeout adds a timeout to the context.
+// WithScheduleToStartTimeout adds a timeout to the copy of the context.
 func WithScheduleToStartTimeout(ctx Context, d time.Duration) Context {
 	return internal.WithScheduleToStartTimeout(ctx, d)
 }
 
-// WithStartToCloseTimeout adds a timeout to the context.
+// WithStartToCloseTimeout adds a timeout to the copy of the context.
 func WithStartToCloseTimeout(ctx Context, d time.Duration) Context {
 	return internal.WithStartToCloseTimeout(ctx, d)
 }
 
-// WithHeartbeatTimeout adds a timeout to the context.
+// WithHeartbeatTimeout adds a timeout to the copy of the context.
 func WithHeartbeatTimeout(ctx Context, d time.Duration) Context {
 	return internal.WithHeartbeatTimeout(ctx, d)
 }
 
-// WithWaitForCancellation adds wait for the cacellation to the context.
+// WithWaitForCancellation adds wait for the cacellation to the copy of the context.
 func WithWaitForCancellation(ctx Context, wait bool) Context {
 	return internal.WithWaitForCancellation(ctx, wait)
 }


### PR DESCRIPTION
Fix for #372. 
The problem was that activity and workflow options are not copied but passed by reference when With... methods are called. Which means overriding an option in a child context would update it in every context.