### PR TITLE
expose encoded values

### DIFF
--- a/encoded/encoded.go
+++ b/encoded/encoded.go
@@ -21,21 +21,23 @@
 // Package encoded contains wrappers that are used for binary payloads deserialization.
 package encoded
 
+import "go.uber.org/cadence/internal"
+
 type (
 
 	// Value is used to encapsulate/extract encoded value from workflow/activity.
-	Value interface {
-		// HasValue return whether there is value encoded.
-		HasValue() bool
-		// Get extract the encoded value into strong typed value pointer.
-		Get(valuePtr interface{}) error
-	}
+	Value = internal.Value
 
 	// Values is used to encapsulate/extract encoded one or more values from workflow/activity.
-	Values interface {
-		// HasValues return whether there are values encoded.
-		HasValues() bool
-		// Get extract the encoded values into strong typed value pointers.
-		Get(valuePtr ...interface{}) error
-	}
+	Values = internal.Values
 )
+
+// NewEncodedValue return encoded data as Value so it can be used to extract strong typed value from the encoded blob.
+func NewEncodedValue(data []byte) Value {
+	return internal.EncodedValue(data)
+}
+
+// NewEncodedValues return encoded data as Values so it can be used to extract strong typed values from the encoded blob.
+func NewEncodedValues(data []byte) Values {
+	return internal.EncodedValues(data)
+}

