### PR TITLE
Add Data Converter to support custom serialization/deserialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bins
 test
 test.log
 /dummy
+.DS_Store

--- a/encoded/encoded.go
+++ b/encoded/encoded.go
@@ -38,4 +38,13 @@ type (
 		// Get extract the encoded values into strong typed value pointers.
 		Get(valuePtr ...interface{}) error
 	}
+
+	// DataConverter is used by the framework to serialize/deserialize method parameters that need to be sent over the wire.
+	DataConverter interface {
+		// ToData implements conversion of a list of values.
+		ToData(value ...interface{}) ([]byte, error)
+		// FromData implements conversion of an array of values of different types.
+		// Useful for deserializing arguments of function invocations.
+		FromData(input []byte, valuePtr ...interface{}) error
+	}
 )

--- a/internal/client.go
+++ b/internal/client.go
@@ -273,6 +273,10 @@ type (
 		// WorkflowIDReusePolicy - Whether server allow reuse of workflow ID, can be useful
 		// for dedup logic if set to WorkflowIdReusePolicyRejectDuplicate
 		WorkflowIDReusePolicy WorkflowIDReusePolicy
+
+		// DataConverter - Used by Cadence to serialize/deserialize workflow arguments
+		// Optional: default use Cadence defaultDataConverter
+		DataConverter encoded.DataConverter
 	}
 
 	// DomainClient is the client for managing operations on the domain.

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -39,6 +39,7 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	"go.uber.org/cadence/.gen/go/shared"
+	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/internal/common"
 	"go.uber.org/cadence/internal/common/backoff"
 	"go.uber.org/zap"
@@ -142,6 +143,9 @@ type (
 
 		StickyScheduleToStartTimeout time.Duration
 	}
+
+	// defaultDataConverter uses thrift encoder/decoder when possible, for everything use json.
+	defaultDataConverter struct{}
 )
 
 // newWorkflowWorker returns an instance of the workflow worker.
