### PR TITLE
Clean up / optimize makefile, sandbox builds better.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bins
 test
 test.log
 /dummy
+.build

--- a/Makefile
+++ b/Makefile
@@ -1,94 +1,77 @@
 .PHONY: test bins clean cover cover_ci
-PROJECT_ROOT = go.uber.org/cadence
-
-export PATH := $(GOPATH)/bin:$(PATH)
-
-THRIFT_GENDIR=.gen
 
 # default target
 default: test
 
-# define the list of thrift files the service depends on
-# (if you have some)
-THRIFTRW_SRCS = \
-  idl/github.com/uber/cadence/cadence.thrift \
-  idl/github.com/uber/cadence/shared.thrift \
+IMPORT_ROOT := go.uber.org/cadence
+THRIFT_GENDIR := .gen/go
+THRIFTRW_SRC := idl/github.com/uber/cadence/cadence.thrift
+# one or more thriftrw-generated file(s), to create / depend on generated code
+THRIFTRW_OUT := $(THRIFT_GENDIR)/cadence/idl.go
+TEST_ARG ?= -coverprofile=$(BUILD)/cover.out -race -v
 
-PROGS = cadence-client
-TEST_ARG ?= -race -v -timeout 5m
-BUILD := ./build
+# general build-product folder, cleaned as part of `make clean`
+BUILD := .build
 
-THRIFT_GEN=$(GOPATH)/bin/thrift-gen
+$(THRIFTRW_OUT): $(THRIFTRW_SRC) $(BUILD)/thriftrw $(BUILD)/thriftrw-plugin-yarpc
+	@echo 'thriftrw: $(THRIFTRW_SRC)'
+	@mkdir -p $(dir $@)
+	@# needs to be able to find the thriftrw-plugin-yarpc bin in PATH
+	@PATH="$(BUILD)" \
+		$(BUILD)/thriftrw \
+		--plugin=yarpc \
+		--pkg-prefix=$(IMPORT_ROOT)/$(THRIFT_GENDIR) \
+		--out=$(THRIFT_GENDIR) \
+		$(THRIFTRW_SRC)
 
-define thriftrwrule
-THRIFTRW_GEN_SRC += $(THRIFT_GENDIR)/go/$1/$1.go
-
-$(THRIFT_GENDIR)/go/$1/$1.go:: $2
-	@mkdir -p $(THRIFT_GENDIR)/go
-	$(ECHO_V)thriftrw --plugin=yarpc --pkg-prefix=$(PROJECT_ROOT)/$(THRIFT_GENDIR)/go/ --out=$(THRIFT_GENDIR)/go $2
-endef
-
-$(foreach tsrc,$(THRIFTRW_SRCS),$(eval $(call \
-	thriftrwrule,$(basename $(notdir \
-	$(shell echo $(tsrc) | tr A-Z a-z))),$(tsrc))))
-
-# Automatically gather all srcs
-ALL_SRC := $(shell find . -name "*.go" | grep -v -e Godeps -e vendor \
-	-e ".*/\..*" \
-	-e ".*/_.*")
+# Automatically gather all srcs + a "sentinel" thriftrw output file (which forces generation).
+ALL_SRC := $(THRIFTRW_OUT) $(shell \
+	find . -name "*.go" | \
+	grep -v \
+	-e vendor/ \
+	-e .gen/ \
+	-e .build/ \
+)
 
 # Files that needs to run lint, exclude testify mock from lint
 LINT_SRC := $(filter-out ./mock%,$(ALL_SRC))
 
-# all directories with *_test.go files in them
-TEST_DIRS := $(sort $(dir $(filter %_test.go,$(ALL_SRC))))
+vendor: vendor/glide.updated
 
-vendor:
+vendor/glide.updated: glide.lock
 	glide install
+	touch vendor/glide.updated
 
-yarpc-install: vendor
-	go get './vendor/go.uber.org/thriftrw'
-	go get './vendor/go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc'
+$(BUILD)/thriftrw:
+	./versioned_go_build.sh go.uber.org/thriftrw v1.11.0 $@
+
+$(BUILD)/thriftrw-plugin-yarpc:
+	./versioned_go_build.sh go.uber.org/yarpc v1.29.0 encoding/thrift/thriftrw-plugin-yarpc $@
+
+$(BUILD)/golint:
+	./versioned_go_build.sh golang.org/x/lint 470b6b0bb3005eda157f0275e2e4895055396a81 golint $@
 
 clean_thrift:
 	rm -rf .gen
 