--- a/internal/client.go
+++ b/internal/client.go
@@ -25,8 +25,6 @@ import (
 	"fmt"
 	"time"
 
-	"go.uber.org/cadence/encoded"
-
 	"github.com/uber-go/tally"
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	s "go.uber.org/cadence/.gen/go/shared"
@@ -202,7 +200,7 @@ type (
 		//  - InternalServiceError
 		//  - EntityNotExistError
 		//  - QueryFailError
-		QueryWorkflow(ctx context.Context, workflowID string, runID string, queryType string, args ...interface{}) (encoded.Value, error)
+		QueryWorkflow(ctx context.Context, workflowID string, runID string, queryType string, args ...interface{}) (Value, error)
 
 		// DescribeWorkflowExecution returns information about the specified workflow execution.
 		// The errors it can return:

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -31,7 +31,6 @@ import (
 
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	s "go.uber.org/cadence/.gen/go/shared"
-	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/internal/common"
 	"go.uber.org/cadence/internal/common/backoff"
 	"go.uber.org/cadence/internal/common/metrics"
@@ -485,7 +484,7 @@ func (wc *workflowClient) DescribeWorkflowExecution(ctx context.Context, workflo
 //  - InternalServiceError
 //  - EntityNotExistError
 //  - QueryFailError
-func (wc *workflowClient) QueryWorkflow(ctx context.Context, workflowID string, runID string, queryType string, args ...interface{}) (encoded.Value, error) {
+func (wc *workflowClient) QueryWorkflow(ctx context.Context, workflowID string, runID string, queryType string, args ...interface{}) (Value, error) {
 	var input []byte
 	if len(args) > 0 {
 		var err error

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -36,7 +36,6 @@ import (
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	"go.uber.org/cadence/.gen/go/cadence/workflowservicetest"
 	"go.uber.org/cadence/.gen/go/shared"
-	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/internal/common"
 	"go.uber.org/yarpc"
 	"go.uber.org/zap"
@@ -129,15 +128,15 @@ type (
 
 		expectedMockCalls map[string]struct{}
 
-		onActivityStartedListener        func(activityInfo *ActivityInfo, ctx context.Context, args encoded.Values)
-		onActivityCompletedListener      func(activityInfo *ActivityInfo, result encoded.Value, err error)
+		onActivityStartedListener        func(activityInfo *ActivityInfo, ctx context.Context, args Values)
+		onActivityCompletedListener      func(activityInfo *ActivityInfo, result Value, err error)
 		onActivityCanceledListener       func(activityInfo *ActivityInfo)
 		onLocalActivityStartedListener   func(activityInfo *ActivityInfo, ctx context.Context, args []interface{})
-		onLocalActivityCompletedListener func(activityInfo *ActivityInfo, result encoded.Value, err error)
+		onLocalActivityCompletedListener func(activityInfo *ActivityInfo, result Value, err error)
 		onLocalActivityCanceledListener  func(activityInfo *ActivityInfo)
-		onActivityHeartbeatListener      func(activityInfo *ActivityInfo, details encoded.Values)
-		onChildWorkflowStartedListener   func(workflowInfo *WorkflowInfo, ctx Context, args encoded.Values)
-		onChildWorkflowCompletedListener func(workflowInfo *WorkflowInfo, result encoded.Value, err error)
+		onActivityHeartbeatListener      func(activityInfo *ActivityInfo, details Values)
+		onChildWorkflowStartedListener   func(workflowInfo *WorkflowInfo, ctx Context, args Values)
+		onChildWorkflowCompletedListener func(workflowInfo *WorkflowInfo, result Value, err error)
 		onChildWorkflowCanceledListener  func(workflowInfo *WorkflowInfo)
 		onTimerScheduledListener         func(timerID string, duration time.Duration)
 		onTimerFiredListener             func(timerID string)
@@ -371,7 +370,7 @@ func (env *testWorkflowEnvironmentImpl) getWorkflowDefinition(wt WorkflowType) (
 func (env *testWorkflowEnvironmentImpl) executeActivity(
 	activityFn interface{},
 	args ...interface{},
-) (encoded.Value, error) {
+) (Value, error) {
 	activityType, input, err := getValidatedActivityFunction(activityFn, args)
 	if err != nil {
 		panic(err)
@@ -417,7 +416,7 @@ func (env *testWorkflowEnvironmentImpl) executeActivity(
 func (env *testWorkflowEnvironmentImpl) executeLocalActivity(
 	activityFn interface{},
 	args ...interface{},
-) (encoded.Value, error) {
+) (Value, error) {
 	params := executeLocalActivityParams{
 		ActivityFn:                    activityFn,
 		InputArgs:                     args,
@@ -1336,7 +1335,7 @@ func (env *testWorkflowEnvironmentImpl) signalWorkflow(name string, input interf
 	}, true)
 }
 
-func (env *testWorkflowEnvironmentImpl) queryWorkflow(queryType string, args ...interface{}) (encoded.Value, error) {
+func (env *testWorkflowEnvironmentImpl) queryWorkflow(queryType string, args ...interface{}) (Value, error) {
 	data, err := getHostEnvironment().encodeArg(args)
 	if err != nil {
 		return nil, err

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/cadence/.gen/go/shared"
-	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/internal/common"
 	"go.uber.org/zap"
 )
@@ -114,7 +113,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_OnActivityStartedListener() {
 	env := s.NewTestWorkflowEnvironment()
 
 	var activityCalls []string
-	env.SetOnActivityStartedListener(func(activityInfo *ActivityInfo, ctx context.Context, args encoded.Values) {
+	env.SetOnActivityStartedListener(func(activityInfo *ActivityInfo, ctx context.Context, args Values) {
 		var input string
 		s.NoError(args.Get(&input))
 		activityCalls = append(activityCalls, fmt.Sprintf("%s:%s", activityInfo.ActivityType.Name, input))
@@ -272,12 +271,12 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowActivityCancellation() {
 	env := s.NewTestWorkflowEnvironment()
 	activityMap := make(map[string]string) // msg -> activityID
 	var completedActivityID, cancelledActivityID string
-	env.SetOnActivityStartedListener(func(activityInfo *ActivityInfo, ctx context.Context, args encoded.Values) {
+	env.SetOnActivityStartedListener(func(activityInfo *ActivityInfo, ctx context.Context, args Values) {
 		var msg string
 		s.NoError(args.Get(&msg))
 		activityMap[msg] = activityInfo.ActivityID
 	})
-	env.SetOnActivityCompletedListener(func(activityInfo *ActivityInfo, result encoded.Value, err error) {
+	env.SetOnActivityCompletedListener(func(activityInfo *ActivityInfo, result Value, err error) {
 		completedActivityID = activityInfo.ActivityID
 	})
 	env.SetOnActivityCanceledListener(func(activityInfo *ActivityInfo) {
@@ -588,10 +587,10 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflow_Listener() {
 	RegisterWorkflow(workflowFn)
 	env := s.NewTestWorkflowEnvironment()
 	var childWorkflowName, childWorkflowResult string
-	env.SetOnChildWorkflowStartedListener(func(workflowInfo *WorkflowInfo, ctx Context, args encoded.Values) {
+	env.SetOnChildWorkflowStartedListener(func(workflowInfo *WorkflowInfo, ctx Context, args Values) {
 		childWorkflowName = workflowInfo.WorkflowType.Name
 	})
-	env.SetOnChildWorkflowCompletedListener(func(workflowInfo *WorkflowInfo, result encoded.Value, err error) {
+	env.SetOnChildWorkflowCompletedListener(func(workflowInfo *WorkflowInfo, result Value, err error) {
 		s.NoError(err)
 		s.NoError(result.Get(&childWorkflowResult))
 	})
@@ -1017,7 +1016,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityFriendlyName() {
 	RegisterWorkflow(workflowFn)
 	env := s.NewTestWorkflowEnvironment()
 	var called []string
-	env.SetOnActivityStartedListener(func(activityInfo *ActivityInfo, ctx context.Context, args encoded.Values) {
+	env.SetOnActivityStartedListener(func(activityInfo *ActivityInfo, ctx context.Context, args Values) {
 		called = append(called, activityInfo.ActivityType.Name)
 	})
 
@@ -1047,7 +1046,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowFriendlyName() {
 	RegisterWorkflow(workflowFn)
 	env := s.NewTestWorkflowEnvironment()
 	var called []string
-	env.SetOnChildWorkflowStartedListener(func(workflowInfo *WorkflowInfo, ctx Context, args encoded.Values) {
+	env.SetOnChildWorkflowStartedListener(func(workflowInfo *WorkflowInfo, ctx Context, args Values) {
 		called = append(called, workflowInfo.WorkflowType.Name)
 	})
 
@@ -1131,7 +1130,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_QueryWorkflow() {
 		env.SignalWorkflow("query-signal", "hello-query")
 	}, time.Hour)
 	env.OnActivity(testActivityHello, mock.Anything, mock.Anything).After(time.Hour).Return("hello_mock", nil)
-	env.SetOnActivityStartedListener(func(activityInfo *ActivityInfo, ctx context.Context, args encoded.Values) {
+	env.SetOnActivityStartedListener(func(activityInfo *ActivityInfo, ctx context.Context, args Values) {
 		verifyStateWithQuery(stateWaitActivity)
 	})
 	env.ExecuteWorkflow(workflowFn)
@@ -1220,7 +1219,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowLocalActivityWithMockAndListene
 		startedCount++
 	})
 
-	env.SetOnLocalActivityCompletedListener(func(activityInfo *ActivityInfo, result encoded.Value, err error) {
+	env.SetOnLocalActivityCompletedListener(func(activityInfo *ActivityInfo, result Value, err error) {
 		s.NoError(err)
 		var resultValue string
 		err = result.Get(&resultValue)

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/uber-go/tally"
-	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/internal/common"
 	"go.uber.org/zap"
 )
@@ -39,6 +38,22 @@ var (
 )
 
 type (
+
+	// Value is used to encapsulate/extract encoded value from workflow/activity.
+	Value interface {
+		// HasValue return whether there is value encoded.
+		HasValue() bool
+		// Get extract the encoded value into strong typed value pointer.
+		Get(valuePtr interface{}) error
+	}
+
+	// Values is used to encapsulate/extract encoded one or more values from workflow/activity.
+	Values interface {
+		// HasValues return whether there are values encoded.
+		HasValues() bool
+		// Get extract the encoded values into strong typed value pointers.
+		Get(valuePtr ...interface{}) error
+	}
 
 	// Channel must be used instead of native go channel by workflow code.
 	// Use workflow.NewChannel(ctx) method to create Channel instance.
@@ -727,7 +742,7 @@ func (b EncodedValue) HasValue() bool {
 //  } else {
 //         ....
 //  }
-func SideEffect(ctx Context, f func(ctx Context) interface{}) encoded.Value {
+func SideEffect(ctx Context, f func(ctx Context) interface{}) Value {
 	future, settable := NewFuture(ctx)
 	wrapperFunc := func() ([]byte, error) {
 		r := f(ctx)

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -25,8 +25,6 @@ import (
 	"reflect"
 	"time"
 
-	"go.uber.org/cadence/encoded"
-
 	"github.com/stretchr/testify/mock"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
@@ -107,13 +105,13 @@ func (s *WorkflowTestSuite) SetMetricsScope(scope tally.Scope) {
 
 // ExecuteActivity executes an activity. The tested activity will be executed synchronously in the calling goroutinue.
 // Caller should use encoded.Value.Get() to extract strong typed result value.
-func (t *TestActivityEnvironment) ExecuteActivity(activityFn interface{}, args ...interface{}) (encoded.Value, error) {
+func (t *TestActivityEnvironment) ExecuteActivity(activityFn interface{}, args ...interface{}) (Value, error) {
 	return t.impl.executeActivity(activityFn, args...)
 }
 
 // ExecuteLocalActivity executes a local activity. The tested activity will be executed synchronously in the calling goroutinue.
 // Caller should use encoded.Value.Get() to extract strong typed result value.
-func (t *TestActivityEnvironment) ExecuteLocalActivity(activityFn interface{}, args ...interface{}) (encoded.Value, error) {
+func (t *TestActivityEnvironment) ExecuteLocalActivity(activityFn interface{}, args ...interface{}) (Value, error) {
 	return t.impl.executeLocalActivity(activityFn, args...)
 }
 
@@ -296,7 +294,7 @@ func (t *TestWorkflowEnvironment) SetTestTimeout(idleTimeout time.Duration) *Tes
 // SetOnActivityStartedListener sets a listener that will be called before activity starts execution.
 // Note: ActivityInfo is defined in internal package, use public type activity.Info instead.
 func (t *TestWorkflowEnvironment) SetOnActivityStartedListener(
-	listener func(activityInfo *ActivityInfo, ctx context.Context, args encoded.Values)) *TestWorkflowEnvironment {
+	listener func(activityInfo *ActivityInfo, ctx context.Context, args Values)) *TestWorkflowEnvironment {
 	t.impl.onActivityStartedListener = listener
 	return t
 }
@@ -304,7 +302,7 @@ func (t *TestWorkflowEnvironment) SetOnActivityStartedListener(
 // SetOnActivityCompletedListener sets a listener that will be called after an activity is completed.
 // Note: ActivityInfo is defined in internal package, use public type activity.Info instead.
 func (t *TestWorkflowEnvironment) SetOnActivityCompletedListener(
-	listener func(activityInfo *ActivityInfo, result encoded.Value, err error)) *TestWorkflowEnvironment {
+	listener func(activityInfo *ActivityInfo, result Value, err error)) *TestWorkflowEnvironment {
 	t.impl.onActivityCompletedListener = listener
 	return t
 }
@@ -320,7 +318,7 @@ func (t *TestWorkflowEnvironment) SetOnActivityCanceledListener(
 // SetOnActivityHeartbeatListener sets a listener that will be called when activity heartbeat.
 // Note: ActivityInfo is defined in internal package, use public type activity.Info instead.
 func (t *TestWorkflowEnvironment) SetOnActivityHeartbeatListener(
-	listener func(activityInfo *ActivityInfo, details encoded.Values)) *TestWorkflowEnvironment {
+	listener func(activityInfo *ActivityInfo, details Values)) *TestWorkflowEnvironment {
 	t.impl.onActivityHeartbeatListener = listener
 	return t
 }
@@ -328,7 +326,7 @@ func (t *TestWorkflowEnvironment) SetOnActivityHeartbeatListener(
 // SetOnChildWorkflowStartedListener sets a listener that will be called before a child workflow starts execution.
 // Note: WorkflowInfo is defined in internal package, use public type workflow.Info instead.
 func (t *TestWorkflowEnvironment) SetOnChildWorkflowStartedListener(
-	listener func(workflowInfo *WorkflowInfo, ctx Context, args encoded.Values)) *TestWorkflowEnvironment {
+	listener func(workflowInfo *WorkflowInfo, ctx Context, args Values)) *TestWorkflowEnvironment {
 	t.impl.onChildWorkflowStartedListener = listener
 	return t
 }
@@ -336,7 +334,7 @@ func (t *TestWorkflowEnvironment) SetOnChildWorkflowStartedListener(
 // SetOnChildWorkflowCompletedListener sets a listener that will be called after a child workflow is completed.
 // Note: WorkflowInfo is defined in internal package, use public type workflow.Info instead.
 func (t *TestWorkflowEnvironment) SetOnChildWorkflowCompletedListener(
-	listener func(workflowInfo *WorkflowInfo, result encoded.Value, err error)) *TestWorkflowEnvironment {
+	listener func(workflowInfo *WorkflowInfo, result Value, err error)) *TestWorkflowEnvironment {
 	t.impl.onChildWorkflowCompletedListener = listener
 	return t
 }
@@ -379,7 +377,7 @@ func (t *TestWorkflowEnvironment) SetOnLocalActivityStartedListener(
 // SetOnLocalActivityCompletedListener sets a listener that will be called after local activity is completed.
 // Note: ActivityInfo is defined in internal package, use public type activity.Info instead.
 func (t *TestWorkflowEnvironment) SetOnLocalActivityCompletedListener(
-	listener func(activityInfo *ActivityInfo, result encoded.Value, err error)) *TestWorkflowEnvironment {
+	listener func(activityInfo *ActivityInfo, result Value, err error)) *TestWorkflowEnvironment {
 	t.impl.onLocalActivityCompletedListener = listener
 	return t
 }
@@ -429,7 +427,7 @@ func (t *TestWorkflowEnvironment) SignalWorkflow(name string, input interface{})
 }
 
 // QueryWorkflow queries to the currently running test workflow and returns result synchronously.
-func (t *TestWorkflowEnvironment) QueryWorkflow(queryType string, args ...interface{}) (encoded.Value, error) {
+func (t *TestWorkflowEnvironment) QueryWorkflow(queryType string, args ...interface{}) (Value, error) {
 	return t.impl.queryWorkflow(queryType, args...)
 }
 


### PR DESCRIPTION
User could use cadenceClient service API to get the closing event of a given workflow, however, that would only give you the blob data of the closing event. We need a way to convert that blob to strong typed values for user to consume.

Move the interface definition to internal to avoid circular dependency.