@@ -406,8 +410,7 @@ type hostEnvImpl struct {
 	workflowAliasMap map[string]string
 	activityFuncMap  map[string]activity
 	activityAliasMap map[string]string
-	encoding         encoding
-	tEncoding        encoding
+	dataConverter    encoded.DataConverter
 }
 
 func (th *hostEnvImpl) RegisterWorkflow(af interface{}) error {
@@ -432,10 +435,6 @@ func (th *hostEnvImpl) RegisterWorkflowWithOptions(
 	// Check if already registered
 	if _, ok := th.getWorkflowFn(registerName); ok {
 		return fmt.Errorf("workflow name \"%v\" is already registered", registerName)
-	}
-	// Register args with encoding.
-	if err := th.registerEncodingTypes(fnType); err != nil {
-		return err
 	}
 	th.addWorkflowFn(registerName, af)
 	if len(alias) > 0 {
@@ -467,10 +466,6 @@ func (th *hostEnvImpl) RegisterActivityWithOptions(
 	if _, ok := th.getActivityFn(registerName); ok {
 		return fmt.Errorf("activity type \"%v\" is already registered", registerName)
 	}
-	// Register args with encoding.
-	if err := th.registerEncodingTypes(fnType); err != nil {
-		return err
-	}
 	th.addActivityFn(registerName, af)
 	if len(alias) > 0 {
 		th.addActivityAlias(fnName, alias)
@@ -478,19 +473,16 @@ func (th *hostEnvImpl) RegisterActivityWithOptions(
 	return nil
 }
 
-// Get the encoder.
-func (th *hostEnvImpl) Encoder() encoding {
-	return th.encoding
+func (th *hostEnvImpl) GetDataConverter() encoded.DataConverter {
+	return th.dataConverter
 }
 
-// Get thrift encoder.
-func (th *hostEnvImpl) ThriftEncoder() encoding {
-	return th.tEncoding
-}
-
-// Register all function args and return types with encoder.
-func (th *hostEnvImpl) RegisterFnType(fnType reflect.Type) error {
-	return th.registerEncodingTypes(fnType)
+func (th *hostEnvImpl) SetDataConverter(dc encoded.DataConverter) {
+	if dc == nil {
+		th.dataConverter = &defaultDataConverter{}
+	} else {
+		th.dataConverter = dc
+	}
 }
 
 func (th *hostEnvImpl) addWorkflowAlias(fnName string, alias string) {
@@ -574,56 +566,9 @@ func (th *hostEnvImpl) getRegisteredActivities() []activity {
 	return activities
 }
 
-// register all the types with encoder.
-func (th *hostEnvImpl) registerEncodingTypes(fnType reflect.Type) error {
-	th.Lock()
-	defer th.Unlock()
-
-	// Register arguments.
-	for i := 0; i < fnType.NumIn(); i++ {
-		err := th.registerType(fnType.In(i), th.Encoder())
-		if err != nil {
-			return err
-		}
-	}
-	// Register return types.
-	// TODO: We need register all concrete implementations of error, Either
-	// through pre-registry (or) at the time conversion.
-	for i := 0; i < fnType.NumOut(); i++ {
-		err := th.registerType(fnType.Out(i), th.Encoder())
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (th *hostEnvImpl) registerValue(v interface{}, encoder encoding) error {
-	if val := reflect.ValueOf(v); val.IsValid() {
-		if val.Kind() == reflect.Ptr && val.IsNil() {
-			return nil
-		}
-		rType := reflect.Indirect(val).Type()
-		return th.registerType(rType, encoder)
-	}
-	return nil
-}
-
-// register type with our encoder.
-func (th *hostEnvImpl) registerType(t reflect.Type, encoder encoding) error {
-	// Interfaces cannot be registered, their implementations should be
-	// https://golang.org/pkg/encoding/gob/#Register
-	if t.Kind() == reflect.Interface || t.Kind() == reflect.Ptr {
-		return nil
-	}
-	arg := reflect.Zero(t).Interface()
-	return encoder.Register(arg)
-}
-
-func (th *hostEnvImpl) isUseThriftEncoding(objs []interface{}) bool {
+func isUseThriftEncoding(objs []interface{}) bool {
 	// NOTE: our criteria to use which encoder is simple if all the types are serializable using thrift then we use
-	// thrift encoder. For everything else we default to gob.
+	// thrift encoder. For everything else we default to json.
 
 	if len(objs) == 0 {
 		return false
@@ -637,9 +582,9 @@ func (th *hostEnvImpl) isUseThriftEncoding(objs []interface{}) bool {
 	return true
 }
 
-func (th *hostEnvImpl) isUseThriftDecoding(objs []interface{}) bool {
+func isUseThriftDecoding(objs []interface{}) bool {
 	// NOTE: our criteria to use which encoder is simple if all the types are de-serializable using thrift then we use
-	// thrift decoder. For everything else we default to gob.
+	// thrift decoder. For everything else we default to json.
 
 	if len(objs) == 0 {
 		return false
@@ -709,53 +654,12 @@ func validateFnFormat(fnType reflect.Type, isWorkflow bool) error {
 
 // encode set of values.
 func (th *hostEnvImpl) encode(r []interface{}) ([]byte, error) {
-	if len(r) == 1 && isTypeByteSlice(reflect.TypeOf(r[0])) {
-		return r[0].([]byte), nil
-	}
-
-	var encoder encoding
-	if th.isUseThriftEncoding(r) {
-		encoder = th.ThriftEncoder()
-	} else {
-		encoder = th.Encoder()
-	}
-
-	for _, v := range r {
-		err := th.registerValue(v, encoder)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	data, err := encoder.Marshal(r)
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
+	return th.dataConverter.ToData(r...)
 }
 
 // decode a set of values.
 func (th *hostEnvImpl) decode(data []byte, to []interface{}) error {
-	if len(to) == 1 && isTypeByteSlice(reflect.TypeOf(to[0])) {
-		reflect.ValueOf(to[0]).Elem().SetBytes(data)
-		return nil
-	}
-
-	var encoder encoding
-	if th.isUseThriftDecoding(to) {
-		encoder = th.ThriftEncoder()
-	} else {
-		encoder = th.Encoder()
-	}
-
-	for _, v := range to {
-		err := th.registerValue(v, encoder)
-		if err != nil {
-			return err
-		}
-	}
-
-	return encoder.Unmarshal(data, to)
+	return th.dataConverter.FromData(data, to...)
 }
 
 // encode multiple arguments(arguments to a function).
@@ -828,8 +732,7 @@ func newHostEnvironment() *hostEnvImpl {
 		workflowAliasMap: make(map[string]string),
 		activityFuncMap:  make(map[string]activity),
 		activityAliasMap: make(map[string]string),
-		encoding:         jsonEncoding{},
-		tEncoding:        thriftEncoding{},
+		dataConverter:    &defaultDataConverter{},
 	}
 }
 
@@ -1029,6 +932,8 @@ func newAggregatedWorker(
 	processTestTags(&wOptions, &workerParams)
 
 	hostEnv := getHostEnvironment()
+	hostEnv.SetDataConverter(wOptions.DataConverter)
+
 	// workflow factory.
 	var workflowWorker Worker
 	if !wOptions.DisableWorkflowWorker {
@@ -1134,18 +1039,12 @@ func isInterfaceNil(i interface{}) bool {
 
 // encoding is capable of encoding and decoding objects
 type encoding interface {
-	Register(obj interface{}) error
 	Marshal([]interface{}) ([]byte, error)
 	Unmarshal([]byte, []interface{}) error
 }
 
 // jsonEncoding encapsulates json encoding and decoding
 type jsonEncoding struct {
-}
-
-// Register implements the encoding interface
-func (g jsonEncoding) Register(obj interface{}) error {
-	return nil
 }
 
 // Marshal encodes an array of object into bytes
@@ -1187,11 +1086,6 @@ func isThriftType(v interface{}) bool {
 // thriftEncoding encapsulates thrift serializer/de-serializer.
 type thriftEncoding struct{}
 
-// Register implements the encoding interface
-func (g thriftEncoding) Register(obj interface{}) error {
-	return nil
-}
-
 // Marshal encodes an array of thrift into bytes
 func (g thriftEncoding) Marshal(objs []interface{}) ([]byte, error) {
 	tlist := []thrift.TStruct{}
@@ -1228,6 +1122,41 @@ func (g thriftEncoding) Unmarshal(data []byte, objs []interface{}) error {
 	return nil
 }
 
+func (dc *defaultDataConverter) ToData(r ...interface{}) ([]byte, error) {
+	if len(r) == 1 && isTypeByteSlice(reflect.TypeOf(r[0])) {
+		return r[0].([]byte), nil
+	}
+
+	var encoder encoding
+	if isUseThriftEncoding(r) {
+		encoder = &thriftEncoding{}
+	} else {
+		encoder = &jsonEncoding{}
+	}
+
+	data, err := encoder.Marshal(r)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (dc *defaultDataConverter) FromData(data []byte, to ...interface{}) error {
+	if len(to) == 1 && isTypeByteSlice(reflect.TypeOf(to[0])) {
+		reflect.ValueOf(to[0]).Elem().SetBytes(data)
+		return nil
+	}
+
+	var encoder encoding
+	if isUseThriftDecoding(to) {
+		encoder = &thriftEncoding{}
+	} else {
+		encoder = &jsonEncoding{}
+	}
+
+	return encoder.Unmarshal(data, to)
+}
+
 func fillWorkerOptionsDefaults(options WorkerOptions) WorkerOptions {
 	if options.MaxConcurrentActivityExecutionSize == 0 {
 		options.MaxConcurrentActivityExecutionSize = defaultMaxConcurrentActivityExecutionSize
@@ -1246,6 +1175,9 @@ func fillWorkerOptionsDefaults(options WorkerOptions) WorkerOptions {
 	}
 	if options.StickyScheduleToStartTimeout.Seconds() == 0 {
 		options.StickyScheduleToStartTimeout = stickyDecisionScheduleToStartTimeoutSeconds * time.Second
+	}
+	if options.DataConverter == nil {
+		options.DataConverter = &defaultDataConverter{}
 	}
 	return options
 }

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -477,9 +477,13 @@ func (th *hostEnvImpl) GetDataConverter() encoded.DataConverter {
 	return th.dataConverter
 }
 
+func newDefaultDataConverter() encoded.DataConverter {
+	return &defaultDataConverter{}
+}
+
 func (th *hostEnvImpl) SetDataConverter(dc encoded.DataConverter) {
 	if dc == nil {
-		th.dataConverter = &defaultDataConverter{}
+		th.dataConverter = newDefaultDataConverter()
 	} else {
 		th.dataConverter = dc
 	}
@@ -732,7 +736,7 @@ func newHostEnvironment() *hostEnvImpl {
 		workflowAliasMap: make(map[string]string),
 		activityFuncMap:  make(map[string]activity),
 		activityAliasMap: make(map[string]string),
-		dataConverter:    &defaultDataConverter{},
+		dataConverter:    newDefaultDataConverter(),
 	}
 }
 
@@ -1177,7 +1181,7 @@ func fillWorkerOptionsDefaults(options WorkerOptions) WorkerOptions {
 		options.StickyScheduleToStartTimeout = stickyDecisionScheduleToStartTimeoutSeconds * time.Second
 	}
 	if options.DataConverter == nil {
-		options.DataConverter = &defaultDataConverter{}
+		options.DataConverter = newDefaultDataConverter()
 	}
 	return options
 }

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -164,6 +164,7 @@ type (
 		signalChannels                      map[string]SignalChannel
 		queryHandlers                       map[string]func([]byte) ([]byte, error)
 		workflowIDReusePolicy               WorkflowIDReusePolicy
+		dataConverter                       encoded.DataConverter
 	}
 
 	// decodeFutureImpl
@@ -1045,6 +1046,9 @@ func getValidatedWorkflowOptions(ctx Context) (*workflowOptions, error) {
 	}
 	if p.executionStartToCloseTimeoutSeconds == nil || *p.executionStartToCloseTimeoutSeconds <= 0 {
 		return nil, errors.New("missing or invalid ExecutionStartToCloseTimeout")
+	}
+	if p.dataConverter == nil {
+		p.dataConverter = newDefaultDataConverter()
 	}
 
 	return p, nil

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -153,6 +153,14 @@ func (wc *workflowClient) StartWorkflow(
 		decisionTaskTimeout = defaultDecisionTaskTimeoutInSecs
 	}
 
+	if options.DataConverter != nil { // use custom DataConverter only for this workflow
+		previousDataConverter := getHostEnvironment().GetDataConverter()
+		if previousDataConverter != options.DataConverter {
+			getHostEnvironment().SetDataConverter(options.DataConverter)
+			defer getHostEnvironment().SetDataConverter(previousDataConverter)
+		}
+	}
+
 	// Validate type and its arguments.
 	workflowType, input, err := getValidatedWorkflowFunction(workflowFunc, args)
 	if err != nil {
@@ -267,6 +275,14 @@ func (wc *workflowClient) SignalWorkflow(ctx context.Context, workflowID string,
 // If the workflow is not running or not found, it starts the workflow and then sends the signal in transaction.
 func (wc *workflowClient) SignalWithStartWorkflow(ctx context.Context, workflowID string, signalName string, signalArg interface{},
 	options StartWorkflowOptions, workflowFunc interface{}, workflowArgs ...interface{}) (*WorkflowExecution, error) {
+
+	if options.DataConverter != nil { // use custom DataConverter only for this workflow
+		previousDataConverter := getHostEnvironment().GetDataConverter()
+		if previousDataConverter != options.DataConverter {
+			getHostEnvironment().SetDataConverter(options.DataConverter)
+			defer getHostEnvironment().SetDataConverter(previousDataConverter)
+		}
+	}
 
 	signalInput, err := getEncodedArg(signalArg)
 	if err != nil {

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -329,6 +329,45 @@ func TestActivityCancellation(t *testing.T) {
 	require.NoError(t, env.GetWorkflowError())
 }
 
+type testWorkflowWithDataConverter struct {
+	t *testing.T
+}
+
+func (w *testWorkflowWithDataConverter) Execute(ctx Context, input []byte) (result []byte, err error) {
+	ao := ActivityOptions{
+		ScheduleToStartTimeout: 10 * time.Second,
+		StartToCloseTimeout:    5 * time.Second,
+	}
+	ctx = WithActivityOptions(ctx, ao)
+
+	dc := newTestDataConverter()
+	ctx = WithWorkflowDataConverter(ctx, dc)
+	require.Equal(w.t, newTestDataConverter(), getWorkflowEnvOptions(ctx).dataConverter)
+
+	f := ExecuteActivity(ctx, testAct)
+	// test data converter was restored to previous one
+	require.Equal(w.t, newTestDataConverter(), getWorkflowEnvOptions(ctx).dataConverter)
+	require.Equal(w.t, newDefaultDataConverter(), getHostEnvironment().dataConverter)
+
+	var res1 string
+	err1 := f.Get(ctx, &res1)
+	require.NoError(w.t, err1, err1)
+	require.Equal(w.t, res1, "test")
+
+	return []byte("workflow-completed"), nil
+}
+
+func TestWorkflowWithDataConverter(t *testing.T) {
+	ts := &WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+	w := &testWorkflowWithDataConverter{t: t}
+	RegisterActivity(testAct)
+	RegisterWorkflow(w.Execute)
+	env.ExecuteWorkflow(w.Execute, []byte{1, 2})
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+}
+
 type sayGreetingActivityRequest struct {
 	Name     string
 	Greeting string

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -27,6 +27,7 @@ import (
 	"github.com/uber-go/tally"
 
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
+	"go.uber.org/cadence/encoded"
 	"go.uber.org/zap"
 )
 
@@ -131,6 +132,10 @@ type (
 		// Optional: sets context for activity. The context can be used to pass any configuration to activity
 		// like common logger for all activities.
 		BackgroundActivityContext context.Context
+
+		// Optional: sets DataConverter to customize serialization/deserialization of arguments in Cadence
+		// default: defaultDataConverter, an combination of thriftEncoder and jsonEncoder
+		DataConverter encoded.DataConverter
 	}
 )
 

--- a/workflow/workflow_options.go
+++ b/workflow/workflow_options.go
@@ -23,6 +23,7 @@ package workflow
 import (
 	"time"
 
+	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/internal"
 )
 
@@ -59,4 +60,9 @@ func WithExecutionStartToCloseTimeout(ctx Context, d time.Duration) Context {
 // WithWorkflowTaskStartToCloseTimeout adds a decision timeout to the context.
 func WithWorkflowTaskStartToCloseTimeout(ctx Context, d time.Duration) Context {
 	return internal.WithWorkflowTaskStartToCloseTimeout(ctx, d)
+}
+
+// WithWorkflowDataConverter adds DataConverter to the context.
+func WithWorkflowDataConverter(ctx Context, dc encoded.DataConverter) Context {
+	return internal.WithWorkflowDataConverter(ctx, dc)
 }


### PR DESCRIPTION
Users now can implement `encoded.DataConverter` and let Cadence use it to serialize/deserialize parameters that need to be sent over the wire.  
DataConverter is support in 3 places:  
1. Worker.  
When create worker, one can provide data converter (shorted as dc) in `WorkerOptions`. Then everything processed by that worker will use provided data converter.
2. Client.  
When use client to start workflow, one can dc in `StartWorkflowOptions`. Then parameters will use provided dc. 
3. Workflow.  
Inside workflow implementation, one can use `WithWorkflowDataConverter` to get context and pass to other API calls like ExecuteActivity. One can use different dc for different API calls in one workflow. For example:  
```
func MyWorkflow(ctx Context, input []byte) (result []byte, err error) {
	...
	ctx = WithActivityOptions(ctx, ao)

	dc1 := MyDataConverter1()
	ctx = WithWorkflowDataConverter(ctx, dc1)
	f := ExecuteActivity(ctx, testActivity)

        // Use another data converter for another antivity
	dc2 := MyDataConverter2()
	ctx = WithWorkflowDataConverter(ctx, dc2)
	f = ExecuteActivity(ctx, testActivity2)
	...
}
```
