### PR TITLE
fix flaky test

### DIFF
--- a/internal/common/backoff/retrypolicy_test.go
+++ b/internal/common/backoff/retrypolicy_test.go
@@ -149,8 +149,7 @@ func TestDefaultPublishRetryPolicy(t *testing.T) {
 		10000 * time.Millisecond,
 		10000 * time.Millisecond,
 		10000 * time.Millisecond,
-		6000 * time.Millisecond,
-		1300 * time.Millisecond,
+		7250 * time.Millisecond,
 		done,
 	}
 


### PR DESCRIPTION
not sure how this test could run for this long, the expected duration was not calculated right.
i have been frequently seeing this test failure in last few days.
https://github.com/uber-go/cadence-client/issues/454