### PR TITLE
Dump all registered activities when activity not found

### DIFF
--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -22,11 +22,11 @@ package internal
 
 import (
 	"errors"
-	"testing"
-
+	"fmt"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/zap"
+	"testing"
 )
 
 const (
@@ -70,6 +70,18 @@ func Test_ActivityPanic(t *testing.T) {
 	panicErr, ok := err.(*PanicError)
 	require.True(t, ok)
 	require.Equal(t, "panic-blabla", panicErr.Error())
+}
+
+func Test_ActivityNotRegistered(t *testing.T) {
+	registeredActivityFn, unregisteredActivitFn := "RegisteredActivity", "UnregisteredActivityFn"
+	RegisterActivityWithOptions(func() error { return nil }, RegisterActivityOptions{Name: registeredActivityFn})
+	s := &WorkflowTestSuite{}
+	s.SetLogger(zap.NewNop())
+	env := s.NewTestActivityEnvironment()
+	_, err := env.ExecuteActivity(unregisteredActivitFn)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("unable to find activityType=%v", unregisteredActivitFn))
+	require.Contains(t, err.Error(), registeredActivityFn)
 }
 
 func Test_WorkflowError(t *testing.T) {

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1240,7 +1240,8 @@ func (ath *activityTaskHandlerImpl) Execute(taskList string, t *s.PollForActivit
 	activityImplementation := ath.getActivity(activityType.GetName())
 	if activityImplementation == nil {
 		// Couldn't find the activity implementation.
-		return nil, fmt.Errorf("unable to find activityType=%v", activityType.GetName())
+		supported := strings.Join(ath.getRegisteredActivityNames(), ", ")
+		return nil, fmt.Errorf("unable to find activityType=%v. Supported types: [%v]", activityType.GetName(), supported)
 	}
 
 	// panic handler
@@ -1280,6 +1281,13 @@ func (ath *activityTaskHandlerImpl) getActivity(name string) activity {
 	}
 
 	return nil
+}
+
+func (ath *activityTaskHandlerImpl) getRegisteredActivityNames() (activityNames []string) {
+	for _, a := range ath.hostEnv.activityFuncMap {
+		activityNames = append(activityNames, a.ActivityType().Name)
+	}
+	return
 }
 
 func createNewDecision(decisionType s.DecisionType) *s.Decision {

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -407,8 +407,11 @@ func (env *testWorkflowEnvironmentImpl) executeActivity(
 	taskHandler := env.newTestActivityTaskHandler(defaultTestTaskList)
 	result, err := taskHandler.Execute(defaultTestTaskList, task)
 	if err != nil {
-		panic(err)
+		topLine := fmt.Sprintf("activity for %s [panic]:", defaultTestTaskList)
+		st := getStackTraceRaw(topLine, 7, 0)
+		return nil, newPanicError(err.Error(), st)
 	}
+
 	if result == ErrActivityResultPending {
 		return nil, ErrActivityResultPending
 	}


### PR DESCRIPTION
This commit modifies task handler in the client SDK to dump all activities registered when a workflow executes an activity whose name is not found, for example, due to a typo when specifying the activity by name.

Fixes #418 