### PR TITLE
clear current decision task on sticky workflow state when complete it

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -720,6 +720,7 @@ func (w *workflowExecutionContext) CompleteDecisionTask() interface{} {
 
 	completeRequest := w.wth.completeWorkflow(w.eventHandler, w.currentDecisionTask, w, w.newDecisions)
 	w.newDecisions = nil
+	w.currentDecisionTask = nil
 
 	return completeRequest
 }


### PR DESCRIPTION
clear the current decision task reference in the sticky workflow when complete the task.
this will help reduce the retained memory size.