### PR TITLE
Add Data Converter to support custom serialization/deserialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bins
 test
 test.log
 /dummy
+.DS_Store

--- a/encoded/encoded.go
+++ b/encoded/encoded.go
@@ -38,4 +38,13 @@ type (
 		// Get extract the encoded values into strong typed value pointers.
 		Get(valuePtr ...interface{}) error
 	}
+
+	// DataConverter is used by the framework to serialize/deserialize method parameters that need to be sent over the wire.
+	DataConverter interface {
+		// ToData implements conversion of a list of values.
+		ToData(value ...interface{}) ([]byte, error)
+		// FromData implements conversion of an array of values of different types.
+		// Useful for deserializing arguments of function invocations.
+		FromData(input []byte, valuePtr ...interface{}) error
+	}
 )

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/uber-go/tally"
 	"go.uber.org/cadence/.gen/go/shared"
+	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/internal/common"
 	"go.uber.org/zap"
 )
@@ -139,7 +140,7 @@ func RecordActivityHeartbeat(ctx context.Context, details ...interface{}) {
 	var err error
 	// We would like to be a able to pass in "nil" as part of details(that is no progress to report to)
 	if len(details) != 1 || details[0] != nil {
-		data, err = getHostEnvironment().encodeArgs(details)
+		data, err = encodeArgs(getDataConverterFromActivityCtx(ctx), details)
 		if err != nil {
 			panic(err)
 		}
@@ -168,6 +169,7 @@ func WithActivityTask(
 	invoker ServiceInvoker,
 	logger *zap.Logger,
 	scope tally.Scope,
+	dataConverter encoded.DataConverter,
 ) context.Context {
 	var deadline time.Time
 	scheduled := time.Unix(0, task.GetScheduledTimestamp())
@@ -198,6 +200,7 @@ func WithActivityTask(
 		scheduledTimestamp: scheduled,
 		startedTimestamp:   started,
 		taskList:           taskList,
+		dataConverter:      dataConverter,
 	})
 }
 

--- a/internal/activity_test.go
+++ b/internal/activity_test.go
@@ -162,7 +162,7 @@ func (s *activityTestSuite) TestActivityHeartbeat_SuppressContinousInvokes() {
 	service3.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), callOptions...).
 		Return(&shared.RecordActivityTaskHeartbeatResponse{}, nil).
 		Do(func(ctx context.Context, request *shared.RecordActivityTaskHeartbeatRequest, opts ...yarpc.CallOption) {
-			ev := EncodedValues(request.Details)
+			ev := newEncodedValues(request.Details, nil)
 			var progress string
 			err := ev.Get(&progress)
 			if err != nil {

--- a/internal/error.go
+++ b/internal/error.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"go.uber.org/cadence/.gen/go/shared"
+	"go.uber.org/cadence/encoded"
 )
 
 /*
@@ -87,7 +88,7 @@ type (
 	// CustomError returned from workflow and activity implementations with reason and optional details.
 	CustomError struct {
 		reason  string
-		details EncodedValues
+		details encoded.Values
 	}
 
 	// GenericError returned from workflow/workflow when the implementations return errors other than from NewCustomError() API.
@@ -98,12 +99,12 @@ type (
 	// TimeoutError returned when activity or child workflow timed out.
 	TimeoutError struct {
 		timeoutType shared.TimeoutType
-		details     EncodedValues
+		details     encoded.Values
 	}
 
 	// CanceledError returned when operation was canceled.
 	CanceledError struct {
-		details EncodedValues
+		details encoded.Values
 	}
 
 	// TerminatedError returned when workflow was terminated.
@@ -146,12 +147,14 @@ func NewCustomError(reason string, details ...interface{}) *CustomError {
 	if strings.HasPrefix(reason, "cadenceInternal:") {
 		panic("'cadenceInternal:' is reserved prefix, please use different reason")
 	}
-
-	data, err := getHostEnvironment().encodeArgs(details)
-	if err != nil {
-		panic(err)
+	// When return error to user, use EncodedValues as details and data is ready to be decoded by calling Get
+	if len(details) == 1 {
+		if d, ok := details[0].(*EncodedValues); ok {
+			return &CustomError{reason: reason, details: d}
+		}
 	}
-	return &CustomError{reason: reason, details: data}
+	// When create error for server, use ErrorDetailsValues as details to hold values and encode later
+	return &CustomError{reason: reason, details: ErrorDetailsValues(details)}
 }
 
 // NewTimeoutError creates TimeoutError instance.
@@ -162,20 +165,22 @@ func NewTimeoutError(timeoutType shared.TimeoutType) *TimeoutError {
 
 // NewHeartbeatTimeoutError creates TimeoutError instance
 func NewHeartbeatTimeoutError(details ...interface{}) *TimeoutError {
-	data, err := getHostEnvironment().encodeArgs(details)
-	if err != nil {
-		panic(err)
+	if len(details) == 1 {
+		if d, ok := details[0].(*EncodedValues); ok {
+			return &TimeoutError{timeoutType: shared.TimeoutTypeHeartbeat, details: d}
+		}
 	}
-	return &TimeoutError{timeoutType: shared.TimeoutTypeHeartbeat, details: data}
+	return &TimeoutError{timeoutType: shared.TimeoutTypeHeartbeat, details: ErrorDetailsValues(details)}
 }
 
 // NewCanceledError creates CanceledError instance
 func NewCanceledError(details ...interface{}) *CanceledError {
-	data, err := getHostEnvironment().encodeArgs(details)
-	if err != nil {
-		panic(err)
+	if len(details) == 1 {
+		if d, ok := details[0].(*EncodedValues); ok {
+			return &CanceledError{details: d}
+		}
 	}
-	return &CanceledError{details: data}
+	return &CanceledError{details: ErrorDetailsValues(details)}
 }
 
 // NewContinueAsNewError creates ContinueAsNewError instance
@@ -192,13 +197,13 @@ func NewCanceledError(details ...interface{}) *CanceledError {
 //
 func NewContinueAsNewError(ctx Context, wfn interface{}, args ...interface{}) *ContinueAsNewError {
 	// Validate type and its arguments.
-	workflowType, input, err := getValidatedWorkflowFunction(wfn, args)
-	if err != nil {
-		panic(err)
-	}
 	options := getWorkflowEnvOptions(ctx)
 	if options == nil {
 		panic("context is missing required options for continue as new")
+	}
+	workflowType, input, err := getValidatedWorkflowFunction(wfn, args, options.dataConverter)
+	if err != nil {
+		panic(err)
 	}
 	if options.taskListName == nil || *options.taskListName == "" {
 		panic("invalid task list provided")
@@ -227,11 +232,14 @@ func (e *CustomError) Reason() string {
 
 // HasDetails return if this error has strong typed detail data.
 func (e *CustomError) HasDetails() bool {
-	return e.details.HasValues()
+	return e.details != nil && e.details.HasValues()
 }
 
 // Details extracts strong typed detail data of this custom error. If there is no details, it will return ErrNoData.
 func (e *CustomError) Details(d ...interface{}) error {
+	if !e.HasDetails() {
+		return ErrNoData
+	}
 	return e.details.Get(d...)
 }
 
@@ -252,11 +260,14 @@ func (e *TimeoutError) TimeoutType() shared.TimeoutType {
 
 // HasDetails return if this error has strong typed detail data.
 func (e *TimeoutError) HasDetails() bool {
-	return e.details.HasValues()
+	return e.details != nil && e.details.HasValues()
 }
 
 // Details extracts strong typed detail data of this error. If there is no details, it will return ErrNoData.
 func (e *TimeoutError) Details(d ...interface{}) error {
+	if !e.HasDetails() {
+		return ErrNoData
+	}
 	return e.details.Get(d...)
 }
 
@@ -267,11 +278,14 @@ func (e *CanceledError) Error() string {
 
 // HasDetails return if this error has strong typed detail data.
 func (e *CanceledError) HasDetails() bool {
-	return e.details.HasValues()
+	return e.details != nil && e.details.HasValues()
 }
 
 // Details extracts strong typed detail data of this error.
 func (e *CanceledError) Details(d ...interface{}) error {
+	if !e.HasDetails() {
+		return ErrNoData
+	}
 	return e.details.Get(d...)
 }
 

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/cadence/.gen/go/shared"
+	"go.uber.org/cadence/internal/common"
 	"go.uber.org/zap"
 	"testing"
 )
@@ -34,42 +35,39 @@ const (
 	customErrReasonA = "CustomReasonA"
 )
 
-var errs = [][]error{
-	// pairs of errors: actualErrorActivityReturns and expectedErrorDeciderSees
-	{errors.New("error:foo"), &GenericError{"error:foo"}},
-	{NewCustomError(customErrReasonA, "my details"), NewCustomError(customErrReasonA, "my details")},
-	// assume "reason:X" is some new reason activity could return, but workflow code was not aware of.
-	{NewCustomError("reason:X"), NewCustomError("reason:X")},
-	{NewCanceledError("some-details"), NewCanceledError("some-details")},
+type testStruct struct {
+	Name string
+	Age  int
 }
 
-func Test_ActivityError(t *testing.T) {
-	errorActivityFn := func(i int) error {
-		return errs[i][0]
+var (
+	testErrorDetails1 = "my details"
+	testErrorDetails2 = 123
+	testErrorDetails3 = testStruct{"a string", 321}
+)
+
+func Test_GenericError(t *testing.T) {
+	// test activity error
+	errorActivityFn := func() error {
+		return errors.New("error:foo")
 	}
 	RegisterActivity(errorActivityFn)
 	s := &WorkflowTestSuite{}
-	for i := 0; i < len(errs); i++ {
-		env := s.NewTestActivityEnvironment()
-		_, err := env.ExecuteActivity(errorActivityFn, i)
-		require.Error(t, err)
-		require.Equal(t, errs[i][1], err)
-	}
-}
-
-func Test_ActivityPanic(t *testing.T) {
-	panicActivityFn := func() error {
-		panic("panic-blabla")
-	}
-	RegisterActivity(panicActivityFn)
-	s := &WorkflowTestSuite{}
-	s.SetLogger(zap.NewNop())
 	env := s.NewTestActivityEnvironment()
-	_, err := env.ExecuteActivity(panicActivityFn)
+	_, err := env.ExecuteActivity(errorActivityFn)
 	require.Error(t, err)
-	panicErr, ok := err.(*PanicError)
-	require.True(t, ok)
-	require.Equal(t, "panic-blabla", panicErr.Error())
+	require.Equal(t, &GenericError{"error:foo"}, err)
+
+	// test workflow error
+	errorWorkflowFn := func(ctx Context) error {
+		return errors.New("error:foo")
+	}
+	RegisterWorkflow(errorWorkflowFn)
+	wfEnv := s.NewTestWorkflowEnvironment()
+	wfEnv.ExecuteWorkflow(errorWorkflowFn)
+	err = wfEnv.GetWorkflowError()
+	require.Error(t, err)
+	require.Equal(t, &GenericError{"error:foo"}, err)
 }
 
 func Test_ActivityNotRegistered(t *testing.T) {
@@ -84,29 +82,172 @@ func Test_ActivityNotRegistered(t *testing.T) {
 	require.Contains(t, err.Error(), registeredActivityFn)
 }
 
-func Test_WorkflowError(t *testing.T) {
-	errorWorkflowFn := func(ctx Context, i int) error {
-		return errs[i][0]
-	}
-	RegisterWorkflow(errorWorkflowFn)
-	s := &WorkflowTestSuite{}
-	for i := 0; i < len(errs); i++ {
-		wfEnv := s.NewTestWorkflowEnvironment()
-		wfEnv.ExecuteWorkflow(errorWorkflowFn, i)
-		err := wfEnv.GetWorkflowError()
-		require.Error(t, err)
-		require.Equal(t, errs[i][1], err)
-	}
-}
-
-func Test_ErrorDetails(t *testing.T) {
+func Test_TimeoutError(t *testing.T) {
 	timeoutErr := NewTimeoutError(shared.TimeoutTypeScheduleToStart)
 	require.False(t, timeoutErr.HasDetails())
 	var data string
 	require.Equal(t, ErrNoData, timeoutErr.Details(&data))
 
-	heartbeatErr := NewHeartbeatTimeoutError("detailed-info")
+	heartbeatErr := NewHeartbeatTimeoutError(testErrorDetails1)
 	require.True(t, heartbeatErr.HasDetails())
 	require.NoError(t, heartbeatErr.Details(&data))
-	require.Equal(t, "detailed-info", data)
+	require.Equal(t, testErrorDetails1, data)
+
+	// test heartbeatTimeout inside internal_event_handlers
+	context := &workflowEnvironmentImpl{
+		decisionsHelper: newDecisionsHelper(),
+		dataConverter:   newDefaultDataConverter(),
+	}
+	var actualErr error
+	activityID := "activityID"
+	context.decisionsHelper.scheduledEventIDToActivityID[5] = activityID
+	di := newActivityDecisionStateMachine(
+		&shared.ScheduleActivityTaskDecisionAttributes{ActivityId: common.StringPtr(activityID)})
+	di.state = decisionStateInitiated
+	di.setData(&scheduledActivity{
+		callback: func(r []byte, e error) {
+			actualErr = e
+		},
+	})
+	context.decisionsHelper.decisions[makeDecisionID(decisionTypeActivity, activityID)] = di
+	timeoutType := shared.TimeoutTypeHeartbeat
+	encodedDetails1, _ := context.dataConverter.ToData(testErrorDetails1)
+	event := createTestEventActivityTaskTimedOut(7, &shared.ActivityTaskTimedOutEventAttributes{
+		Details:          encodedDetails1,
+		ScheduledEventId: common.Int64Ptr(5),
+		StartedEventId:   common.Int64Ptr(6),
+		TimeoutType:      &timeoutType,
+	})
+	weh := &workflowExecutionEventHandlerImpl{context, nil}
+	weh.handleActivityTaskTimedOut(event)
+	err, ok := actualErr.(*TimeoutError)
+	require.True(t, ok)
+	require.True(t, err.HasDetails())
+	data = ""
+	require.NoError(t, err.Details(&data))
+	require.Equal(t, testErrorDetails1, data)
+}
+
+func Test_CustomError(t *testing.T) {
+	// test ErrorDetailValues as Details
+	var a1 string
+	var a2 int
+	var a3 testStruct
+	err0 := NewCustomError(customErrReasonA, testErrorDetails1)
+	require.True(t, err0.HasDetails())
+	err0.Details(&a1)
+	require.Equal(t, testErrorDetails1, a1)
+	a1 = ""
+	err0 = NewCustomError(customErrReasonA, testErrorDetails1, testErrorDetails2, testErrorDetails3)
+	require.True(t, err0.HasDetails())
+	err0.Details(&a1, &a2, &a3)
+	require.Equal(t, testErrorDetails1, a1)
+	require.Equal(t, testErrorDetails2, a2)
+	require.Equal(t, testErrorDetails3, a3)
+
+	// test EncodedValues as Details
+	errorActivityFn := func() error {
+		return err0
+	}
+	RegisterActivity(errorActivityFn)
+	s := &WorkflowTestSuite{}
+	env := s.NewTestActivityEnvironment()
+	_, err := env.ExecuteActivity(errorActivityFn)
+	require.Error(t, err)
+	err1, ok := err.(*CustomError)
+	require.True(t, ok)
+	require.True(t, err1.HasDetails())
+	var b1 string
+	var b2 int
+	var b3 testStruct
+	err1.Details(&b1, &b2, &b3)
+	require.Equal(t, testErrorDetails1, b1)
+	require.Equal(t, testErrorDetails2, b2)
+	require.Equal(t, testErrorDetails3, b3)
+
+	// test reason and no detail
+	require.Panics(t, func() { NewCustomError("cadenceInternal:testReason") })
+	newReason := "another reason"
+	err2 := NewCustomError(newReason)
+	require.True(t, !err2.HasDetails())
+	require.Equal(t, ErrNoData, err2.Details())
+	require.Equal(t, newReason, err2.Reason())
+	err3 := NewCustomError(newReason, nil)
+	// TODO: probably we want to handle this case when details are nil, HasDetails return false
+	require.True(t, err3.HasDetails())
+
+	// test workflow error
+	errorWorkflowFn := func(ctx Context) error {
+		return err0
+	}
+	RegisterWorkflow(errorWorkflowFn)
+	wfEnv := s.NewTestWorkflowEnvironment()
+	wfEnv.ExecuteWorkflow(errorWorkflowFn)
+	err = wfEnv.GetWorkflowError()
+	require.Error(t, err)
+	err4, ok := err.(*CustomError)
+	require.True(t, ok)
+	require.True(t, err4.HasDetails())
+	err4.Details(&b1, &b2, &b3)
+	require.Equal(t, testErrorDetails1, b1)
+	require.Equal(t, testErrorDetails2, b2)
+	require.Equal(t, testErrorDetails3, b3)
+}
+
+func Test_CanceledError(t *testing.T) {
+	// test ErrorDetailValues as Details
+	var a1 string
+	var a2 int
+	var a3 testStruct
+	err0 := NewCanceledError(testErrorDetails1)
+	require.True(t, err0.HasDetails())
+	err0.Details(&a1)
+	require.Equal(t, testErrorDetails1, a1)
+	a1 = ""
+	err0 = NewCanceledError(testErrorDetails1, testErrorDetails2, testErrorDetails3)
+	require.True(t, err0.HasDetails())
+	err0.Details(&a1, &a2, &a3)
+	require.Equal(t, testErrorDetails1, a1)
+	require.Equal(t, testErrorDetails2, a2)
+	require.Equal(t, testErrorDetails3, a3)
+
+	// test EncodedValues as Details
+	errorActivityFn := func() error {
+		return err0
+	}
+	RegisterActivity(errorActivityFn)
+	s := &WorkflowTestSuite{}
+	env := s.NewTestActivityEnvironment()
+	_, err := env.ExecuteActivity(errorActivityFn)
+	require.Error(t, err)
+	err1, ok := err.(*CanceledError)
+	require.True(t, ok)
+	require.True(t, err1.HasDetails())
+	var b1 string
+	var b2 int
+	var b3 testStruct
+	err1.Details(&b1, &b2, &b3)
+	require.Equal(t, testErrorDetails1, b1)
+	require.Equal(t, testErrorDetails2, b2)
+	require.Equal(t, testErrorDetails3, b3)
+
+	err2 := NewCanceledError()
+	require.False(t, err2.HasDetails())
+
+	// test workflow error
+	errorWorkflowFn := func(ctx Context) error {
+		return err0
+	}
+	RegisterWorkflow(errorWorkflowFn)
+	wfEnv := s.NewTestWorkflowEnvironment()
+	wfEnv.ExecuteWorkflow(errorWorkflowFn)
+	err = wfEnv.GetWorkflowError()
+	require.Error(t, err)
+	err3, ok := err.(*CanceledError)
+	require.True(t, ok)
+	require.True(t, err3.HasDetails())
+	err3.Details(&b1, &b2, &b3)
+	require.Equal(t, testErrorDetails1, b1)
+	require.Equal(t, testErrorDetails2, b2)
+	require.Equal(t, testErrorDetails3, b3)
 }

--- a/internal/internal_activity.go
+++ b/internal/internal_activity.go
@@ -29,6 +29,7 @@ import (
 	"reflect"
 
 	"github.com/uber-go/tally"
+	"go.uber.org/cadence/encoded"
 	"go.uber.org/zap"
 	"time"
 )
@@ -68,6 +69,7 @@ type (
 		InputArgs                     []interface{}
 		ScheduleToCloseTimeoutSeconds int32
 		WorkflowInfo                  *WorkflowInfo
+		DataConverter                 encoded.DataConverter
 	}
 
 	// asyncActivityClient for requesting activity execution
@@ -104,6 +106,7 @@ type (
 		scheduledTimestamp time.Time
 		startedTimestamp   time.Time
 		taskList           string
+		dataConverter      encoded.DataConverter
 	}
 
 	// context.WithValue need this type instead of basic type string to avoid lint error
@@ -178,6 +181,9 @@ func getValidatedLocalActivityOptions(ctx Context) (*executeLocalActivityParams,
 	if p.ScheduleToCloseTimeoutSeconds <= 0 {
 		return nil, errors.New("missing or negative ScheduleToCloseTimeoutSeconds")
 	}
+	if p.DataConverter == nil {
+		p.DataConverter = newDefaultDataConverter()
+	}
 
 	return p, nil
 }
@@ -221,7 +227,7 @@ func validateFunctionArgs(f interface{}, args []interface{}, isWorkflow bool) er
 	return nil
 }
 
-func getValidatedActivityFunction(f interface{}, args []interface{}) (*ActivityType, []byte, error) {
+func getValidatedActivityFunction(f interface{}, args []interface{}, dataConverter encoded.DataConverter) (*ActivityType, []byte, error) {
 	fnName := ""
 	fType := reflect.TypeOf(f)
 	switch getKind(fType) {
@@ -242,7 +248,7 @@ func getValidatedActivityFunction(f interface{}, args []interface{}) (*ActivityT
 			"Invalid type 'f' parameter provided, it can be either activity function or name of the activity: %v", f)
 	}
 
-	input, err := getHostEnvironment().encodeArgs(args)
+	input, err := encodeArgs(dataConverter, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -261,7 +267,7 @@ func isActivityContext(inType reflect.Type) bool {
 	return inType != nil && inType.Implements(contextElem)
 }
 
-func validateFunctionAndGetResults(f interface{}, values []reflect.Value) ([]byte, error) {
+func validateFunctionAndGetResults(f interface{}, values []reflect.Value, dataConverter encoded.DataConverter) ([]byte, error) {
 	fnName := getFunctionName(f)
 	resultSize := len(values)
 
@@ -278,7 +284,7 @@ func validateFunctionAndGetResults(f interface{}, values []reflect.Value) ([]byt
 	if resultSize > 1 {
 		retValue := values[0]
 		if retValue.Kind() != reflect.Ptr || !retValue.IsNil() {
-			result, err = getHostEnvironment().encodeArg(retValue.Interface())
+			result, err = encodeArg(dataConverter, retValue.Interface())
 			if err != nil {
 				return nil, err
 			}
@@ -299,7 +305,7 @@ func validateFunctionAndGetResults(f interface{}, values []reflect.Value) ([]byt
 	return result, errInterface
 }
 
-func deSerializeFnResultFromFnType(fnType reflect.Type, result []byte, to interface{}) error {
+func deSerializeFnResultFromFnType(fnType reflect.Type, result []byte, to interface{}, dataConverter encoded.DataConverter) error {
 	if fnType.Kind() != reflect.Func {
 		return fmt.Errorf("expecting only function type but got type: %v", fnType)
 	}
@@ -311,7 +317,7 @@ func deSerializeFnResultFromFnType(fnType reflect.Type, result []byte, to interf
 		if result == nil {
 			return nil
 		}
-		err := getHostEnvironment().decodeArg(result, to)
+		err := decodeArg(dataConverter, result, to)
 		if err != nil {
 			return err
 		}
@@ -319,24 +325,27 @@ func deSerializeFnResultFromFnType(fnType reflect.Type, result []byte, to interf
 	return nil
 }
 
-func deSerializeFunctionResult(f interface{}, result []byte, to interface{}) error {
+func deSerializeFunctionResult(f interface{}, result []byte, to interface{}, dataConverter encoded.DataConverter) error {
 	fType := reflect.TypeOf(f)
+	if dataConverter == nil {
+		dataConverter = newDefaultDataConverter()
+	}
 
 	switch getKind(fType) {
 	case reflect.Func:
 		// We already validated that it either have (result, error) (or) just error.
-		return deSerializeFnResultFromFnType(fType, result, to)
+		return deSerializeFnResultFromFnType(fType, result, to, dataConverter)
 
 	case reflect.String:
 		// If we know about this function through registration then we will try to return corresponding result type.
 		fnName := reflect.ValueOf(f).String()
 		if fnRegistered, ok := getHostEnvironment().getActivityFn(fnName); ok {
-			return deSerializeFnResultFromFnType(reflect.TypeOf(fnRegistered), result, to)
+			return deSerializeFnResultFromFnType(reflect.TypeOf(fnRegistered), result, to, dataConverter)
 		}
 	}
 
 	// For everything we return result.
-	return getHostEnvironment().decodeArg(result, to)
+	return decodeArg(dataConverter, result, to)
 }
 
 func setActivityParametersIfNotExist(ctx Context) Context {

--- a/internal/internal_decision_state_machine.go
+++ b/internal/internal_decision_state_machine.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 
 	s "go.uber.org/cadence/.gen/go/shared"
+	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/internal/common"
 	"go.uber.org/cadence/internal/common/util"
 )
@@ -723,9 +724,9 @@ func (h *decisionsHelper) getActivityID(event *s.HistoryEvent) string {
 	return activityID
 }
 
-func (h *decisionsHelper) recordVersionMarker(changeID string, version Version) decisionStateMachine {
+func (h *decisionsHelper) recordVersionMarker(changeID string, version Version, dataConverter encoded.DataConverter) decisionStateMachine {
 	markerID := fmt.Sprintf("%v_%v", versionMarkerName, changeID)
-	details, err := getHostEnvironment().encodeArgs([]interface{}{changeID, version})
+	details, err := encodeArgs(dataConverter, []interface{}{changeID, version})
 	if err != nil {
 		panic(err)
 	}

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -105,8 +105,9 @@ type (
 		isReplay              bool // flag to indicate if workflow is in replay mode
 		enableLoggingInReplay bool // flag to indicate if workflow should enable logging in replay mode
 
-		metricsScope tally.Scope
-		hostEnv      *hostEnvImpl
+		metricsScope  tally.Scope
+		hostEnv       *hostEnvImpl
+		dataConverter encoded.DataConverter
 	}
 
 	localActivityTask struct {
@@ -161,6 +162,7 @@ func newWorkflowExecutionEventHandler(
 	enableLoggingInReplay bool,
 	scope tally.Scope,
 	hostEnv *hostEnvImpl,
+	dataConverter encoded.DataConverter,
 ) workflowExecutionEventHandler {
 	context := &workflowEnvironmentImpl{
 		workflowInfo:          workflowInfo,
@@ -173,6 +175,7 @@ func newWorkflowExecutionEventHandler(
 		completeHandler:       completeHandler,
 		enableLoggingInReplay: enableLoggingInReplay,
 		hostEnv:               hostEnv,
+		dataConverter:         dataConverter,
 	}
 	context.logger = logger.With(
 		zapcore.Field{Key: tagWorkflowType, Type: zapcore.StringType, String: workflowInfo.WorkflowType.Name},
@@ -319,6 +322,10 @@ func (wc *workflowEnvironmentImpl) GetLogger() *zap.Logger {
 
 func (wc *workflowEnvironmentImpl) GetMetricsScope() tally.Scope {
 	return wc.metricsScope
+}
+
+func (wc *workflowEnvironmentImpl) GetDataConverter() encoded.DataConverter {
+	return wc.dataConverter
 }
 
 func (wc *workflowEnvironmentImpl) IsReplaying() bool {
@@ -471,7 +478,7 @@ func (wc *workflowEnvironmentImpl) GetVersion(changeID string, minSupported, max
 	} else {
 		// GetVersion for changeID is called first time (non-replay mode), we need to generate a marker decision for it.
 		version = maxSupported
-		wc.decisionsHelper.recordVersionMarker(changeID, version)
+		wc.decisionsHelper.recordVersionMarker(changeID, version, wc.dataConverter)
 	}
 
 	validateVersion(changeID, version, minSupported, maxSupported)
@@ -504,7 +511,7 @@ func (wc *workflowEnvironmentImpl) SideEffect(f func() ([]byte, error), callback
 			callback(result, err)
 			return
 		}
-		details, err = wc.hostEnv.encodeArgs([]interface{}{sideEffectID, result})
+		details, err = encodeArgs(wc.GetDataConverter(), []interface{}{sideEffectID, result})
 		if err != nil {
 			callback(nil, fmt.Errorf("failure encoding sideEffectID: %v", err))
 			return
@@ -519,17 +526,17 @@ func (wc *workflowEnvironmentImpl) SideEffect(f func() ([]byte, error), callback
 
 func (wc *workflowEnvironmentImpl) MutableSideEffect(id string, f func() interface{}, equals func(a, b interface{}) bool) encoded.Value {
 	if result, ok := wc.mutableSideEffect[id]; ok {
-		encodedResult := EncodedValue(result)
+		encodedResult := newEncodedValue(result, wc.GetDataConverter())
 		if wc.isReplay {
 			return encodedResult
 		}
 
 		newValue := f()
-		if isEqualValue(newValue, result, equals) {
+		if wc.isEqualValue(newValue, result, equals) {
 			return encodedResult
 		}
 
-		return wc.recordMutableSideEffect(id, encodeValue(newValue))
+		return wc.recordMutableSideEffect(id, wc.encodeValue(newValue))
 	}
 
 	if wc.isReplay {
@@ -537,21 +544,21 @@ func (wc *workflowEnvironmentImpl) MutableSideEffect(id string, f func() interfa
 		panic("MutableSideEffect with given ID not found during replay")
 	}
 
-	return wc.recordMutableSideEffect(id, encodeValue(f()))
+	return wc.recordMutableSideEffect(id, wc.encodeValue(f()))
 }
 
-func isEqualValue(newValue interface{}, encodedOldValue []byte, equals func(a, b interface{}) bool) bool {
+func (wc *workflowEnvironmentImpl) isEqualValue(newValue interface{}, encodedOldValue []byte, equals func(a, b interface{}) bool) bool {
 	if newValue == nil {
 		// new value is nil
-		newEncodedValue := encodeValue(nil)
+		newEncodedValue := wc.encodeValue(nil)
 		return bytes.Equal(newEncodedValue, encodedOldValue)
 	}
 
-	oldValue := decodeValue(encodedOldValue, newValue)
+	oldValue := decodeValue(newEncodedValue(encodedOldValue, wc.GetDataConverter()), newValue)
 	return equals(newValue, oldValue)
 }
 
-func decodeValue(encodedValue EncodedValue, value interface{}) interface{} {
+func decodeValue(encodedValue encoded.Value, value interface{}) interface{} {
 	// We need to decode oldValue out of encodedValue, first we need to prepare valuePtr as the same type as value
 	valuePtr := reflect.New(reflect.TypeOf(value)).Interface()
 	if err := encodedValue.Get(valuePtr); err != nil {
@@ -561,22 +568,26 @@ func decodeValue(encodedValue EncodedValue, value interface{}) interface{} {
 	return decodedValue
 }
 
-func encodeValue(value interface{}) []byte {
-	blob, err := getHostEnvironment().encodeArg(value)
+func (wc *workflowEnvironmentImpl) encodeValue(value interface{}) []byte {
+	blob, err := wc.encodeArg(value)
 	if err != nil {
 		panic(err)
 	}
 	return blob
 }
 
+func (wc *workflowEnvironmentImpl) encodeArg(arg interface{}) ([]byte, error) {
+	return wc.dataConverter.ToData(arg)
+}
+
 func (wc *workflowEnvironmentImpl) recordMutableSideEffect(id string, data []byte) encoded.Value {
-	details, err := wc.hostEnv.encodeArgs([]interface{}{id, string(data)})
+	details, err := encodeArgs(wc.GetDataConverter(), []interface{}{id, string(data)})
 	if err != nil {
 		panic(err)
 	}
 	wc.decisionsHelper.recordMutableSideEffectMarker(id, details)
 	wc.mutableSideEffect[id] = data
-	return EncodedValue(data)
+	return newEncodedValue(data, wc.GetDataConverter())
 }
 
 func (weh *workflowExecutionEventHandlerImpl) ProcessEvent(
@@ -749,7 +760,7 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessEvent(
 
 func (weh *workflowExecutionEventHandlerImpl) ProcessQuery(queryType string, queryArgs []byte) ([]byte, error) {
 	if queryType == QueryTypeStackTrace {
-		return getHostEnvironment().encodeArg(weh.StackTrace())
+		return weh.encodeArg(weh.StackTrace())
 	}
 	return weh.queryHandler(queryType, queryArgs)
 }
@@ -799,7 +810,7 @@ func (weh *workflowExecutionEventHandlerImpl) handleActivityTaskFailed(event *m.
 	}
 
 	attributes := event.ActivityTaskFailedEventAttributes
-	err := constructError(*attributes.Reason, attributes.Details)
+	err := constructError(*attributes.Reason, attributes.Details, weh.GetDataConverter())
 	activity.handle(nil, err)
 	return nil
 }
@@ -816,7 +827,8 @@ func (weh *workflowExecutionEventHandlerImpl) handleActivityTaskTimedOut(event *
 	var err error
 	tt := attributes.GetTimeoutType()
 	if tt == m.TimeoutTypeHeartbeat {
-		err = NewHeartbeatTimeoutError(attributes.Details)
+		details := newEncodedValues(attributes.Details, weh.GetDataConverter())
+		err = NewHeartbeatTimeoutError(details)
 	} else {
 		err = NewTimeoutError(attributes.GetTimeoutType())
 	}
@@ -834,7 +846,8 @@ func (weh *workflowExecutionEventHandlerImpl) handleActivityTaskCanceled(event *
 
 	if decision.isDone() || !activity.waitForCancelRequest {
 		// Clear this so we don't have a recursive call that while executing might call the cancel one.
-		err := NewCanceledError(event.ActivityTaskCanceledEventAttributes.Details)
+		details := newEncodedValues(event.ActivityTaskCanceledEventAttributes.Details, weh.GetDataConverter())
+		err := NewCanceledError(details)
 		activity.handle(nil, err)
 	}
 
@@ -860,7 +873,7 @@ func (weh *workflowExecutionEventHandlerImpl) handleMarkerRecorded(
 	eventID int64,
 	attributes *m.MarkerRecordedEventAttributes,
 ) error {
-	encodedValues := EncodedValues(attributes.Details)
+	encodedValues := newEncodedValues(attributes.Details, weh.dataConverter)
 	switch attributes.GetMarkerName() {
 	case sideEffectMarkerName:
 		var sideEffectID int32
@@ -888,9 +901,9 @@ func (weh *workflowExecutionEventHandlerImpl) handleMarkerRecorded(
 	}
 }
 
-func (weh *workflowExecutionEventHandlerImpl) handleLocalActivityMarker(markerData EncodedValue) error {
+func (weh *workflowExecutionEventHandlerImpl) handleLocalActivityMarker(markerData []byte) error {
 	var lamd localActivityMarkerData
-	if err := markerData.Get(&lamd); err != nil {
+	if err := newEncodedValue(markerData, weh.dataConverter).Get(&lamd); err != nil {
 		return err
 	}
 
@@ -900,7 +913,7 @@ func (weh *workflowExecutionEventHandlerImpl) handleLocalActivityMarker(markerDa
 		delete(weh.pendingLaTasks, lamd.ActivityID)
 		delete(weh.unstartedLaTasks, lamd.ActivityID)
 		if len(lamd.ErrReason) > 0 {
-			la.callback(nil, constructError(lamd.ErrReason, []byte(lamd.ErrJSON)))
+			la.callback(nil, constructError(lamd.ErrReason, []byte(lamd.ErrJSON), weh.GetDataConverter()))
 		} else {
 			la.callback([]byte(lamd.ResultJSON), nil)
 		}
@@ -922,7 +935,7 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessLocalActivityResult(lar *lo
 		ReplayTime: weh.currentReplayTime.Add(time.Now().Sub(weh.currentLocalTime)),
 	}
 	if lar.err != nil {
-		errReason, errDetails := getErrorDetails(lar.err)
+		errReason, errDetails := getErrorDetails(lar.err, weh.GetDataConverter())
 		lamd.ErrReason = errReason
 		lamd.ErrJSON = string(errDetails)
 	} else {
@@ -930,7 +943,7 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessLocalActivityResult(lar *lo
 	}
 
 	// encode marker data
-	markerData, err := getHostEnvironment().encodeArg(lamd)
+	markerData, err := weh.encodeArg(lamd)
 	if err != nil {
 		return nil, err
 	}
@@ -1010,7 +1023,7 @@ func (weh *workflowExecutionEventHandlerImpl) handleChildWorkflowExecutionFailed
 		return nil
 	}
 
-	err := constructError(attributes.GetReason(), attributes.Details)
+	err := constructError(attributes.GetReason(), attributes.Details, weh.GetDataConverter())
 	childWorkflow.handle(nil, err)
 
 	return nil
@@ -1024,7 +1037,8 @@ func (weh *workflowExecutionEventHandlerImpl) handleChildWorkflowExecutionCancel
 	if childWorkflow.handled {
 		return nil
 	}
-	err := NewCanceledError(attributes.Details)
+	details := newEncodedValues(attributes.Details, weh.GetDataConverter())
+	err := NewCanceledError(details)
 	childWorkflow.handle(nil, err)
 	return nil
 }

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -35,6 +35,7 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	s "go.uber.org/cadence/.gen/go/shared"
+	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/internal/common"
 	"go.uber.org/cadence/internal/common/backoff"
 	"go.uber.org/cadence/internal/common/cache"
@@ -108,6 +109,7 @@ type (
 		disableStickyExecution bool
 		hostEnv                *hostEnvImpl
 		laTunnel               *localActivityTunnel
+		dataConverter          encoded.DataConverter
 	}
 
 	activityProvider func(name string) activity
@@ -121,6 +123,7 @@ type (
 		userContext      context.Context
 		hostEnv          *hostEnvImpl
 		activityProvider activityProvider
+		dataConverter    encoded.DataConverter
 	}
 
 	// history wrapper method to help information about events.
@@ -345,6 +348,7 @@ func newWorkflowTaskHandler(
 		enableLoggingInReplay:  params.EnableLoggingInReplay,
 		disableStickyExecution: params.DisableStickyExecution,
 		hostEnv:                hostEnv,
+		dataConverter:          params.DataConverter,
 	}
 }
 
@@ -429,7 +433,8 @@ func (w *workflowExecutionContext) resetWorkflowState() {
 		w.wth.logger,
 		w.wth.enableLoggingInReplay,
 		w.wth.metricsScope,
-		w.wth.hostEnv).(*workflowExecutionEventHandlerImpl)
+		w.wth.hostEnv,
+		w.wth.dataConverter).(*workflowExecutionEventHandlerImpl)
 }
 
 func resetHistory(task *s.PollForDecisionTaskResponse, historyIterator HistoryIterator) (*s.History, error) {
@@ -998,7 +1003,7 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 			zap.String("PanicError", panicErr.Error()),
 			zap.String("PanicStack", panicErr.StackTrace()))
 		failedCause := s.DecisionTaskFailedCauseWorkflowWorkerUnhandledFailure
-		_, details := getErrorDetails(panicErr)
+		_, details := getErrorDetails(panicErr, wth.dataConverter)
 		return &s.RespondDecisionTaskFailedRequest{
 			TaskToken: task.TaskToken,
 			Cause:     &failedCause,
@@ -1013,8 +1018,9 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 		// Workflow cancelled
 		wth.metricsScope.Counter(metrics.WorkflowCanceledCounter).Inc(1)
 		closeDecision = createNewDecision(s.DecisionTypeCancelWorkflowExecution)
+		_, details := getErrorDetails(canceledErr, wth.dataConverter)
 		closeDecision.CancelWorkflowExecutionDecisionAttributes = &s.CancelWorkflowExecutionDecisionAttributes{
-			Details: canceledErr.details,
+			Details: details,
 		}
 	} else if contErr, ok := workflowContext.err.(*ContinueAsNewError); ok {
 		// Continue as new error.
@@ -1031,7 +1037,7 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 		// Workflow failures
 		wth.metricsScope.Counter(metrics.WorkflowFailedCounter).Inc(1)
 		closeDecision = createNewDecision(s.DecisionTypeFailWorkflowExecution)
-		reason, details := getErrorDetails(workflowContext.err)
+		reason, details := getErrorDetails(workflowContext.err, wth.dataConverter)
 		closeDecision.FailWorkflowExecutionDecisionAttributes = &s.FailWorkflowExecutionDecisionAttributes{
 			Reason:  common.StringPtr(reason),
 			Details: details,
@@ -1097,6 +1103,7 @@ func newActivityTaskHandlerWithCustomProvider(
 		userContext:      params.UserContext,
 		hostEnv:          env,
 		activityProvider: activityProvider,
+		dataConverter:    params.DataConverter,
 	}
 }
 
@@ -1235,7 +1242,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskList string, t *s.PollForActivit
 	canCtx, cancel := context.WithCancel(rootCtx)
 	invoker := newServiceInvoker(t.TaskToken, ath.identity, ath.service, cancel, t.GetHeartbeatTimeoutSeconds())
 	defer invoker.Close()
-	ctx := WithActivityTask(canCtx, t, taskList, invoker, ath.logger, ath.metricsScope)
+	ctx := WithActivityTask(canCtx, t, taskList, invoker, ath.logger, ath.metricsScope, ath.dataConverter)
 	activityType := *t.ActivityType
 	activityImplementation := ath.getActivity(activityType.GetName())
 	if activityImplementation == nil {
@@ -1255,7 +1262,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskList string, t *s.PollForActivit
 			scope := ath.metricsScope.GetTaggedScope(tagActivityType, t.ActivityType.GetName())
 			scope.Counter(metrics.ActivityTaskPanicCounter).Inc(1)
 			panicErr := newPanicError(p, st)
-			result, err = convertActivityResultToRespondRequest(ath.identity, t.TaskToken, nil, panicErr), nil
+			result, err = convertActivityResultToRespondRequest(ath.identity, t.TaskToken, nil, panicErr, ath.dataConverter), nil
 		}
 	}()
 	info := ctx.Value(activityEnvContextKey).(*activityEnvironment)
@@ -1268,7 +1275,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskList string, t *s.PollForActivit
 		return nil, ctx.Err()
 	}
 
-	return convertActivityResultToRespondRequest(ath.identity, t.TaskToken, output, err), nil
+	return convertActivityResultToRespondRequest(ath.identity, t.TaskToken, output, err, ath.dataConverter), nil
 }
 
 func (ath *activityTaskHandlerImpl) getActivity(name string) activity {

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -31,6 +31,7 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	s "go.uber.org/cadence/.gen/go/shared"
+	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/internal/common"
 	"go.uber.org/cadence/internal/common/backoff"
 	"go.uber.org/cadence/internal/common/metrics"
@@ -109,9 +110,10 @@ type (
 	}
 
 	localActivityTaskHandler struct {
-		userContext  context.Context
-		metricsScope tally.Scope
-		logger       *zap.Logger
+		userContext   context.Context
+		metricsScope  tally.Scope
+		logger        *zap.Logger
+		dataConverter encoded.DataConverter
 	}
 
 	localActivityResult struct {
@@ -317,9 +319,10 @@ func (wtp *workflowTaskPoller) RespondTaskCompleted(completedRequest interface{}
 
 func newLocalActivityPoller(params workerExecutionParameters, laTunnel *localActivityTunnel) *localActivityTaskPoller {
 	handler := &localActivityTaskHandler{
-		userContext:  params.UserContext,
-		metricsScope: params.MetricsScope,
-		logger:       params.Logger,
+		userContext:   params.UserContext,
+		metricsScope:  params.MetricsScope,
+		logger:        params.Logger,
+		dataConverter: params.DataConverter,
 	}
 	return &localActivityTaskPoller{
 		handler:      handler,
@@ -356,6 +359,7 @@ func (lath *localActivityTaskHandler) executeLocalActivityTask(task *localActivi
 		logger:            lath.logger,
 		metricsScope:      lath.metricsScope,
 		isLocalActivity:   true,
+		dataConverter:     lath.dataConverter,
 	})
 
 	// panic handler
@@ -806,7 +810,8 @@ func reportActivityCompleteByID(ctx context.Context, service workflowserviceclie
 	return reportErr
 }
 
-func convertActivityResultToRespondRequest(identity string, taskToken, result []byte, err error) interface{} {
+func convertActivityResultToRespondRequest(identity string, taskToken, result []byte, err error,
+	dataConverter encoded.DataConverter) interface{} {
 	if err == ErrActivityResultPending {
 		// activity result is pending and will be completed asynchronously.
 		// nothing to report at this point
@@ -820,7 +825,7 @@ func convertActivityResultToRespondRequest(identity string, taskToken, result []
 			Identity:  common.StringPtr(identity)}
 	}
 
-	reason, details := getErrorDetails(err)
+	reason, details := getErrorDetails(err, dataConverter)
 	if _, ok := err.(*CanceledError); ok || err == context.Canceled {
 		return &s.RespondActivityTaskCanceledRequest{
 			TaskToken: taskToken,
@@ -836,7 +841,7 @@ func convertActivityResultToRespondRequest(identity string, taskToken, result []
 }
 
 func convertActivityResultToRespondRequestByID(identity, domain, workflowID, runID, activityID string,
-	result []byte, err error) interface{} {
+	result []byte, err error, dataConverter encoded.DataConverter) interface{} {
 	if err == ErrActivityResultPending {
 		// activity result is pending and will be completed asynchronously.
 		// nothing to report at this point
@@ -853,7 +858,7 @@ func convertActivityResultToRespondRequestByID(identity, domain, workflowID, run
 			Identity:   common.StringPtr(identity)}
 	}
 
-	reason, details := getErrorDetails(err)
+	reason, details := getErrorDetails(err, dataConverter)
 	if _, ok := err.(*CanceledError); ok || err == context.Canceled {
 		return &s.RespondActivityTaskCanceledByIDRequest{
 			Domain:     common.StringPtr(domain),

--- a/internal/internal_utils_test.go
+++ b/internal/internal_utils_test.go
@@ -35,27 +35,22 @@ func TestChannelBuilderOptions(t *testing.T) {
 	require.Equal(t, time.Minute, builder.Timeout)
 }
 
-type testDecodeStruct struct {
-	Name string
-	Age  int
-}
-
 func TestNewValues(t *testing.T) {
 	var details []interface{}
 	heartbeatDetail := "status-report-to-workflow"
 	heartbeatDetail2 := 1
-	heartbeatDetail3 := testDecodeStruct{
+	heartbeatDetail3 := testStruct{
 		Name: heartbeatDetail,
 		Age:  heartbeatDetail2,
 	}
 	details = append(details, heartbeatDetail, heartbeatDetail2, heartbeatDetail3)
-	data, err := getHostEnvironment().encodeArgs(details)
+	data, err := encodeArgs(nil, details)
 	if err != nil {
 		panic(err)
 	}
 	var res string
 	var res2 int
-	var res3 testDecodeStruct
+	var res3 testStruct
 	NewValues(data).Get(&res, &res2, &res3)
 	require.Equal(t, heartbeatDetail, res)
 	require.Equal(t, heartbeatDetail2, res2)
@@ -64,7 +59,7 @@ func TestNewValues(t *testing.T) {
 
 func TestNewValue(t *testing.T) {
 	heartbeatDetail := "status-report-to-workflow"
-	data, err := getHostEnvironment().encodeArg(heartbeatDetail)
+	data, err := encodeArg(nil, heartbeatDetail)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -39,6 +39,7 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	"go.uber.org/cadence/.gen/go/shared"
+	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/internal/common"
 	"go.uber.org/cadence/internal/common/backoff"
 	"go.uber.org/zap"
@@ -141,7 +142,12 @@ type (
 		DisableStickyExecution bool
 
 		StickyScheduleToStartTimeout time.Duration
+
+		DataConverter encoded.DataConverter
 	}
+
+	// defaultDataConverter uses thrift encoder/decoder when possible, for everything else use json.
+	defaultDataConverter struct{}
 )
 
 // newWorkflowWorker returns an instance of the workflow worker.
@@ -169,10 +175,13 @@ func ensureRequiredParams(params *workerExecutionParameters) {
 		params.Logger = logger
 		params.Logger.Info("No logger configured for cadence worker. Created default one.")
 	}
-
 	if params.MetricsScope == nil {
 		params.MetricsScope = tally.NoopScope
 		params.Logger.Info("No metrics scope configured for cadence worker. Use NoopScope as default.")
+	}
+	if params.DataConverter == nil {
+		params.DataConverter = newDefaultDataConverter()
+		params.Logger.Info("No DataConverter configured for cadence worker. Use default one.")
 	}
 }
 
@@ -406,8 +415,6 @@ type hostEnvImpl struct {
 	workflowAliasMap map[string]string
 	activityFuncMap  map[string]activity
 	activityAliasMap map[string]string
-	encoding         encoding
-	tEncoding        encoding
 }
 
 func (th *hostEnvImpl) RegisterWorkflow(af interface{}) error {
@@ -432,10 +439,6 @@ func (th *hostEnvImpl) RegisterWorkflowWithOptions(
 	// Check if already registered
 	if _, ok := th.getWorkflowFn(registerName); ok {
 		return fmt.Errorf("workflow name \"%v\" is already registered", registerName)
-	}
-	// Register args with encoding.
-	if err := th.registerEncodingTypes(fnType); err != nil {
-		return err
 	}
 	th.addWorkflowFn(registerName, af)
 	if len(alias) > 0 {
@@ -467,30 +470,11 @@ func (th *hostEnvImpl) RegisterActivityWithOptions(
 	if _, ok := th.getActivityFn(registerName); ok {
 		return fmt.Errorf("activity type \"%v\" is already registered", registerName)
 	}
-	// Register args with encoding.
-	if err := th.registerEncodingTypes(fnType); err != nil {
-		return err
-	}
 	th.addActivityFn(registerName, af)
 	if len(alias) > 0 {
 		th.addActivityAlias(fnName, alias)
 	}
 	return nil
-}
-
-// Get the encoder.
-func (th *hostEnvImpl) Encoder() encoding {
-	return th.encoding
-}
-
-// Get thrift encoder.
-func (th *hostEnvImpl) ThriftEncoder() encoding {
-	return th.tEncoding
-}
-
-// Register all function args and return types with encoder.
-func (th *hostEnvImpl) RegisterFnType(fnType reflect.Type) error {
-	return th.registerEncodingTypes(fnType)
 }
 
 func (th *hostEnvImpl) addWorkflowAlias(fnName string, alias string) {
@@ -574,54 +558,7 @@ func (th *hostEnvImpl) getRegisteredActivities() []activity {
 	return activities
 }
 
-// register all the types with encoder.
-func (th *hostEnvImpl) registerEncodingTypes(fnType reflect.Type) error {
-	th.Lock()
-	defer th.Unlock()
-
-	// Register arguments.
-	for i := 0; i < fnType.NumIn(); i++ {
-		err := th.registerType(fnType.In(i), th.Encoder())
-		if err != nil {
-			return err
-		}
-	}
-	// Register return types.
-	// TODO: We need register all concrete implementations of error, Either
-	// through pre-registry (or) at the time conversion.
-	for i := 0; i < fnType.NumOut(); i++ {
-		err := th.registerType(fnType.Out(i), th.Encoder())
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (th *hostEnvImpl) registerValue(v interface{}, encoder encoding) error {
-	if val := reflect.ValueOf(v); val.IsValid() {
-		if val.Kind() == reflect.Ptr && val.IsNil() {
-			return nil
-		}
-		rType := reflect.Indirect(val).Type()
-		return th.registerType(rType, encoder)
-	}
-	return nil
-}
-
-// register type with our encoder.
-func (th *hostEnvImpl) registerType(t reflect.Type, encoder encoding) error {
-	// Interfaces cannot be registered, their implementations should be
-	// https://golang.org/pkg/encoding/gob/#Register
-	if t.Kind() == reflect.Interface || t.Kind() == reflect.Ptr {
-		return nil
-	}
-	arg := reflect.Zero(t).Interface()
-	return encoder.Register(arg)
-}
-
-func (th *hostEnvImpl) isUseThriftEncoding(objs []interface{}) bool {
+func isUseThriftEncoding(objs []interface{}) bool {
 	// NOTE: our criteria to use which encoder is simple if all the types are serializable using thrift then we use
 	// thrift encoder. For everything else we default to gob.
 
@@ -637,7 +574,7 @@ func (th *hostEnvImpl) isUseThriftEncoding(objs []interface{}) bool {
 	return true
 }
 
-func (th *hostEnvImpl) isUseThriftDecoding(objs []interface{}) bool {
+func isUseThriftDecoding(objs []interface{}) bool {
 	// NOTE: our criteria to use which encoder is simple if all the types are de-serializable using thrift then we use
 	// thrift decoder. For everything else we default to gob.
 
@@ -707,64 +644,19 @@ func validateFnFormat(fnType reflect.Type, isWorkflow bool) error {
 	return nil
 }
 
-// encode set of values.
-func (th *hostEnvImpl) encode(r []interface{}) ([]byte, error) {
-	if len(r) == 1 && isTypeByteSlice(reflect.TypeOf(r[0])) {
-		return r[0].([]byte), nil
-	}
-
-	var encoder encoding
-	if th.isUseThriftEncoding(r) {
-		encoder = th.ThriftEncoder()
-	} else {
-		encoder = th.Encoder()
-	}
-
-	for _, v := range r {
-		err := th.registerValue(v, encoder)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	data, err := encoder.Marshal(r)
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
-}
-
-// decode a set of values.
-func (th *hostEnvImpl) decode(data []byte, to []interface{}) error {
-	if len(to) == 1 && isTypeByteSlice(reflect.TypeOf(to[0])) {
-		reflect.ValueOf(to[0]).Elem().SetBytes(data)
-		return nil
-	}
-
-	var encoder encoding
-	if th.isUseThriftDecoding(to) {
-		encoder = th.ThriftEncoder()
-	} else {
-		encoder = th.Encoder()
-	}
-
-	for _, v := range to {
-		err := th.registerValue(v, encoder)
-		if err != nil {
-			return err
-		}
-	}
-
-	return encoder.Unmarshal(data, to)
-}
-
 // encode multiple arguments(arguments to a function).
-func (th *hostEnvImpl) encodeArgs(args []interface{}) ([]byte, error) {
-	return th.encode(args)
+func encodeArgs(dc encoded.DataConverter, args []interface{}) ([]byte, error) {
+	if dc == nil {
+		return newDefaultDataConverter().ToData(args...)
+	}
+	return dc.ToData(args...)
 }
 
 // decode multiple arguments(arguments to a function).
-func (th *hostEnvImpl) decodeArgs(fnType reflect.Type, data []byte) (result []reflect.Value, err error) {
+func decodeArgs(dc encoded.DataConverter, fnType reflect.Type, data []byte) (result []reflect.Value, err error) {
+	if dc == nil {
+		dc = newDefaultDataConverter()
+	}
 	var r []interface{}
 argsLoop:
 	for i := 0; i < fnType.NumIn(); i++ {
@@ -775,7 +667,7 @@ argsLoop:
 		arg := reflect.New(argT).Interface()
 		r = append(r, arg)
 	}
-	err = th.decode(data, r)
+	err = dc.FromData(data, r...)
 	if err != nil {
 		return
 	}
@@ -786,16 +678,22 @@ argsLoop:
 }
 
 // encode single value(like return parameter).
-func (th *hostEnvImpl) encodeArg(arg interface{}) ([]byte, error) {
-	return th.encode([]interface{}{arg})
+func encodeArg(dc encoded.DataConverter, arg interface{}) ([]byte, error) {
+	if dc == nil {
+		return newDefaultDataConverter().ToData(arg)
+	}
+	return dc.ToData(arg)
 }
 
 // decode single value(like return parameter).
-func (th *hostEnvImpl) decodeArg(data []byte, to interface{}) error {
-	return th.decode(data, []interface{}{to})
+func decodeArg(dc encoded.DataConverter, data []byte, to interface{}) error {
+	if dc == nil {
+		return newDefaultDataConverter().FromData(data, to)
+	}
+	return dc.FromData(data, to)
 }
 
-func (th *hostEnvImpl) decodeAndAssignValue(from interface{}, toValuePtr interface{}) error {
+func decodeAndAssignValue(dc encoded.DataConverter, from interface{}, toValuePtr interface{}) error {
 	if toValuePtr == nil {
 		return nil
 	}
@@ -803,7 +701,7 @@ func (th *hostEnvImpl) decodeAndAssignValue(from interface{}, toValuePtr interfa
 		return errors.New("value parameter provided is not a pointer")
 	}
 	if data, ok := from.([]byte); ok {
-		if err := th.decodeArg(data, toValuePtr); err != nil {
+		if err := decodeArg(dc, data, toValuePtr); err != nil {
 			return err
 		}
 	} else if fv := reflect.ValueOf(from); fv.IsValid() {
@@ -828,8 +726,6 @@ func newHostEnvironment() *hostEnvImpl {
 		workflowAliasMap: make(map[string]string),
 		activityFuncMap:  make(map[string]activity),
 		activityAliasMap: make(map[string]string),
-		encoding:         jsonEncoding{},
-		tEncoding:        thriftEncoding{},
 	}
 }
 
@@ -851,12 +747,13 @@ func (we *workflowExecutor) Execute(ctx Context, input []byte) ([]byte, error) {
 	// Workflow context.
 	args := []reflect.Value{reflect.ValueOf(ctx)}
 
+	dataConverter := getWorkflowEnvOptions(ctx).dataConverter
 	if fnType.NumIn() > 1 && isTypeByteSlice(fnType.In(1)) {
 		// 0 - is workflow context.
 		// 1 ... input types.
 		args = append(args, reflect.ValueOf(input))
 	} else {
-		decoded, err := getHostEnvironment().decodeArgs(fnType, input)
+		decoded, err := decodeArgs(dataConverter, fnType, input)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"unable to decode the workflow function input bytes with error: %v, function name: %v",
@@ -868,7 +765,7 @@ func (we *workflowExecutor) Execute(ctx Context, input []byte) ([]byte, error) {
 	// Invoke the workflow with arguments.
 	fnValue := reflect.ValueOf(we.fn)
 	retValues := fnValue.Call(args)
-	return validateFunctionAndGetResults(we.fn, retValues)
+	return validateFunctionAndGetResults(we.fn, retValues, dataConverter)
 }
 
 // Wrapper to execute activity functions.
@@ -888,6 +785,7 @@ func (ae *activityExecutor) GetFunction() interface{} {
 func (ae *activityExecutor) Execute(ctx context.Context, input []byte) ([]byte, error) {
 	fnType := reflect.TypeOf(ae.fn)
 	args := []reflect.Value{}
+	dataConverter := getDataConverterFromActivityCtx(ctx)
 
 	// activities optionally might not take context.
 	if fnType.NumIn() > 0 && isActivityContext(fnType.In(0)) {
@@ -897,7 +795,7 @@ func (ae *activityExecutor) Execute(ctx context.Context, input []byte) ([]byte, 
 	if fnType.NumIn() == 1 && isTypeByteSlice(fnType.In(0)) {
 		args = append(args, reflect.ValueOf(input))
 	} else {
-		decoded, err := getHostEnvironment().decodeArgs(fnType, input)
+		decoded, err := decodeArgs(dataConverter, fnType, input)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"unable to decode the activity function input bytes with error: %v for function name: %v",
@@ -908,12 +806,13 @@ func (ae *activityExecutor) Execute(ctx context.Context, input []byte) ([]byte, 
 
 	fnValue := reflect.ValueOf(ae.fn)
 	retValues := fnValue.Call(args)
-	return validateFunctionAndGetResults(ae.fn, retValues)
+	return validateFunctionAndGetResults(ae.fn, retValues, dataConverter)
 }
 
 func (ae *activityExecutor) ExecuteWithActualArgs(ctx context.Context, actualArgs []interface{}) ([]byte, error) {
 	fnType := reflect.TypeOf(ae.fn)
 	args := []reflect.Value{}
+	dataConverter := getDataConverterFromActivityCtx(ctx)
 
 	// activities optionally might not take context.
 	argsOffeset := 0
@@ -932,7 +831,18 @@ func (ae *activityExecutor) ExecuteWithActualArgs(ctx context.Context, actualArg
 
 	fnValue := reflect.ValueOf(ae.fn)
 	retValues := fnValue.Call(args)
-	return validateFunctionAndGetResults(ae.fn, retValues)
+	return validateFunctionAndGetResults(ae.fn, retValues, dataConverter)
+}
+
+func getDataConverterFromActivityCtx(ctx context.Context) encoded.DataConverter {
+	if ctx == nil || ctx.Value(activityEnvContextKey) == nil {
+		return newDefaultDataConverter()
+	}
+	info := ctx.Value(activityEnvContextKey).(*activityEnvironment)
+	if info.dataConverter == nil {
+		return newDefaultDataConverter()
+	}
+	return info.dataConverter
 }
 
 // aggregatedWorker combines management of both workflowWorker and activityWorker worker lifecycle.
@@ -1015,6 +925,7 @@ func newAggregatedWorker(
 		DisableStickyExecution:               wOptions.DisableStickyExecution,
 		StickyScheduleToStartTimeout:         wOptions.StickyScheduleToStartTimeout,
 		TaskListActivitiesPerSecond:          wOptions.TaskListActivitiesPerSecond,
+		DataConverter:                        wOptions.DataConverter,
 	}
 
 	ensureRequiredParams(&workerParams)
@@ -1134,18 +1045,12 @@ func isInterfaceNil(i interface{}) bool {
 
 // encoding is capable of encoding and decoding objects
 type encoding interface {
-	Register(obj interface{}) error
 	Marshal([]interface{}) ([]byte, error)
 	Unmarshal([]byte, []interface{}) error
 }
 
 // jsonEncoding encapsulates json encoding and decoding
 type jsonEncoding struct {
-}
-
-// Register implements the encoding interface
-func (g jsonEncoding) Register(obj interface{}) error {
-	return nil
 }
 
 // Marshal encodes an array of object into bytes
@@ -1186,11 +1091,6 @@ func isThriftType(v interface{}) bool {
 
 // thriftEncoding encapsulates thrift serializer/de-serializer.
 type thriftEncoding struct{}
-
-// Register implements the encoding interface
-func (g thriftEncoding) Register(obj interface{}) error {
-	return nil
-}
 
 // Marshal encodes an array of thrift into bytes
 func (g thriftEncoding) Marshal(objs []interface{}) ([]byte, error) {
@@ -1247,6 +1147,9 @@ func fillWorkerOptionsDefaults(options WorkerOptions) WorkerOptions {
 	if options.StickyScheduleToStartTimeout.Seconds() == 0 {
 		options.StickyScheduleToStartTimeout = stickyDecisionScheduleToStartTimeoutSeconds * time.Second
 	}
+	if options.DataConverter == nil {
+		options.DataConverter = newDefaultDataConverter()
+	}
 	return options
 }
 
@@ -1259,4 +1162,43 @@ func getTestTags(ctx context.Context) map[string]map[string]string {
 		}
 	}
 	return nil
+}
+
+func newDefaultDataConverter() encoded.DataConverter {
+	return &defaultDataConverter{}
+}
+
+func (dc *defaultDataConverter) ToData(r ...interface{}) ([]byte, error) {
+	if len(r) == 1 && isTypeByteSlice(reflect.TypeOf(r[0])) {
+		return r[0].([]byte), nil
+	}
+
+	var encoder encoding
+	if isUseThriftEncoding(r) {
+		encoder = &thriftEncoding{}
+	} else {
+		encoder = &jsonEncoding{}
+	}
+
+	data, err := encoder.Marshal(r)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (dc *defaultDataConverter) FromData(data []byte, to ...interface{}) error {
+	if len(to) == 1 && isTypeByteSlice(reflect.TypeOf(to[0])) {
+		reflect.ValueOf(to[0]).Elem().SetBytes(data)
+		return nil
+	}
+
+	var encoder encoding
+	if isUseThriftDecoding(to) {
+		encoder = &thriftEncoding{}
+	} else {
+		encoder = &jsonEncoding{}
+	}
+
+	return encoder.Unmarshal(data, to)
 }

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -72,6 +72,7 @@ type (
 		RegisterQueryHandler(handler func(queryType string, queryArgs []byte) ([]byte, error))
 		IsReplaying() bool
 		MutableSideEffect(id string, f func() interface{}, equals func(a, b interface{}) bool) encoded.Value
+		GetDataConverter() encoded.DataConverter
 	}
 
 	// WorkflowDefinition wraps the code that can execute a workflow.

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -30,12 +30,15 @@ import (
 	"testing"
 	"time"
 
+	"bytes"
+	"encoding/gob"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/cadence/.gen/go/cadence/workflowservicetest"
 	"go.uber.org/cadence/.gen/go/shared"
+	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/internal/common"
 	"go.uber.org/yarpc"
 	"go.uber.org/zap"
@@ -77,7 +80,7 @@ type internalWorkerTestSuite struct {
 	service  *workflowservicetest.MockClient
 }
 
-func TestinternalWorkferTestSuite(t *testing.T) {
+func TestInternalWorkferTestSuite(t *testing.T) {
 	s := new(internalWorkerTestSuite)
 	suite.Run(t, s)
 }
@@ -114,13 +117,12 @@ func testActivity(ctx context.Context) error {
 	return nil
 }
 
-func (s *internalWorkerTestSuite) TestDecisionTaskHandler() {
-	logger := getLogger()
+func (s *internalWorkerTestSuite) testDecisionTaskHandlerHelper(params workerExecutionParameters) {
 	taskList := "taskList1"
 	testEvents := []*shared.HistoryEvent{
 		createTestEventWorkflowExecutionStarted(1, &shared.WorkflowExecutionStartedEventAttributes{
 			TaskList: &shared.TaskList{Name: common.StringPtr(taskList)},
-			Input:    testEncodeFunctionArgs(testReplayWorkflow),
+			Input:    testEncodeFunctionArgs(params.DataConverter, testReplayWorkflow),
 		}),
 		createTestEventDecisionTaskScheduled(2, &shared.DecisionTaskScheduledEventAttributes{}),
 		createTestEventDecisionTaskStarted(3),
@@ -144,15 +146,28 @@ func (s *internalWorkerTestSuite) TestDecisionTaskHandler() {
 		PreviousStartedEventId: common.Int64Ptr(5),
 	}
 
-	params := workerExecutionParameters{
-		Identity: "identity",
-		Logger:   logger,
-	}
 	r := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
 	_, stackTrace, err := r.ProcessWorkflowTask(task, nil, true)
 	require.NoError(s.T(), err)
 	require.NotEmpty(s.T(), stackTrace, stackTrace)
 	require.Contains(s.T(), stackTrace, "cadence/internal.(*decodeFutureImpl).Get")
+}
+
+func (s *internalWorkerTestSuite) TestDecisionTaskHandler() {
+	params := workerExecutionParameters{
+		Identity: "identity",
+		Logger:   getLogger(),
+	}
+	s.testDecisionTaskHandlerHelper(params)
+}
+
+func (s *internalWorkerTestSuite) TestDecisionTaskHandler_WithDataConverter() {
+	params := workerExecutionParameters{
+		Identity:      "identity",
+		Logger:        getLogger(),
+		DataConverter: newTestDataConverter(),
+	}
+	s.testDecisionTaskHandlerHelper(params)
 }
 
 // testSampleWorkflow
@@ -175,7 +190,15 @@ func testActivityMultipleArgs(ctx context.Context, arg1 int, arg2 string, arg3 b
 }
 
 func (s *internalWorkerTestSuite) TestCreateWorker() {
-	worker := createWorkerWithThrottle(s.T(), s.service, float64(500.0))
+	worker := createWorkerWithThrottle(s.service, float64(500.0), nil)
+	err := worker.Start()
+	require.NoError(s.T(), err)
+	time.Sleep(time.Millisecond * 200)
+	worker.Stop()
+}
+
+func (s *internalWorkerTestSuite) TestCreateWorker_WithDataConverter() {
+	worker := createWorkerWithDataConverter(s.service)
 	err := worker.Start()
 	require.NoError(s.T(), err)
 	time.Sleep(time.Millisecond * 200)
@@ -187,7 +210,7 @@ func (s *internalWorkerTestSuite) TestCreateWorkerRun() {
 	mockCtrl := gomock.NewController(s.T())
 	service := workflowservicetest.NewMockClient(mockCtrl)
 
-	worker := createWorker(s.T(), service)
+	worker := createWorker(service)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -203,7 +226,7 @@ func (s *internalWorkerTestSuite) TestCreateWorkerRun() {
 
 func (s *internalWorkerTestSuite) TestNoActivitiesOrWorkflows() {
 	t := s.T()
-	w := createWorker(t, s.service)
+	w := createWorker(s.service)
 	aw := w.(*aggregatedWorker)
 	aw.hostEnv = newHostEnvironment()
 	assert.Empty(t, aw.hostEnv.getRegisteredActivities())
@@ -232,7 +255,7 @@ func (s *internalWorkerTestSuite) TestWorkerStartFailsWithInvalidDomain() {
 				// log
 			}).Times(2)
 
-		worker := createWorker(t, service)
+		worker := createWorker(service)
 		if tc.isErrFatal {
 			err := worker.Start()
 			assert.Error(t, err, "worker.start() MUST fail when domain is invalid")
@@ -272,12 +295,12 @@ func (m *mockPollForActivityTaskRequest) String() string {
 	return "PollForActivityTaskRequest"
 }
 
-func createWorker(t *testing.T, service *workflowservicetest.MockClient) Worker {
-	return createWorkerWithThrottle(t, service, float64(0.0))
+func createWorker(service *workflowservicetest.MockClient) Worker {
+	return createWorkerWithThrottle(service, float64(0.0), nil)
 }
 
 func createWorkerWithThrottle(
-	t *testing.T, service *workflowservicetest.MockClient, activitiesPerSecond float64,
+	service *workflowservicetest.MockClient, activitiesPerSecond float64, dc encoded.DataConverter,
 ) Worker {
 	domain := "testDomain"
 	domainStatus := shared.DomainStatusRegistered
@@ -311,6 +334,9 @@ func createWorkerWithThrottle(
 	workerOptions := WorkerOptions{}
 	workerOptions.WorkerActivitiesPerSecond = 20
 	workerOptions.TaskListActivitiesPerSecond = activitiesPerSecond
+	if dc != nil {
+		workerOptions.DataConverter = dc
+	}
 
 	// Start Worker.
 	worker := NewWorker(
@@ -321,11 +347,15 @@ func createWorkerWithThrottle(
 	return worker
 }
 
-func (s *internalWorkerTestSuite) TestCompleteActivity() {
+func createWorkerWithDataConverter(service *workflowservicetest.MockClient) Worker {
+	return createWorkerWithThrottle(service, float64(0.0), newTestDataConverter())
+}
+
+func (s *internalWorkerTestSuite) testCompleteActivityHelper(opt *ClientOptions) {
 	t := s.T()
 	mockService := s.service
 	domain := "testDomain"
-	wfClient := NewClient(mockService, domain, nil)
+	wfClient := NewClient(mockService, domain, opt)
 	var completedRequest, canceledRequest, failedRequest interface{}
 	mockService.EXPECT().RespondActivityTaskCompleted(gomock.Any(), gomock.Any(), callOptions...).Return(nil).Do(
 		func(ctx context.Context, request *shared.RespondActivityTaskCompletedRequest, opts ...yarpc.CallOption) {
@@ -350,9 +380,18 @@ func (s *internalWorkerTestSuite) TestCompleteActivity() {
 	require.NotNil(t, failedRequest)
 }
 
-func (s *internalWorkerTestSuite) TestCompleteActivityById(t *testing.T) {
-	mockService := s.service
+func (s *internalWorkerTestSuite) TestCompleteActivity() {
+	s.testCompleteActivityHelper(nil)
+}
 
+func (s *internalWorkerTestSuite) TestCompleteActivity_WithDataConverter() {
+	opt := &ClientOptions{DataConverter: newTestDataConverter()}
+	s.testCompleteActivityHelper(opt)
+}
+
+func (s *internalWorkerTestSuite) TestCompleteActivityById() {
+	t := s.T()
+	mockService := s.service
 	domain := "testDomain"
 	wfClient := NewClient(mockService, domain, nil)
 	var completedRequest, canceledRequest, failedRequest interface{}
@@ -399,6 +438,30 @@ func (s *internalWorkerTestSuite) TestRecordActivityHeartbeat() {
 	require.NotNil(s.T(), heartbeatRequest)
 }
 
+func (s *internalWorkerTestSuite) TestRecordActivityHeartbeat_WithDataConverter() {
+	t := s.T()
+	domain := "testDomain"
+	dc := newTestDataConverter()
+	opt := &ClientOptions{DataConverter: dc}
+	wfClient := NewClient(s.service, domain, opt)
+	var heartbeatRequest *shared.RecordActivityTaskHeartbeatRequest
+	cancelRequested := false
+	heartbeatResponse := shared.RecordActivityTaskHeartbeatResponse{CancelRequested: &cancelRequested}
+	detail1 := "testStack"
+	detail2 := testStruct{"abc", 123}
+	detail3 := 4
+	encodedDetail, err := dc.ToData(detail1, detail2, detail3)
+	require.Nil(t, err)
+	s.service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), callOptions...).Return(&heartbeatResponse, nil).
+		Do(func(ctx context.Context, request *shared.RecordActivityTaskHeartbeatRequest, opts ...yarpc.CallOption) {
+			heartbeatRequest = request
+			require.Equal(t, encodedDetail, request.Details)
+		}).Times(1)
+
+	wfClient.RecordActivityHeartbeat(context.Background(), nil, detail1, detail2, detail3)
+	require.NotNil(t, heartbeatRequest)
+}
+
 func (s *internalWorkerTestSuite) TestRecordActivityHeartbeatByID() {
 	domain := "testDomain"
 	wfClient := NewClient(s.service, domain, nil)
@@ -414,50 +477,6 @@ func (s *internalWorkerTestSuite) TestRecordActivityHeartbeatByID() {
 	wfClient.RecordActivityHeartbeatByID(context.Background(), domain, "wid", "rid", "aid",
 		"testStack", "customerObjects", 4)
 	require.NotNil(s.T(), heartbeatRequest)
-}
-
-func testEncodeFunction(t *testing.T, f interface{}, args ...interface{}) string {
-	input, err := getHostEnvironment().Encoder().Marshal(args)
-	require.NoError(t, err, err)
-
-	var result []interface{}
-	for _, v := range args {
-		arg := reflect.New(reflect.TypeOf(v)).Interface()
-		result = append(result, arg)
-	}
-	err = getHostEnvironment().Encoder().Unmarshal(input, result)
-	require.NoError(t, err, err)
-
-	targetArgs := []reflect.Value{}
-	for _, arg := range result {
-		targetArgs = append(targetArgs, reflect.ValueOf(arg).Elem())
-	}
-	fnValue := reflect.ValueOf(f)
-	retValues := fnValue.Call(targetArgs)
-	return retValues[0].Interface().(string)
-}
-
-func (s *internalWorkerTestSuite) TestEncoder() {
-	t := s.T()
-	getHostEnvironment().Encoder().Register(new(emptyCtx))
-	// Two param functor.
-	f1 := func(ctx Context, r []byte) string {
-		return "result"
-	}
-	r1 := testEncodeFunction(t, f1, new(emptyCtx), []byte("test"))
-	require.Equal(t, r1, "result")
-	// No parameters.
-	f2 := func() string {
-		return "empty-result"
-	}
-	r2 := testEncodeFunction(t, f2)
-	require.Equal(t, r2, "empty-result")
-	// Nil parameter.
-	f3 := func(r []byte) string {
-		return "nil-result"
-	}
-	r3 := testEncodeFunction(t, f3, []byte(""))
-	require.Equal(t, r3, "nil-result")
 }
 
 type activitiesCallingOptionsWorkflow struct {
@@ -626,11 +645,27 @@ func testActivityReturnStructPtrPtr() (**testActivityResult, error) {
 }
 
 func TestVariousActivitySchedulingOption(t *testing.T) {
-	ts := &WorkflowTestSuite{}
-	env := ts.NewTestWorkflowEnvironment()
 	w := &activitiesCallingOptionsWorkflow{t: t}
 	RegisterWorkflow(w.Execute)
-	env.ExecuteWorkflow(w.Execute, []byte{1, 2})
+
+	testVariousActivitySchedulingOption(t, w.Execute)
+	testVariousActivitySchedulingOptionWithDataConverter(t, w.Execute)
+}
+
+func testVariousActivitySchedulingOption(t *testing.T, wf interface{}) {
+	ts := &WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+	env.ExecuteWorkflow(wf, []byte{1, 2})
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+}
+
+func testVariousActivitySchedulingOptionWithDataConverter(t *testing.T, wf interface{}) {
+	dc := newTestDataConverter()
+	ts := &WorkflowTestSuite{dataConverter: dc}
+	env := ts.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(WorkerOptions{DataConverter: dc})
+	env.ExecuteWorkflow(wf, []byte{1, 2})
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
 }
@@ -686,15 +721,15 @@ type testErrorDetails struct {
 	T string
 }
 
-func TestActivityErrorWithDetails(t *testing.T) {
+func testActivityErrorWithDetailsHelper(ctx context.Context, t *testing.T, dataConverter encoded.DataConverter) {
 	a1 := activityExecutor{
 		name: "test",
 		fn: func(arg1 int) (err error) {
 			return NewCustomError("testReason", "testStringDetails")
 		}}
-	encResult, e := a1.Execute(context.Background(), testEncodeFunctionArgs(a1.fn, 1))
 
-	err := deSerializeFunctionResult(a1.fn, encResult, nil)
+	encResult, e := a1.Execute(ctx, testEncodeFunctionArgs(dataConverter, a1.fn, 1))
+	err := deSerializeFunctionResult(a1.fn, encResult, nil, dataConverter)
 	require.NoError(t, err)
 	require.Error(t, e)
 	errWD := e.(*CustomError)
@@ -708,8 +743,8 @@ func TestActivityErrorWithDetails(t *testing.T) {
 		fn: func(arg1 int) (err error) {
 			return NewCustomError("testReason", testErrorDetails{T: "testErrorStack"})
 		}}
-	encResult, e = a2.Execute(context.Background(), testEncodeFunctionArgs(a2.fn, 1))
-	err = deSerializeFunctionResult(a2.fn, encResult, nil)
+	encResult, e = a2.Execute(ctx, testEncodeFunctionArgs(dataConverter, a2.fn, 1))
+	err = deSerializeFunctionResult(a2.fn, encResult, nil, dataConverter)
 	require.NoError(t, err)
 	require.Error(t, e)
 	errWD = e.(*CustomError)
@@ -723,9 +758,9 @@ func TestActivityErrorWithDetails(t *testing.T) {
 		fn: func(arg1 int) (result string, err error) {
 			return "testResult", NewCustomError("testReason", testErrorDetails{T: "testErrorStack3"})
 		}}
-	encResult, e = a3.Execute(context.Background(), testEncodeFunctionArgs(a3.fn, 1))
+	encResult, e = a3.Execute(ctx, testEncodeFunctionArgs(dataConverter, a3.fn, 1))
 	var result string
-	err = deSerializeFunctionResult(a3.fn, encResult, &result)
+	err = deSerializeFunctionResult(a3.fn, encResult, &result, dataConverter)
 	require.NoError(t, err)
 	require.Equal(t, "testResult", result)
 	require.Error(t, e)
@@ -739,8 +774,8 @@ func TestActivityErrorWithDetails(t *testing.T) {
 		fn: func(arg1 int) (result string, err error) {
 			return "testResult4", NewCustomError("testReason", "testMultipleString", testErrorDetails{T: "testErrorStack4"})
 		}}
-	encResult, e = a4.Execute(context.Background(), testEncodeFunctionArgs(a4.fn, 1))
-	err = deSerializeFunctionResult(a3.fn, encResult, &result)
+	encResult, e = a4.Execute(ctx, testEncodeFunctionArgs(dataConverter, a4.fn, 1))
+	err = deSerializeFunctionResult(a3.fn, encResult, &result, dataConverter)
 	require.NoError(t, err)
 	require.Equal(t, "testResult4", result)
 	require.Error(t, e)
@@ -752,14 +787,24 @@ func TestActivityErrorWithDetails(t *testing.T) {
 	require.Equal(t, testErrorDetails{T: "testErrorStack4"}, td)
 }
 
-func TestActivityCancelledError(t *testing.T) {
+func TestActivityErrorWithDetails(t *testing.T) {
+	testActivityErrorWithDetailsHelper(context.Background(), t, nil)
+}
+
+func TestActivityErrorWithDetails_WithDataConverter(t *testing.T) {
+	dc := newTestDataConverter()
+	ctx := context.WithValue(context.Background(), activityEnvContextKey, &activityEnvironment{dataConverter: dc})
+	testActivityErrorWithDetailsHelper(ctx, t, dc)
+}
+
+func testActivityCancelledErrorHelper(ctx context.Context, t *testing.T, dataConverter encoded.DataConverter) {
 	a1 := activityExecutor{
 		name: "test",
 		fn: func(arg1 int) (err error) {
 			return NewCanceledError("testCancelStringDetails")
 		}}
-	encResult, e := a1.Execute(context.Background(), testEncodeFunctionArgs(a1.fn, 1))
-	err := deSerializeFunctionResult(a1.fn, encResult, nil)
+	encResult, e := a1.Execute(ctx, testEncodeFunctionArgs(dataConverter, a1.fn, 1))
+	err := deSerializeFunctionResult(a1.fn, encResult, nil, dataConverter)
 	require.NoError(t, err)
 	require.Error(t, e)
 	errWD := e.(*CanceledError)
@@ -772,8 +817,8 @@ func TestActivityCancelledError(t *testing.T) {
 		fn: func(arg1 int) (err error) {
 			return NewCanceledError(testErrorDetails{T: "testCancelErrorStack"})
 		}}
-	encResult, e = a2.Execute(context.Background(), testEncodeFunctionArgs(a2.fn, 1))
-	err = deSerializeFunctionResult(a2.fn, encResult, nil)
+	encResult, e = a2.Execute(ctx, testEncodeFunctionArgs(dataConverter, a2.fn, 1))
+	err = deSerializeFunctionResult(a2.fn, encResult, nil, dataConverter)
 	require.NoError(t, err)
 	require.Error(t, e)
 	errWD = e.(*CanceledError)
@@ -786,9 +831,9 @@ func TestActivityCancelledError(t *testing.T) {
 		fn: func(arg1 int) (result string, err error) {
 			return "testResult", NewCanceledError(testErrorDetails{T: "testErrorStack3"})
 		}}
-	encResult, e = a3.Execute(context.Background(), testEncodeFunctionArgs(a2.fn, 1))
+	encResult, e = a3.Execute(ctx, testEncodeFunctionArgs(dataConverter, a2.fn, 1))
 	var r string
-	err = deSerializeFunctionResult(a3.fn, encResult, &r)
+	err = deSerializeFunctionResult(a3.fn, encResult, &r, dataConverter)
 	require.NoError(t, err)
 	require.Equal(t, "testResult", r)
 	require.Error(t, e)
@@ -801,8 +846,8 @@ func TestActivityCancelledError(t *testing.T) {
 		fn: func(arg1 int) (result string, err error) {
 			return "testResult4", NewCanceledError("testMultipleString", testErrorDetails{T: "testErrorStack4"})
 		}}
-	encResult, e = a4.Execute(context.Background(), testEncodeFunctionArgs(a2.fn, 1))
-	err = deSerializeFunctionResult(a3.fn, encResult, &r)
+	encResult, e = a4.Execute(ctx, testEncodeFunctionArgs(dataConverter, a2.fn, 1))
+	err = deSerializeFunctionResult(a3.fn, encResult, &r, dataConverter)
 	require.NoError(t, err)
 	require.Equal(t, "testResult4", r)
 	require.Error(t, e)
@@ -813,15 +858,25 @@ func TestActivityCancelledError(t *testing.T) {
 	require.Equal(t, testErrorDetails{T: "testErrorStack4"}, td)
 }
 
-func TestActivityExecutionVariousTypes(t *testing.T) {
+func TestActivityCancelledError(t *testing.T) {
+	testActivityCancelledErrorHelper(context.Background(), t, nil)
+}
+
+func TestActivityCancelledError_WithDataConverter(t *testing.T) {
+	dc := newTestDataConverter()
+	ctx := context.WithValue(context.Background(), activityEnvContextKey, &activityEnvironment{dataConverter: dc})
+	testActivityCancelledErrorHelper(ctx, t, dc)
+}
+
+func testActivityExecutionVariousTypesHelper(ctx context.Context, t *testing.T, dataConverter encoded.DataConverter) {
 	a1 := activityExecutor{
 		fn: func(ctx context.Context, arg1 string) (*testWorkflowResult, error) {
 			return &testWorkflowResult{V: 1}, nil
 		}}
-	encResult, e := a1.Execute(context.Background(), testEncodeFunctionArgs(a1.fn, "test"))
+	encResult, e := a1.Execute(ctx, testEncodeFunctionArgs(dataConverter, a1.fn, "test"))
 	require.NoError(t, e)
 	var r *testWorkflowResult
-	err := deSerializeFunctionResult(a1.fn, encResult, &r)
+	err := deSerializeFunctionResult(a1.fn, encResult, &r, dataConverter)
 	require.NoError(t, err)
 	require.Equal(t, 1, r.V)
 
@@ -829,11 +884,23 @@ func TestActivityExecutionVariousTypes(t *testing.T) {
 		fn: func(ctx context.Context, arg1 *testWorkflowResult) (*testWorkflowResult, error) {
 			return &testWorkflowResult{V: 2}, nil
 		}}
-	encResult, e = a2.Execute(context.Background(), testEncodeFunctionArgs(a2.fn, r))
+	encResult, e = a2.Execute(ctx, testEncodeFunctionArgs(dataConverter, a2.fn, r))
 	require.NoError(t, e)
-	err = deSerializeFunctionResult(a2.fn, encResult, &r)
+	err = deSerializeFunctionResult(a2.fn, encResult, &r, dataConverter)
 	require.NoError(t, err)
 	require.Equal(t, 2, r.V)
+}
+
+func TestActivityExecutionVariousTypes(t *testing.T) {
+	testActivityExecutionVariousTypesHelper(context.Background(), t, nil)
+}
+
+func TestActivityExecutionVariousTypes_WithDataConverter(t *testing.T) {
+	dc := newTestDataConverter()
+	ctx := context.WithValue(context.Background(), activityEnvContextKey, &activityEnvironment{
+		dataConverter: dc,
+	})
+	testActivityExecutionVariousTypesHelper(ctx, t, dc)
 }
 
 type encodingTest struct {
@@ -841,17 +908,7 @@ type encodingTest struct {
 	input    []interface{}
 }
 
-// duplicate of GetHostEnvironment().registerType()
-func testRegisterType(enc encoding, v interface{}) error {
-	t := reflect.Indirect(reflect.ValueOf(v)).Type()
-	if t.Kind() == reflect.Interface || t.Kind() == reflect.Ptr {
-		return nil
-	}
-	arg := reflect.Zero(t).Interface()
-	return enc.Register(arg)
-}
-
-func Test_ActivityNilArgs(t *testing.T) {
+func TestActivityNilArgs(t *testing.T) {
 	nilErr := errors.New("nils")
 	activityFn := func(name string, idx int, strptr *string) error {
 		if name == "" && idx == 0 && strptr == nil {
@@ -861,14 +918,28 @@ func Test_ActivityNilArgs(t *testing.T) {
 	}
 
 	args := []interface{}{nil, nil, nil}
-	_, input, err := getValidatedActivityFunction(activityFn, args)
+	_, input, err := getValidatedActivityFunction(activityFn, args, nil)
 	require.NoError(t, err)
 
-	reflectArgs, err := getHostEnvironment().decodeArgs(reflect.TypeOf(activityFn), input)
+	reflectArgs, err := decodeArgs(nil, reflect.TypeOf(activityFn), input)
 	require.NoError(t, err)
 
 	reflectResults := reflect.ValueOf(activityFn).Call(reflectArgs)
 	require.Equal(t, nilErr, reflectResults[0].Interface())
+}
+
+func TestActivityNilArgs_WithDataConverter(t *testing.T) {
+	nilErr := errors.New("nils")
+	activityFn := func(name string, idx int, strptr *string) error {
+		if name == "" && idx == 0 && strptr == nil {
+			return nilErr
+		}
+		return nil
+	}
+
+	args := []interface{}{nil, nil, nil}
+	_, _, err := getValidatedActivityFunction(activityFn, args, newTestDataConverter())
+	require.Error(t, err) // testDataConverter cannot encode nil value
 }
 
 /*
@@ -921,16 +992,92 @@ func _TestThriftEncoding(t *testing.T) {
 */
 
 // Encode function args
-func testEncodeFunctionArgs(workflowFunc interface{}, args ...interface{}) []byte {
-	err := getHostEnvironment().RegisterFnType(reflect.TypeOf(workflowFunc))
-	if err != nil {
-		fmt.Println(err)
-		panic("Failed to register function types")
-	}
-	input, err := getHostEnvironment().encodeArgs(args)
+func testEncodeFunctionArgs(dataConverter encoded.DataConverter, workflowFunc interface{}, args ...interface{}) []byte {
+	input, err := encodeArgs(dataConverter, args)
 	if err != nil {
 		fmt.Println(err)
 		panic("Failed to encode arguments")
 	}
 	return input
+}
+
+func testDataConverterFunction(t *testing.T, dc encoded.DataConverter, f interface{}, args ...interface{}) string {
+	input, err := dc.ToData(args...)
+	require.NoError(t, err, err)
+
+	var result []interface{}
+	for _, v := range args {
+		arg := reflect.New(reflect.TypeOf(v)).Interface()
+		result = append(result, arg)
+	}
+	err = dc.FromData(input, result...)
+	require.NoError(t, err, err)
+
+	targetArgs := []reflect.Value{}
+	for _, arg := range result {
+		targetArgs = append(targetArgs, reflect.ValueOf(arg).Elem())
+	}
+	fnValue := reflect.ValueOf(f)
+	retValues := fnValue.Call(targetArgs)
+	return retValues[0].Interface().(string)
+}
+
+func testDataConverterHelper(t *testing.T, dc encoded.DataConverter) {
+	f1 := func(ctx Context, r []byte) string {
+		return "result"
+	}
+	r1 := testDataConverterFunction(t, dc, f1, new(emptyCtx), []byte("test"))
+	require.Equal(t, r1, "result")
+	// No parameters.
+	f2 := func() string {
+		return "empty-result"
+	}
+	r2 := testDataConverterFunction(t, dc, f2)
+	require.Equal(t, r2, "empty-result")
+	// Nil parameter.
+	f3 := func(r []byte) string {
+		return "nil-result"
+	}
+	r3 := testDataConverterFunction(t, dc, f3, []byte(""))
+	require.Equal(t, r3, "nil-result")
+}
+
+func TestDefaultDataConverter(t *testing.T) {
+	dc := newDefaultDataConverter()
+	testDataConverterHelper(t, dc)
+}
+
+// testDataConverter implements encoded.DataConverter using gob
+type testDataConverter struct{}
+
+func newTestDataConverter() encoded.DataConverter {
+	return &testDataConverter{}
+}
+
+func (tdc *testDataConverter) ToData(value ...interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	for i, obj := range value {
+		if err := enc.Encode(obj); err != nil {
+			return nil, fmt.Errorf(
+				"unable to encode argument: %d, %v, with gob error: %v", i, reflect.TypeOf(obj), err)
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+func (tdc *testDataConverter) FromData(input []byte, valuePtr ...interface{}) error {
+	dec := gob.NewDecoder(bytes.NewBuffer(input))
+	for i, obj := range valuePtr {
+		if err := dec.Decode(obj); err != nil {
+			return fmt.Errorf(
+				"unable to decode argument: %d, %v, with gob error: %v", i, reflect.TypeOf(obj), err)
+		}
+	}
+	return nil
+}
+
+func TestTestDataConverter(t *testing.T) {
+	dc := newTestDataConverter()
+	testDataConverterHelper(t, dc)
 }

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -96,13 +96,14 @@ type (
 	receiveCallback func(v interface{}, more bool) bool
 
 	channelImpl struct {
-		name            string              // human readable channel name
-		size            int                 // Channel buffer size. 0 for non buffered.
-		buffer          []interface{}       // buffered messages
-		blockedSends    []valueCallbackPair // puts waiting when buffer is full.
-		blockedReceives []receiveCallback   // receives waiting when no messages are available.
-		closed          bool                // true if channel is closed.
-		recValue        *interface{}        // Used only while receiving value, this is used as pre-fetch buffer value from the channel.
+		name            string                // human readable channel name
+		size            int                   // Channel buffer size. 0 for non buffered.
+		buffer          []interface{}         // buffered messages
+		blockedSends    []valueCallbackPair   // puts waiting when buffer is full.
+		blockedReceives []receiveCallback     // receives waiting when no messages are available.
+		closed          bool                  // true if channel is closed.
+		recValue        *interface{}          // Used only while receiving value, this is used as pre-fetch buffer value from the channel.
+		dataConverter   encoded.DataConverter // for decode data
 	}
 
 	// Single case statement of the Select
@@ -164,6 +165,7 @@ type (
 		signalChannels                      map[string]SignalChannel
 		queryHandlers                       map[string]func([]byte) ([]byte, error)
 		workflowIDReusePolicy               WorkflowIDReusePolicy
+		dataConverter                       encoded.DataConverter
 	}
 
 	// decodeFutureImpl
@@ -195,8 +197,9 @@ type (
 	}
 
 	queryHandler struct {
-		fn        interface{}
-		queryType string
+		fn            interface{}
+		queryType     string
+		dataConverter encoded.DataConverter
 	}
 )
 
@@ -355,6 +358,7 @@ func newWorkflowContext(env workflowEnvironment) Context {
 	rootCtx = WithExecutionStartToCloseTimeout(rootCtx, time.Duration(wInfo.ExecutionStartToCloseTimeoutSeconds)*time.Second)
 	rootCtx = WithWorkflowTaskStartToCloseTimeout(rootCtx, time.Duration(wInfo.TaskStartToCloseTimeoutSeconds)*time.Second)
 	rootCtx = WithTaskList(rootCtx, wInfo.TaskListName)
+	rootCtx = WithWorkflowDataConverter(rootCtx, env.GetDataConverter())
 	return rootCtx
 }
 
@@ -484,21 +488,21 @@ func getState(ctx Context) *coroutineState {
 func (c *channelImpl) ReceiveEncodedValue(ctx Context) (value encoded.Value, more bool) {
 	var blob []byte
 	more = c.Receive(ctx, &blob)
-	value = EncodedValue(blob)
+	value = newEncodedValue(blob, c.dataConverter)
 	return
 }
 
 func (c *channelImpl) ReceiveEncodedValueAsync() (value encoded.Value, ok bool) {
 	var blob []byte
 	ok = c.ReceiveAsync(&blob)
-	value = EncodedValue(blob)
+	value = newEncodedValue(blob, c.dataConverter)
 	return
 }
 
 func (c *channelImpl) ReceiveEncodedValueAsyncWithMoreFlag() (value encoded.Value, ok bool, more bool) {
 	var blob []byte
 	ok, more = c.ReceiveAsyncWithMoreFlag(&blob)
-	value = EncodedValue(blob)
+	value = newEncodedValue(blob, c.dataConverter)
 	return
 }
 
@@ -636,7 +640,7 @@ func (c *channelImpl) Close() {
 
 // Takes a value and assigns that 'to' value.
 func (c *channelImpl) assignValue(from interface{}, to interface{}) {
-	err := getHostEnvironment().decodeAndAssignValue(from, to)
+	err := decodeAndAssignValue(c.dataConverter, from, to)
 	if err != nil {
 		panic(err)
 	}
@@ -993,7 +997,7 @@ func newWorkflowDefinition(workflow workflow) workflowDefinition {
 	return &syncWorkflowDefinition{workflow: workflow}
 }
 
-func getValidatedWorkflowFunction(workflowFunc interface{}, args []interface{}) (*WorkflowType, []byte, error) {
+func getValidatedWorkflowFunction(workflowFunc interface{}, args []interface{}, dataConverter encoded.DataConverter) (*WorkflowType, []byte, error) {
 	fnName := ""
 	fType := reflect.TypeOf(workflowFunc)
 	switch getKind(fType) {
@@ -1015,7 +1019,10 @@ func getValidatedWorkflowFunction(workflowFunc interface{}, args []interface{}) 
 			workflowFunc)
 	}
 
-	input, err := getHostEnvironment().encodeArgs(args)
+	if dataConverter == nil {
+		dataConverter = newDefaultDataConverter()
+	}
+	input, err := encodeArgs(dataConverter, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1067,7 +1074,18 @@ func setWorkflowEnvOptionsIfNotExist(ctx Context) Context {
 		newOptions.signalChannels = make(map[string]SignalChannel)
 		newOptions.queryHandlers = make(map[string]func([]byte) ([]byte, error))
 	}
+	if newOptions.dataConverter == nil {
+		newOptions.dataConverter = newDefaultDataConverter()
+	}
 	return WithValue(ctx, workflowEnvOptionsContextKey, &newOptions)
+}
+
+func getDataConverterFromWorkflowContext(ctx Context) encoded.DataConverter {
+	options := getWorkflowEnvOptions(ctx)
+	if options == nil || options.dataConverter == nil {
+		return newDefaultDataConverter()
+	}
+	return options.dataConverter
 }
 
 // getSignalChannel finds the assosciated channel for the signal.
@@ -1110,7 +1128,7 @@ func (d *decodeFutureImpl) Get(ctx Context, value interface{}) error {
 		return errors.New("value parameter is not a pointer")
 	}
 
-	err := deSerializeFunctionResult(d.fn, d.futureImpl.value.([]byte), value)
+	err := deSerializeFunctionResult(d.fn, d.futureImpl.value.([]byte), value, getDataConverterFromWorkflowContext(ctx))
 	if err != nil {
 		return err
 	}
@@ -1142,7 +1160,7 @@ func newDecodeFuture(ctx Context, fn interface{}) (Future, Settable) {
 
 // setQueryHandler sets query handler for given queryType.
 func setQueryHandler(ctx Context, queryType string, handler interface{}) error {
-	qh := &queryHandler{fn: handler, queryType: queryType}
+	qh := &queryHandler{fn: handler, queryType: queryType, dataConverter: getDataConverterFromWorkflowContext(ctx)}
 	err := qh.validateHandlerFn()
 	if err != nil {
 		return err
@@ -1199,7 +1217,7 @@ func (h *queryHandler) execute(input []byte) (result []byte, err error) {
 	if fnType.NumIn() == 1 && isTypeByteSlice(fnType.In(0)) {
 		args = append(args, reflect.ValueOf(input))
 	} else {
-		decoded, err := getHostEnvironment().decodeArgs(fnType, input)
+		decoded, err := decodeArgs(h.dataConverter, fnType, input)
 		if err != nil {
 			return nil, fmt.Errorf("unable to decode the input for queryType: %v, with error: %v", h.queryType, err)
 		}
@@ -1213,7 +1231,7 @@ func (h *queryHandler) execute(input []byte) (result []byte, err error) {
 	// we already verified (in validateHandlerFn()) that the query handler returns 2 values
 	retValue := retValues[0]
 	if retValue.Kind() != reflect.Ptr || !retValue.IsNil() {
-		result, err = getHostEnvironment().encodeArg(retValue.Interface())
+		result, err = encodeArg(h.dataConverter, retValue.Interface())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -52,6 +52,7 @@ type (
 		domain          string
 		metricsScope    *metrics.TaggedScope
 		identity        string
+		dataConverter   encoded.DataConverter
 	}
 
 	// domainClient is the client for managing domains.
@@ -82,10 +83,11 @@ type (
 
 	// workflowRunImpl is an implementation of WorkflowRun
 	workflowRunImpl struct {
-		workflowFn   interface{}
-		firstRunID   string
-		currentRunID string
-		iterFn       func(ctx context.Context, runID string) HistoryEventIterator
+		workflowFn    interface{}
+		firstRunID    string
+		currentRunID  string
+		iterFn        func(ctx context.Context, runID string) HistoryEventIterator
+		dataConverter encoded.DataConverter
 	}
 
 	// HistoryEventIterator represents the interface for
@@ -154,7 +156,7 @@ func (wc *workflowClient) StartWorkflow(
 	}
 
 	// Validate type and its arguments.
-	workflowType, input, err := getValidatedWorkflowFunction(workflowFunc, args)
+	workflowType, input, err := getValidatedWorkflowFunction(workflowFunc, args, wc.dataConverter)
 	if err != nil {
 		return nil, err
 	}
@@ -230,16 +232,17 @@ func (wc *workflowClient) ExecuteWorkflow(ctx context.Context, options StartWork
 	}
 
 	return &workflowRunImpl{
-		workflowFn:   workflow,
-		firstRunID:   runID,
-		currentRunID: runID,
-		iterFn:       iterFn,
+		workflowFn:    workflow,
+		firstRunID:    runID,
+		currentRunID:  runID,
+		iterFn:        iterFn,
+		dataConverter: wc.dataConverter,
 	}, nil
 }
 
 // SignalWorkflow signals a workflow in execution.
 func (wc *workflowClient) SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error {
-	input, err := getEncodedArg(arg)
+	input, err := encodeArg(wc.dataConverter, arg)
 	if err != nil {
 		return err
 	}
@@ -268,7 +271,7 @@ func (wc *workflowClient) SignalWorkflow(ctx context.Context, workflowID string,
 func (wc *workflowClient) SignalWithStartWorkflow(ctx context.Context, workflowID string, signalName string, signalArg interface{},
 	options StartWorkflowOptions, workflowFunc interface{}, workflowArgs ...interface{}) (*WorkflowExecution, error) {
 
-	signalInput, err := getEncodedArg(signalArg)
+	signalInput, err := encodeArg(wc.dataConverter, signalArg)
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +298,7 @@ func (wc *workflowClient) SignalWithStartWorkflow(ctx context.Context, workflowI
 	}
 
 	// Validate type and its arguments.
-	workflowType, input, err := getValidatedWorkflowFunction(workflowFunc, workflowArgs)
+	workflowType, input, err := getValidatedWorkflowFunction(workflowFunc, workflowArgs, wc.dataConverter)
 	if err != nil {
 		return nil, err
 	}
@@ -437,12 +440,12 @@ func (wc *workflowClient) CompleteActivity(ctx context.Context, taskToken []byte
 	var data []byte
 	if result != nil {
 		var err0 error
-		data, err0 = getHostEnvironment().encodeArg(result)
+		data, err0 = encodeArg(wc.dataConverter, result)
 		if err0 != nil {
 			return err0
 		}
 	}
-	request := convertActivityResultToRespondRequest(wc.identity, taskToken, data, err)
+	request := convertActivityResultToRespondRequest(wc.identity, taskToken, data, err, wc.dataConverter)
 	return reportActivityComplete(ctx, wc.workflowService, request, wc.metricsScope)
 }
 
@@ -458,19 +461,19 @@ func (wc *workflowClient) CompleteActivityByID(ctx context.Context, domain, work
 	var data []byte
 	if result != nil {
 		var err0 error
-		data, err0 = getHostEnvironment().encodeArg(result)
+		data, err0 = encodeArg(wc.dataConverter, result)
 		if err0 != nil {
 			return err0
 		}
 	}
 
-	request := convertActivityResultToRespondRequestByID(wc.identity, domain, workflowID, runID, activityID, data, err)
+	request := convertActivityResultToRespondRequestByID(wc.identity, domain, workflowID, runID, activityID, data, err, wc.dataConverter)
 	return reportActivityCompleteByID(ctx, wc.workflowService, request, wc.metricsScope)
 }
 
 // RecordActivityHeartbeat records heartbeat for an activity.
 func (wc *workflowClient) RecordActivityHeartbeat(ctx context.Context, taskToken []byte, details ...interface{}) error {
-	data, err := getHostEnvironment().encodeArgs(details)
+	data, err := encodeArgs(wc.dataConverter, details)
 	if err != nil {
 		return err
 	}
@@ -480,7 +483,7 @@ func (wc *workflowClient) RecordActivityHeartbeat(ctx context.Context, taskToken
 // RecordActivityHeartbeatByID records heartbeat for an activity.
 func (wc *workflowClient) RecordActivityHeartbeatByID(ctx context.Context,
 	domain, workflowID, runID, activityID string, details ...interface{}) error {
-	data, err := getHostEnvironment().encodeArgs(details)
+	data, err := encodeArgs(wc.dataConverter, details)
 	if err != nil {
 		return err
 	}
@@ -579,7 +582,7 @@ func (wc *workflowClient) QueryWorkflow(ctx context.Context, workflowID string, 
 	var input []byte
 	if len(args) > 0 {
 		var err error
-		if input, err = getHostEnvironment().encodeArgs(args); err != nil {
+		if input, err = encodeArgs(wc.dataConverter, args); err != nil {
 			return nil, err
 		}
 	}
@@ -608,7 +611,7 @@ func (wc *workflowClient) QueryWorkflow(ctx context.Context, workflowID string, 
 		return nil, err
 	}
 
-	return EncodedValue(resp.QueryResult), nil
+	return newEncodedValue(resp.QueryResult, wc.dataConverter), nil
 }
 
 // DescribeTaskList returns information about the target tasklist, right now this API returns the
@@ -787,13 +790,14 @@ func (workflowRun *workflowRunImpl) Get(ctx context.Context, valuePtr interface{
 		if rf.Type().Kind() != reflect.Ptr {
 			return errors.New("value parameter is not a pointer")
 		}
-		err = deSerializeFunctionResult(workflowRun.workflowFn, attributes.Result, valuePtr)
+		err = deSerializeFunctionResult(workflowRun.workflowFn, attributes.Result, valuePtr, workflowRun.dataConverter)
 	case s.EventTypeWorkflowExecutionFailed:
 		attributes := closeEvent.WorkflowExecutionFailedEventAttributes
-		err = constructError(attributes.GetReason(), attributes.Details)
+		err = constructError(attributes.GetReason(), attributes.Details, workflowRun.dataConverter)
 	case s.EventTypeWorkflowExecutionCanceled:
 		attributes := closeEvent.WorkflowExecutionCanceledEventAttributes
-		err = NewCanceledError(attributes.Details)
+		details := newEncodedValues(attributes.Details, workflowRun.dataConverter)
+		err = NewCanceledError(details)
 	case s.EventTypeWorkflowExecutionTerminated:
 		err = newTerminatedError()
 	case s.EventTypeWorkflowExecutionTimedOut:
@@ -807,15 +811,4 @@ func (workflowRun *workflowRunImpl) Get(ctx context.Context, valuePtr interface{
 		err = fmt.Errorf("Unexpected event type %s when handling workflow execution result", closeEvent.GetEventType())
 	}
 	return err
-}
-
-func getEncodedArg(arg interface{}) ([]byte, error) {
-	var input []byte
-	if arg != nil {
-		var err error
-		if input, err = getHostEnvironment().encodeArg(arg); err != nil {
-			return nil, err
-		}
-	}
-	return input, nil
 }

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -187,12 +187,11 @@ func (s *workflowRunSuite) SetupTest() {
 	s.workflowServiceClient = workflowservicetest.NewMockClient(s.mockCtrl)
 
 	metricsScope := metrics.NewTaggedScope(nil)
-	s.workflowClient = &workflowClient{
-		workflowService: s.workflowServiceClient,
-		domain:          domain,
-		metricsScope:    metricsScope,
-		identity:        identity,
+	options := &ClientOptions{
+		MetricsScope: metricsScope,
+		Identity:     identity,
 	}
+	s.workflowClient = NewClient(s.workflowServiceClient, domain, options)
 }
 
 func (s *workflowRunSuite) TearDownTest() {
@@ -208,7 +207,7 @@ func (s *workflowRunSuite) TestExecuteWorkflow_NoDup_Success() {
 	filterType := shared.HistoryEventFilterTypeCloseEvent
 	eventType := shared.EventTypeWorkflowExecutionCompleted
 	workflowResult := time.Hour * 59
-	encodedResult, _ := getHostEnvironment().encodeArg(workflowResult)
+	encodedResult, _ := encodeArg(newDefaultDataConverter(), workflowResult)
 	getRequest := getGetWorkflowExecutionHistoryRequest(filterType)
 	getResponse := &shared.GetWorkflowExecutionHistoryResponse{
 		History: &shared.History{
@@ -252,7 +251,7 @@ func (s *workflowRunSuite) TestExecuteWorkflow_NoDup_Cancelled() {
 	filterType := shared.HistoryEventFilterTypeCloseEvent
 	eventType := shared.EventTypeWorkflowExecutionCanceled
 	details := "some details"
-	encodedDetails, _ := getHostEnvironment().encodeArg(details)
+	encodedDetails, _ := encodeArg(newDefaultDataConverter(), details)
 	getRequest := getGetWorkflowExecutionHistoryRequest(filterType)
 	getResponse := &shared.GetWorkflowExecutionHistoryResponse{
 		History: &shared.History{
@@ -299,7 +298,8 @@ func (s *workflowRunSuite) TestExecuteWorkflow_NoDup_Failed() {
 	eventType := shared.EventTypeWorkflowExecutionFailed
 	reason := "some reason"
 	details := "some details"
-	encodedDetails, _ := getHostEnvironment().encodeArg(details)
+	dataConverter := newDefaultDataConverter()
+	encodedDetails, _ := encodeArg(dataConverter, details)
 	getRequest := getGetWorkflowExecutionHistoryRequest(filterType)
 	getResponse := &shared.GetWorkflowExecutionHistoryResponse{
 		History: &shared.History{
@@ -331,7 +331,7 @@ func (s *workflowRunSuite) TestExecuteWorkflow_NoDup_Failed() {
 	s.Equal(workflowRun.GetRunID(), runID)
 	decodedResult := time.Minute
 	err = workflowRun.Get(context.Background(), &decodedResult)
-	s.Equal(constructError(reason, encodedDetails), err)
+	s.Equal(constructError(reason, encodedDetails, dataConverter), err)
 	s.Equal(time.Minute, decodedResult)
 }
 
@@ -447,7 +447,7 @@ func (s *workflowRunSuite) TestExecuteWorkflow_NoDup_ContinueAsNew() {
 	s.workflowServiceClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), getRequest1, gomock.Any(), gomock.Any(), gomock.Any()).Return(getResponse1, nil).Times(1)
 
 	workflowResult := time.Hour * 59
-	encodedResult, _ := getHostEnvironment().encodeArg(workflowResult)
+	encodedResult, _ := encodeArg(newDefaultDataConverter(), workflowResult)
 	eventType2 := shared.EventTypeWorkflowExecutionCompleted
 	getRequest2 := getGetWorkflowExecutionHistoryRequest(filterType)
 	getRequest2.Execution.RunId = common.StringPtr(newRunID)
@@ -579,6 +579,65 @@ func (s *workflowClientTestSuite) TestSignalWithStartWorkflow_Error() {
 	s.service.EXPECT().SignalWithStartWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).Return(createResponse, nil)
 	resp, err = s.client.SignalWithStartWorkflow(context.Background(), workflowID, signalName, signalInput,
 		options, workflowType)
+	s.Nil(err)
+	s.Equal(createResponse.GetRunId(), resp.RunID)
+}
+
+func (s *workflowClientTestSuite) TestStartWorkflow() {
+	client, ok := s.client.(*workflowClient)
+	s.True(ok)
+	options := StartWorkflowOptions{
+		ID:                              workflowID,
+		TaskList:                        tasklist,
+		ExecutionStartToCloseTimeout:    timeoutInSeconds,
+		DecisionTaskStartToCloseTimeout: timeoutInSeconds,
+	}
+	f1 := func(ctx Context, r []byte) string {
+		return "result"
+	}
+
+	createResponse := &shared.StartWorkflowExecutionResponse{
+		RunId: common.StringPtr(runID),
+	}
+	s.service.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).Return(createResponse, nil)
+
+	resp, err := client.StartWorkflow(context.Background(), options, f1, []byte("test"))
+	s.Equal(newDefaultDataConverter(), client.dataConverter)
+	s.Nil(err)
+	s.Equal(createResponse.GetRunId(), resp.RunID)
+}
+
+func (s *workflowClientTestSuite) TestStartWorkflow_WithDataConverter() {
+	dc := newTestDataConverter()
+	s.client = NewClient(s.service, domain, &ClientOptions{DataConverter: dc})
+	client, ok := s.client.(*workflowClient)
+	s.True(ok)
+	options := StartWorkflowOptions{
+		ID:                              workflowID,
+		TaskList:                        tasklist,
+		ExecutionStartToCloseTimeout:    timeoutInSeconds,
+		DecisionTaskStartToCloseTimeout: timeoutInSeconds,
+	}
+	f1 := func(ctx Context, r []byte) string {
+		return "result"
+	}
+	input := []byte("test")
+
+	createResponse := &shared.StartWorkflowExecutionResponse{
+		RunId: common.StringPtr(runID),
+	}
+	s.service.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).Return(createResponse, nil).
+		Do(func(_ interface{}, req *shared.StartWorkflowExecutionRequest, _ ...interface{}) {
+			dc := client.dataConverter
+			encodedArg, _ := dc.ToData(input)
+			s.Equal(req.Input, encodedArg)
+			var decodedArg []byte
+			dc.FromData(req.Input, &decodedArg)
+			s.Equal(input, decodedArg)
+		})
+
+	resp, err := client.StartWorkflow(context.Background(), options, f1, input)
+	s.Equal(newTestDataConverter(), client.dataConverter)
 	s.Nil(err)
 	s.Equal(createResponse.GetRunId(), resp.RunID)
 }

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -82,6 +82,27 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityMockFunction() {
 	env.AssertExpectations(s.T())
 }
 
+func (s *WorkflowTestSuiteUnitTest) Test_ActivityMockFunction_WithDataConverter() {
+	mockActivity := func(ctx context.Context, msg string) (string, error) {
+		return "mock_" + msg, nil
+	}
+
+	s.SetDataConverter(newTestDataConverter())
+	env := s.NewTestWorkflowEnvironment()
+	env.OnActivity(testActivityHello, mock.Anything, mock.Anything).Return(mockActivity).Once()
+
+	env.ExecuteWorkflow(testWorkflowHello)
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	var result string
+	env.GetWorkflowResult(&result)
+	s.Equal("mock_world", result)
+	env.AssertExpectations(s.T())
+	// set back to default to not affect other tests
+	s.SetDataConverter(newDefaultDataConverter())
+}
+
 func (s *WorkflowTestSuiteUnitTest) Test_ActivityMockValues() {
 	env := s.NewTestWorkflowEnvironment()
 	env.OnActivity(testActivityHello, mock.Anything, mock.Anything).Return("mock_value", nil).Once()

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -27,6 +27,7 @@ import (
 	"github.com/uber-go/tally"
 
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
+	"go.uber.org/cadence/encoded"
 	"go.uber.org/zap"
 )
 
@@ -131,6 +132,10 @@ type (
 		// Optional: sets context for activity. The context can be used to pass any configuration to activity
 		// like common logger for all activities.
 		BackgroundActivityContext context.Context
+
+		// Optional: sets DataConverter to customize serialization/deserialization of arguments in Cadence
+		// default: defaultDataConverter, an combination of thriftEncoder and jsonEncoder
+		DataConverter encoded.DataConverter
 	}
 )
 

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -155,8 +155,10 @@ type (
 	}
 
 	// EncodedValue is type alias used to encapsulate/extract encoded result from workflow/activity.
-	EncodedValue []byte
-
+	EncodedValue struct {
+		value         []byte
+		dataConverter encoded.DataConverter
+	}
 	// Version represents a change version. See GetVersion call.
 	Version int
 
@@ -262,18 +264,18 @@ func NewChannel(ctx Context) Channel {
 // NewNamedChannel create new Channel instance with a given human readable name.
 // Name appears in stack traces that are blocked on this channel.
 func NewNamedChannel(ctx Context, name string) Channel {
-	return &channelImpl{name: name}
+	return &channelImpl{name: name, dataConverter: getDataConverterFromWorkflowContext(ctx)}
 }
 
 // NewBufferedChannel create new buffered Channel instance
 func NewBufferedChannel(ctx Context, size int) Channel {
-	return &channelImpl{size: size}
+	return &channelImpl{size: size, dataConverter: getDataConverterFromWorkflowContext(ctx)}
 }
 
 // NewNamedBufferedChannel create new BufferedChannel instance with a given human readable name.
 // Name appears in stack traces that are blocked on this Channel.
 func NewNamedBufferedChannel(ctx Context, name string, size int) Channel {
-	return &channelImpl{name: name, size: size}
+	return &channelImpl{name: name, size: size, dataConverter: getDataConverterFromWorkflowContext(ctx)}
 }
 
 // NewSelector creates a new Selector instance.
@@ -334,8 +336,9 @@ func NewFuture(ctx Context) (Future, Settable) {
 // ExecuteActivity returns Future with activity result or failure.
 func ExecuteActivity(ctx Context, activity interface{}, args ...interface{}) Future {
 	// Validate type and its arguments.
+	dataConverter := getDataConverterFromWorkflowContext(ctx)
 	future, settable := newDecodeFuture(ctx, activity)
-	activityType, input, err := getValidatedActivityFunction(activity, args)
+	activityType, input, err := getValidatedActivityFunction(activity, args, dataConverter)
 	if err != nil {
 		settable.Set(nil, err)
 		return future
@@ -457,7 +460,7 @@ func ExecuteChildWorkflow(ctx Context, childWorkflow interface{}, args ...interf
 		decodeFutureImpl: mainFuture.(*decodeFutureImpl),
 		executionFuture:  executionFuture.(*futureImpl),
 	}
-	wfType, input, err := getValidatedWorkflowFunction(childWorkflow, args)
+	wfType, input, err := getValidatedWorkflowFunction(childWorkflow, args, getWorkflowEnvOptions(ctx).dataConverter)
 	if err != nil {
 		executionSettable.Set(nil, err)
 		mainSettable.Set(nil, err)
@@ -646,7 +649,7 @@ func signalExternalWorkflow(ctx Context, workflowID, runID, signalName string, a
 		return future
 	}
 
-	input, err := getEncodedArg(arg)
+	input, err := encodeArg(options.dataConverter, arg)
 	if err != nil {
 		settable.Set(nil, err)
 		return future
@@ -733,22 +736,39 @@ func WithWorkflowTaskStartToCloseTimeout(ctx Context, d time.Duration) Context {
 	return ctx1
 }
 
+// WithWorkflowDataConverter adds DataConverter to the context.
+func WithWorkflowDataConverter(ctx Context, dc encoded.DataConverter) Context {
+	if dc == nil {
+		panic("data converter is nil for WithWorkflowDataConverter")
+	}
+	ctx1 := setWorkflowEnvOptionsIfNotExist(ctx)
+	getWorkflowEnvOptions(ctx1).dataConverter = dc
+	return ctx1
+}
+
 // GetSignalChannel returns channel corresponding to the signal name.
 func GetSignalChannel(ctx Context, signalName string) SignalChannel {
 	return getWorkflowEnvOptions(ctx).getSignalChannel(ctx, signalName)
 }
 
+func newEncodedValue(value []byte, dc encoded.DataConverter) encoded.Value {
+	if dc == nil {
+		dc = newDefaultDataConverter()
+	}
+	return &EncodedValue{value, dc}
+}
+
 // Get extract data from encoded data to desired value type. valuePtr is pointer to the actual value type.
 func (b EncodedValue) Get(valuePtr interface{}) error {
-	if b == nil {
+	if !b.HasValue() {
 		return ErrNoData
 	}
-	return getHostEnvironment().decodeArg(b, valuePtr)
+	return decodeArg(b.dataConverter, b.value, valuePtr)
 }
 
 // HasValue return whether there is value encoded.
 func (b EncodedValue) HasValue() bool {
-	return b != nil
+	return b.value != nil
 }
 
 // SideEffect executes the provided function once, records its result into the workflow history. The recorded result on
@@ -788,13 +808,14 @@ func (b EncodedValue) HasValue() bool {
 //         ....
 //  }
 func SideEffect(ctx Context, f func(ctx Context) interface{}) encoded.Value {
+	dc := getDataConverterFromWorkflowContext(ctx)
 	future, settable := NewFuture(ctx)
 	wrapperFunc := func() ([]byte, error) {
 		r := f(ctx)
-		return getHostEnvironment().encodeArg(r)
+		return encodeArg(dc, r)
 	}
 	resultCallback := func(result []byte, err error) {
-		settable.Set(EncodedValue(result), err)
+		settable.Set(EncodedValue{result, dc}, err)
 	}
 	getWorkflowEnvironment(ctx).SideEffect(wrapperFunc, resultCallback)
 	var encoded EncodedValue

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -35,12 +35,19 @@ import (
 
 type (
 	// EncodedValues is a type alias used to encapsulate/extract encoded arguments from workflow/activity.
-	EncodedValues []byte
+	EncodedValues struct {
+		values        []byte
+		dataConverter encoded.DataConverter
+	}
+
+	// ErrorDetailsValues is a type alias used hold error details objects.
+	ErrorDetailsValues []interface{}
 
 	// WorkflowTestSuite is the test suite to run unit tests for workflow/activity.
 	WorkflowTestSuite struct {
-		logger *zap.Logger
-		scope  tally.Scope
+		logger        *zap.Logger
+		scope         tally.Scope
+		dataConverter encoded.DataConverter
 	}
 
 	// TestWorkflowEnvironment is the environment that you use to test workflow
@@ -64,17 +71,40 @@ type (
 	}
 )
 
+func newEncodedValues(values []byte, dc encoded.DataConverter) encoded.Values {
+	if dc == nil {
+		dc = newDefaultDataConverter()
+	}
+	return &EncodedValues{values, dc}
+}
+
 // Get extract data from encoded data to desired value type. valuePtr is pointer to the actual value type.
 func (b EncodedValues) Get(valuePtr ...interface{}) error {
-	if b == nil {
+	if !b.HasValues() {
 		return ErrNoData
 	}
-	return getHostEnvironment().decode(b, valuePtr)
+	return b.dataConverter.FromData(b.values, valuePtr...)
 }
 
 // HasValues return whether there are values encoded.
 func (b EncodedValues) HasValues() bool {
-	return b != nil
+	return b.values != nil
+}
+
+// Get extract data from encoded data to desired value type. valuePtr is pointer to the actual value type.
+func (b ErrorDetailsValues) Get(valuePtr ...interface{}) error {
+	if !b.HasValues() {
+		return ErrNoData
+	}
+	for i, item := range b {
+		reflect.ValueOf(valuePtr[i]).Elem().Set(reflect.ValueOf(item))
+	}
+	return nil
+}
+
+// HasValues return whether there are values.
+func (b ErrorDetailsValues) HasValues() bool {
+	return b != nil && len(b) != 0
 }
 
 // NewTestWorkflowEnvironment creates a new instance of TestWorkflowEnvironment. Use the returned TestWorkflowEnvironment
@@ -104,6 +134,16 @@ func (s *WorkflowTestSuite) GetLogger() *zap.Logger {
 // tally.NoopScope
 func (s *WorkflowTestSuite) SetMetricsScope(scope tally.Scope) {
 	s.scope = scope
+}
+
+// SetDataConverter sets the data converter for this WorkflowTestSuite. If you don't set, it will be defaultDataConverter
+func (s *WorkflowTestSuite) SetDataConverter(dc encoded.DataConverter) {
+	s.dataConverter = dc
+}
+
+// GetDataConverter get the data converter for this WorkflowTestSuite.
+func (s *WorkflowTestSuite) GetDataConverter() encoded.DataConverter {
+	return s.dataConverter
 }
 
 // ExecuteActivity executes an activity. The tested activity will be executed synchronously in the calling goroutinue.

--- a/workflow/workflow_options.go
+++ b/workflow/workflow_options.go
@@ -23,6 +23,7 @@ package workflow
 import (
 	"time"
 
+	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/internal"
 )
 
@@ -59,4 +60,9 @@ func WithExecutionStartToCloseTimeout(ctx Context, d time.Duration) Context {
 // WithWorkflowTaskStartToCloseTimeout adds a decision timeout to the context.
 func WithWorkflowTaskStartToCloseTimeout(ctx Context, d time.Duration) Context {
 	return internal.WithWorkflowTaskStartToCloseTimeout(ctx, d)
+}
+
+// WithWorkflowDataConverter adds DataConverter to the context.
+func WithWorkflowDataConverter(ctx Context, dc encoded.DataConverter) Context {
+	return internal.WithWorkflowDataConverter(ctx, dc)
 }


### PR DESCRIPTION
Users now can implement encoded.DataConverter and let Cadence use it to serialize/deserialize parameters that need to be sent over the wire.
DataConverter can be set in 3 places:

1. Worker.
When create worker, one can provide data converter in WorkerOptions. Then everything processed by that worker will use provided data converter.
2. Client.
When create client to perform operations, one can provide data converter in clientOptions. Then all operation will use provided converter to encode arguments.
3. Workflow/Activity. 
Inside workflow implementation, one can use WithWorkflowDataConverter to create context and pass to other API calls like ExecuteActivity. 

 
