### PR TITLE
fix local activity worker

### DIFF
--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -106,6 +106,10 @@ type (
 		pollerRequestCh chan struct{}
 		taskQueueCh     chan interface{}
 	}
+
+	polledTask struct {
+		task interface{}
+	}
 )
 
 func createPollRetryPolicy() backoff.RetryPolicy {
@@ -211,8 +215,9 @@ func (bw *baseWorker) runTaskDispatcher() {
 		case <-bw.shutdownCh:
 			return
 		case task := <-bw.taskQueueCh:
-			// block until taskRateLimiter satisfied
-			if bw.taskLimiter.Wait(bw.limiterContext) != nil {
+			// for non-polled-task (local activity result as task), we don't need to rate limit
+			_, isPolledTask := task.(*polledTask)
+			if isPolledTask && bw.taskLimiter.Wait(bw.limiterContext) != nil {
 				if bw.isShutdown() {
 					return
 				}
@@ -239,13 +244,19 @@ func (bw *baseWorker) pollTask() {
 	}
 
 	if task != nil {
-		bw.taskQueueCh <- task
+		bw.taskQueueCh <- &polledTask{task}
 	} else {
 		bw.pollerRequestCh <- struct{}{} // poll failed, trigger a new pool
 	}
 }
 
 func (bw *baseWorker) processTask(task interface{}) {
+	// If the task is from poller, after processing it we would need to request a new poll. Otherwise, the task is from
+	// local activity worker, we don't need a new poll from server.
+	polledTask, isPolledTask := task.(*polledTask)
+	if isPolledTask {
+		task = polledTask.task
+	}
 	defer func() {
 		if p := recover(); p != nil {
 			bw.metricsScope.Counter(metrics.WorkerPanicCounter).Inc(1)
@@ -255,7 +266,10 @@ func (bw *baseWorker) processTask(task interface{}) {
 				zap.String("PanicError", fmt.Sprintf("%v", p)),
 				zap.String("PanicStack", st))
 		}
-		bw.pollerRequestCh <- struct{}{}
+
+		if isPolledTask {
+			bw.pollerRequestCh <- struct{}{}
+		}
 	}()
 	err := bw.options.taskWorker.ProcessTask(task)
 	if err != nil {


### PR DESCRIPTION
Poller only poll from server for task when worker is ready to process it. We use a channel (pollerRequestCh) to notify poller to poll. After each task is processed by worker, it put back a request to pollerRequestCh so poller could poll for new task. This works well until we have local activity. Local activity worker would send local activity result as task directly to the workflow worker. So after that local activity result (as task) is processed, it should not request a new poll from server.
This change is to differentiate the task from poller and task from local activity worker. 

The bug would cause a go routinue blocked at sending request to pollerRequestCh for each local activity result.