-thriftc: clean_thrift yarpc-install $(THRIFTRW_GEN_SRC)
-
-copyright: ./internal/cmd/tools/copyright/licensegen.go
+# `make copyright` or depend on "copyright" to force-run licensegen,
+# or depend on $(BUILD)/copyright to let it run as needed.
+copyright $(BUILD)/copyright: $(ALL_SRC)
 	go run ./internal/cmd/tools/copyright/licensegen.go --verifyOnly
+	touch $(BUILD)/copyright
 
-vendor/glide.updated: glide.lock glide.yaml
-	glide install
-	touch vendor/glide.updated
+$(BUILD)/dummy: vendor/glide.updated $(ALL_SRC)
+	go build -i -o $@ internal/cmd/dummy/dummy.go
 
-dummy: vendor/glide.updated $(ALL_SRC)
-	go build -i -o dummy internal/cmd/dummy/dummy.go
+test $(BUILD)/cover.out: $(BUILD)/copyright $(BUILD)/dummy $(ALL_SRC)
+	go test ./... $(TEST_ARG)
 
-test: bins
-	@rm -f test
-	@rm -f test.log
-	@for dir in $(TEST_DIRS); do \
-		go test -race -coverprofile=$@ "$$dir" | tee -a test.log; \
-	done;
+bins: $(ALL_SRC) $(BUILD)/copyright lint $(BUILD)/dummy
 
-bins: thriftc copyright lint dummy
-
-cover_profile: clean copyright lint vendor/glide.updated
-	@mkdir -p $(BUILD)
-	@echo "mode: atomic" > $(BUILD)/cover.out
-
-	@echo Testing packages:
-	@for dir in $(TEST_DIRS); do \
-		mkdir -p $(BUILD)/"$$dir"; \
-		go test "$$dir" $(TEST_ARG) -coverprofile=$(BUILD)/"$$dir"/coverage.out || exit 1; \
-		cat $(BUILD)/"$$dir"/coverage.out | grep -v "mode: atomic" >> $(BUILD)/cover.out; \
-	done;
-
-cover: cover_profile
+cover: $(BUILD)/cover.out
 	go tool cover -html=$(BUILD)/cover.out;
 
-cover_ci: cover_profile
+cover_ci: $(BUILD)/cover.out
 	goveralls -coverprofile=$(BUILD)/cover.out -service=travis-ci || echo -e "\x1b[31mCoveralls failed\x1b[m";
 
 # golint fails to report many lint failures if it is only given a single file
@@ -102,10 +85,10 @@ cover_ci: cover_profile
 # - filter to only files in LINT_SRC
 # - if it's not empty, run golint against the list
 define lint_if_present
-test -n "$1" && golint -set_exit_status $1
+test -n "$1" && $(BUILD)/golint -set_exit_status $1
 endef
 
