### PR TITLE
sticky cache metrics

### DIFF
--- a/internal/common/metrics/constants.go
+++ b/internal/common/metrics/constants.go
@@ -90,4 +90,5 @@ const (
 	StickyCacheHit   = CadenceMetricsPrefix + "sticky-cache-hit"
 	StickyCacheMiss  = CadenceMetricsPrefix + "sticky-cache-miss"
 	StickyCacheStall = CadenceMetricsPrefix + "sticky-cache-stall"
+	StickyCacheSize  = CadenceMetricsPrefix + "sticky-cache-size"
 )


### PR DESCRIPTION
the key we used to evict sticky cache is not correctly set, which means we never evict from our sticky cache.
We did destroy the cached workflow state when workflow completed which release the most heavy weighted resources.
Also added metics to report the cache size.