### PR TITLE
 local activity worker needs separate options for throttling/maxConcurrent control

### DIFF
--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -281,7 +281,7 @@ func createWorkerWithThrottle(
 	activityTask := &s.PollForActivityTaskResponse{}
 	expectedActivitiesPerSecond := activitiesPerSecond
 	if expectedActivitiesPerSecond == 0.0 {
-		expectedActivitiesPerSecond = _defaultTaskListActivitiesPerSecond
+		expectedActivitiesPerSecond = defaultTaskListActivitiesPerSecond
 	}
 	service.EXPECT().PollForActivityTask(
 		gomock.Any(), ofPollForActivityTaskRequest(expectedActivitiesPerSecond), callOptions...,

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -46,7 +46,7 @@ type (
 	// The current timeout resolution implementation is in seconds and uses math.Ceil(d.Seconds()) as the duration. But is
 	// subjected to change in the future.
 	WorkerOptions struct {
-		// Optional: To set the maximum concurrent activity executions this host can have.
+		// Optional: To set the maximum concurrent activity executions this worker can have.
 		// The zero value of this uses the default value.
 		// default: defaultMaxConcurrentActivityExecutionSize(1k)
 		MaxConcurrentActivityExecutionSize int
@@ -58,6 +58,19 @@ type (
 		// once for every 10 seconds. This can be used to protect down stream services from flooding.
 		// The zero value of this uses the default value. Default: 100k
 		WorkerActivitiesPerSecond float64
+
+		// Optional: To set the maximum concurrent local activity executions this worker can have.
+		// The zero value of this uses the default value.
+		// default: 1k
+		MaxConcurrentLocalActivityExecutionSize int
+
+		// Optional: Sets the rate limiting on number of local activities that can be executed per second per
+		// worker. This can be used to limit resources used by the worker.
+		// Notice that the number is represented in float, so that you can set it to less than
+		// 1 if needed. For example, set the number to 0.1 means you want your local activity to be executed
+		// once for every 10 seconds. This can be used to protect down stream services from flooding.
+		// The zero value of this uses the default value. Default: 100k
+		WorkerLocalActivitiesPerSecond float64
 
 		// Optional: Sets the rate limiting on number of activities that can be executed per second.
 		// This is managed by the server and controls activities per second for your entire tasklist


### PR DESCRIPTION
Local activity worker needs separate options for throttling/maxConcurrent control.
Also, local activity does not need the poller rate limit. (For local activity worker, the poller is just poll from a local channel.)