-lint:
+lint: $(BUILD)/golint $(ALL_SRC)
 	@$(foreach pkg,\
 		$(sort $(dir $(LINT_SRC))), \
 		$(call lint_if_present,$(filter $(wildcard $(pkg)*.go),$(LINT_SRC))) || ERR=1; \
@@ -121,6 +104,5 @@ fmt:
 	@gofmt -w $(ALL_SRC)
 
 clean:
-	rm -rf cadence-client
 	rm -Rf $(BUILD)
-	rm -f dummy
+	rm -Rf .gen

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ $(BUILD)/thriftrw:
 	./versioned_go_build.sh go.uber.org/thriftrw v1.11.0 $@
 
 $(BUILD)/thriftrw-plugin-yarpc:
-	./versioned_go_build.sh go.uber.org/yarpc v1.29.0 encoding/thrift/thriftrw-plugin-yarpc $@
+	./versioned_go_build.sh go.uber.org/yarpc v1.29.1 encoding/thrift/thriftrw-plugin-yarpc $@
 
 $(BUILD)/golint:
 	./versioned_go_build.sh golang.org/x/lint 470b6b0bb3005eda157f0275e2e4895055396a81 golint $@

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ THRIFT_GENDIR := .gen/go
 THRIFTRW_SRC := idl/github.com/uber/cadence/cadence.thrift
 # one or more thriftrw-generated file(s), to create / depend on generated code
 THRIFTRW_OUT := $(THRIFT_GENDIR)/cadence/idl.go
-TEST_ARG ?= -coverprofile=$(BUILD)/cover.out -race -v
+TEST_ARG ?= -coverprofile=$(BUILD)/cover.out -race
 
 # general build-product folder, cleaned as part of `make clean`
 BUILD := .build

--- a/internal/cmd/tools/copyright/licensegen.go
+++ b/internal/cmd/tools/copyright/licensegen.go
@@ -53,7 +53,7 @@ const licenseHeaderPrefix = "// Copyright (c)"
 
 var (
 	// directories to be excluded
-	dirBlacklist = []string{"vendor/"}
+	dirBlacklist = []string{"vendor/", ".build/"}
 	// default perms for the newly created files
 	defaultFilePerms = os.FileMode(0644)
 )

--- a/versioned_go_build.sh
+++ b/versioned_go_build.sh
@@ -63,8 +63,8 @@ git checkout --quiet "$VERSION"
 
 if [ -z "$(echo "$VERSION" | grep -E '^v{0,1}\d+(\.\d+){0,3}$')" ]; then
     # not versioned, check for newer commits
-    BEHIND=$(git rev-list ..HEAD | wc -l)
-    [ "$BEHIND" -eq 0 ] || (>&2 echo "$GO_GETTABLE_REPO is $BEHIND commits behind the current HEAD")
+    BEHIND=$(git rev-list "..$HEAD" | wc -l | tr -dc '0-9')
+    [ "$BEHIND" -eq 0 ] || (>&2 echo "$GO_GETTABLE_REPO is $BEHIND commits behind the current HEAD: $HEAD")
 else
     # versioned, check for newer tags.
     # using xargs because it's safer (for big lists) + it doesn't result in

--- a/versioned_go_build.sh
+++ b/versioned_go_build.sh
@@ -49,7 +49,7 @@ elif [ $# -eq 3 ]; then
     INSTALL_LOCATION="$3"
 else
     # should be unreachable
-    help
+    usage
 fi
 
 

--- a/versioned_go_build.sh
+++ b/versioned_go_build.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -e
+
+usage () {
+    echo 'Installs a specific version of a go-gettable bin to the specified location.'
+    echo ''
+    echo 'Usage:'
+    echo ''
+    echo -e "\t$0 [--debug] go-gettable-repo version [path-to-bin-in-repo] install-location"
+    echo ''
+    echo 'Examples:'
+    echo ''
+    echo -e "\t$0 go.uber.org/thriftrw 1.10.0 somewhere/thriftrw"
+    echo -e '\t\Installs v1.10.0 of go.uber.org/thriftrw to somewhere/thriftrw.'
+    echo -e '\t\tNotice that go.uber.org/thriftrw is both the repository AND the binary name.'
+    echo ''
+    echo -e "\t$0 golang.org/x/lint SOME_SHA golint somewhere/golint"
+    echo -e '\t\Installs a specific SHA of e.g. "golang.org/x/lint/golint" to "somewhere/golint",'
+    echo -e '\t\tNotice that the golint bin is in a subfolder of the golang.org/x/lint repository.'
+
+    exit 1
+}
+
+# needs 3 or 4 args, plus optional --debug
+
+if [ "$1" == "--debug" ]; then
+    shift  # consume it
+    DEBUG=1
+fi
+
+[ $# -ge 3 ] || usage
+[ $# -le 4 ] || usage
+
+[ -z $DEBUG ] || set -x
+
+# set up gopath, and make sure it's cleaned up regardless of how we exit
+export GOPATH=$(mktemp -d)
+trap "rm -rf $GOPATH" EXIT
+
+# variable inits
+GO_GETTABLE_REPO="$1"
+VERSION="$2"
+if [ $# -eq 4 ]; then
+    GO_GETTABLE_BIN="$1/$3"
+    INSTALL_LOCATION="$4"
+elif [ $# -eq 3 ]; then
+    GO_GETTABLE_BIN="$1"
+    INSTALL_LOCATION="$3"
+else
+    # should be unreachable
+    help
+fi
+
+
+go get -d "$GO_GETTABLE_BIN"
+pushd "$GOPATH/src/$GO_GETTABLE_REPO"
+git checkout "$VERSION"
+
+# only glide install when there is a glide file, or it tries to install
+# to the current repo (not in our current folder)
+if [ -f glide.lock ]; then
+    glide install
+fi
+
+popd
+go build -o "$INSTALL_LOCATION" "$GO_GETTABLE_BIN"


### PR DESCRIPTION
- removed a bunch of cruft from overly-generic makefile copypasta
  (many of it doesn't do anything here, and makes it harder to read).
- much of this does more work than is necessary (e.g. `go get` and
  thrift-gen happens on every `make test`).
- don't use the global thriftrw + plugin, or install globally, just
  build and use a local version from the vendored code.

It still does more than is necessary, but I haven't found a quick way
to make "always re-gen copyright" both reliable and efficient, so it's
currently unavoidable.
If you remove `thriftc` and `copyright` from test though, you can see
how e.g. `make cover` just prints the previous run if no source changed,
which would be ideal (and `make test` still forces a rerun, intentionally).