### PR TITLE
adding helper methods to check error type

### DIFF
--- a/error.go
+++ b/error.go
@@ -22,6 +22,7 @@ package cadence
 
 import (
 	"go.uber.org/cadence/internal"
+	"go.uber.org/cadence/workflow"
 )
 
 type (
@@ -42,4 +43,46 @@ func NewCustomError(reason string, details ...interface{}) *CustomError {
 // Return this error from activity or child workflow to indicate that it was successfully cancelled.
 func NewCanceledError(details ...interface{}) *CanceledError {
 	return internal.NewCanceledError(details...)
+}
+
+// IsCustomError return if the err is a CustomError
+func IsCustomError(err error) bool {
+	_, ok := err.(*CustomError)
+	return ok
+}
+
+// IsCanceledError return if the err is a CanceledError
+func IsCanceledError(err error) bool {
+	_, ok := err.(*CanceledError)
+	return ok
+}
+
+// IsGenericError return if the err is a GenericError
+func IsGenericError(err error) bool {
+	_, ok := err.(*workflow.GenericError)
+	return ok
+}
+
+// IsTimeoutError return if the err is a TimeoutError
+func IsTimeoutError(err error) bool {
+	_, ok := err.(*workflow.TimeoutError)
+	return ok
+}
+
+// IsTerminatedError return if the err is a TerminatedError
+func IsTerminatedError(err error) bool {
+	_, ok := err.(*workflow.TerminatedError)
+	return ok
+}
+
+// IsPanicError return if the err is a PanicError
+func IsPanicError(err error) bool {
+	_, ok := err.(*workflow.PanicError)
+	return ok
+}
+
+// IsContinueAsNewError return if the err is a ContinueAsNewError
+func IsContinueAsNewError(err error) bool {
+	_, ok := err.(*workflow.ContinueAsNewError)
+	return ok
 }

--- a/error.go
+++ b/error.go
@@ -80,9 +80,3 @@ func IsPanicError(err error) bool {
 	_, ok := err.(*workflow.PanicError)
 	return ok
 }
-
-// IsContinueAsNewError return if the err is a ContinueAsNewError
-func IsContinueAsNewError(err error) bool {
-	_, ok := err.(*workflow.ContinueAsNewError)
-	return ok
-}


### PR DESCRIPTION
i realize we defined errors in 2 packages: workflow package and cadence package. But I want to have those helper method defined in one place so people can easily find them.