### PR TITLE
properly handle start child workflow failed

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -883,6 +883,7 @@ func (weh *workflowExecutionEventHandlerImpl) handleStartChildWorkflowExecutionF
 	}
 
 	err := fmt.Errorf("ChildWorkflowFailed: %v", attributes.GetCause())
+	childWorkflow.startedCallback(WorkflowExecution{}, err)
 	childWorkflow.handle(nil, err)
 
 	return nil


### PR DESCRIPTION
fix bug 1: when start child workflow failed, we should unblock the start future, otherwise user code may be blocked forever if it is waiting on the start future instead of the result future.

fix bug 2: the unit test framework does not handle WorkflowIDReusePolicy properly.
