### PR TITLE
clear marker state machine

### DIFF
--- a/internal/internal_decision_state_machine_test.go
+++ b/internal/internal_decision_state_machine_test.go
@@ -455,19 +455,9 @@ func Test_MarkerStateMachine(t *testing.T) {
 
 	// send decisions
 	decisions := h.getDecisions(true)
-	require.Equal(t, decisionStateDecisionSent, d.getState())
+	require.Equal(t, decisionStateCompleted, d.getState())
 	require.Equal(t, 1, len(decisions))
 	require.Equal(t, s.DecisionTypeRecordMarker, decisions[0].GetDecisionType())
-
-	// marker recorded
-	h.handleSideEffectMarkerRecorded(1)
-	require.Equal(t, decisionStateCompleted, d.getState())
-
-	// one more marker recorded event will make it invalid state transition
-	err := runAndCatchPanic(func() {
-		h.handleSideEffectMarkerRecorded(1)
-	})
-	require.NotNil(t, err)
 }
 
 func Test_CancelExternalWorkflowStateMachine_Succeed(t *testing.T) {


### PR DESCRIPTION
Fix one more bug discovered during local activity stress test.
I run test workflow that receive 1000 signals, each signal generate 100 local activities. As the workflow making progress, the perf degraded that it takes longer and longer to process each signal. (initially, it took about 10ms to process 100 local activities.)

We use marker state machine to generate decision, we are not drive marker state machine to completed state by history events. Once marker decision is sent, the markerStateMachine is considered as completed.

For SideEffect/Version markers, when the history event is applied, there is no marker decision state machine yet because we preload those marker events.
For local activity, when we apply the history event, we use it to create the marker state machine, there is no other event to drive it to completed state. 

So for marker state machine, the sent state should be treated as the completed state and it should be removed once it is in sent state.
