### PR TITLE
fix more memory leaks

### DIFF
--- a/internal/internal_activity.go
+++ b/internal/internal_activity.go
@@ -140,46 +140,46 @@ func getLocalActivityOptions(ctx Context) *executeLocalActivityParams {
 	return opts.(*executeLocalActivityParams)
 }
 
-func getValidatedActivityOptions(ctx Context) (*executeActivityParameters, error) {
+func getValidatedActivityOptions(ctx Context) (executeActivityParameters, error) {
 	p := getActivityOptions(ctx)
 	if p == nil {
 		// We need task list as a compulsory parameter. This can be removed after registration
-		return nil, errActivityParamsBadRequest
+		return executeActivityParameters{}, errActivityParamsBadRequest
 	}
 	if p.TaskListName == "" {
 		// We default to origin task list name.
 		p.TaskListName = p.OriginalTaskListName
 	}
 	if p.ScheduleToStartTimeoutSeconds <= 0 {
-		return nil, errors.New("missing or negative ScheduleToStartTimeoutSeconds")
+		return executeActivityParameters{}, errors.New("missing or negative ScheduleToStartTimeoutSeconds")
 	}
 	if p.StartToCloseTimeoutSeconds <= 0 {
-		return nil, errors.New("missing or negative StartToCloseTimeoutSeconds")
+		return executeActivityParameters{}, errors.New("missing or negative StartToCloseTimeoutSeconds")
 	}
 	if p.ScheduleToCloseTimeoutSeconds < 0 {
-		return nil, errors.New("missing or negative ScheduleToCloseTimeoutSeconds")
+		return executeActivityParameters{}, errors.New("missing or negative ScheduleToCloseTimeoutSeconds")
 	}
 	if p.ScheduleToCloseTimeoutSeconds == 0 {
 		// This is a optional parameter, we default to sum of the other two timeouts.
 		p.ScheduleToCloseTimeoutSeconds = p.ScheduleToStartTimeoutSeconds + p.StartToCloseTimeoutSeconds
 	}
 	if p.HeartbeatTimeoutSeconds < 0 {
-		return nil, errors.New("invalid negative HeartbeatTimeoutSeconds")
+		return executeActivityParameters{}, errors.New("invalid negative HeartbeatTimeoutSeconds")
 	}
 
-	return p, nil
+	return *p, nil
 }
 
-func getValidatedLocalActivityOptions(ctx Context) (*executeLocalActivityParams, error) {
+func getValidatedLocalActivityOptions(ctx Context) (executeLocalActivityParams, error) {
 	p := getLocalActivityOptions(ctx)
 	if p == nil {
-		return nil, errLocalActivityParamsBadRequest
+		return executeLocalActivityParams{}, errLocalActivityParamsBadRequest
 	}
 	if p.ScheduleToCloseTimeoutSeconds <= 0 {
-		return nil, errors.New("missing or negative ScheduleToCloseTimeoutSeconds")
+		return executeLocalActivityParams{}, errors.New("missing or negative ScheduleToCloseTimeoutSeconds")
 	}
 
-	return p, nil
+	return *p, nil
 }
 
 func validateFunctionArgs(f interface{}, args []interface{}, isWorkflow bool) error {

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -1079,11 +1079,11 @@ func getValidatedWorkflowFunction(workflowFunc interface{}, args []interface{}) 
 	return &WorkflowType{Name: fnName}, input, nil
 }
 
-func getValidatedWorkflowOptions(ctx Context) (*workflowOptions, error) {
+func getValidatedWorkflowOptions(ctx Context) (workflowOptions, error) {
 	p := getWorkflowEnvOptions(ctx)
 	if p == nil {
 		// We need task list as a compulsory parameter. This can be removed after registration
-		return nil, errWorkflowOptionBadRequest
+		return workflowOptions{}, errWorkflowOptionBadRequest
 	}
 	info := GetWorkflowInfo(ctx)
 	if p.domain == nil || *p.domain == "" {
@@ -1095,16 +1095,16 @@ func getValidatedWorkflowOptions(ctx Context) (*workflowOptions, error) {
 		p.taskListName = common.StringPtr(info.TaskListName)
 	}
 	if p.taskStartToCloseTimeoutSeconds == nil || *p.taskStartToCloseTimeoutSeconds < 0 {
-		return nil, errors.New("missing or negative DecisionTaskStartToCloseTimeout")
+		return workflowOptions{}, errors.New("missing or negative DecisionTaskStartToCloseTimeout")
 	}
 	if *p.taskStartToCloseTimeoutSeconds == 0 {
 		p.taskStartToCloseTimeoutSeconds = common.Int32Ptr(defaultDecisionTaskTimeoutInSecs)
 	}
 	if p.executionStartToCloseTimeoutSeconds == nil || *p.executionStartToCloseTimeoutSeconds <= 0 {
-		return nil, errors.New("missing or invalid ExecutionStartToCloseTimeout")
+		return workflowOptions{}, errors.New("missing or invalid ExecutionStartToCloseTimeout")
 	}
 
-	return p, nil
+	return *p, nil
 }
 
 func getWorkflowEnvOptions(ctx Context) *workflowOptions {

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -341,8 +341,7 @@ func ExecuteActivity(ctx Context, activity interface{}, args ...interface{}) Fut
 		return future
 	}
 	// Validate context options.
-	parameters := getActivityOptions(ctx)
-	parameters, err = getValidatedActivityOptions(ctx)
+	parameters, err := getValidatedActivityOptions(ctx)
 	if err != nil {
 		settable.Set(nil, err)
 		return future
@@ -352,7 +351,7 @@ func ExecuteActivity(ctx Context, activity interface{}, args ...interface{}) Fut
 
 	ctxDone, cancellable := ctx.Done().(*channelImpl)
 	cancellationCallback := &receiveCallback{}
-	a := getWorkflowEnvironment(ctx).ExecuteActivity(*parameters, func(r []byte, e error) {
+	a := getWorkflowEnvironment(ctx).ExecuteActivity(parameters, func(r []byte, e error) {
 		settable.Set(r, e)
 		if cancellable {
 			// future is done, we don't need the cancellation callback anymore.
@@ -425,7 +424,7 @@ func ExecuteLocalActivity(ctx Context, activity interface{}, args ...interface{}
 
 	ctxDone, cancellable := ctx.Done().(*channelImpl)
 	cancellationCallback := &receiveCallback{}
-	la := getWorkflowEnvironment(ctx).ExecuteLocalActivity(*params, func(r []byte, e error) {
+	la := getWorkflowEnvironment(ctx).ExecuteLocalActivity(params, func(r []byte, e error) {
 		settable.Set(r, e)
 		if cancellable {
 			// future is done, we don't need cancellation anymore
@@ -491,7 +490,7 @@ func ExecuteChildWorkflow(ctx Context, childWorkflow interface{}, args ...interf
 
 	ctxDone, cancellable := ctx.Done().(*channelImpl)
 	cancellationCallback := &receiveCallback{}
-	err = getWorkflowEnvironment(ctx).ExecuteChildWorkflow(*options, func(r []byte, e error) {
+	err = getWorkflowEnvironment(ctx).ExecuteChildWorkflow(options, func(r []byte, e error) {
 		mainSettable.Set(r, e)
 		if cancellable {
 			// future is done, we don't need cancellation anymore


### PR DESCRIPTION
The activity options (*executeActivityParameters) is attached to workflow context. When we execute activity, we get the option, set the input value to that parameters. That parameters won't be reclaimed until workflow is closed.
We need to break that link by return a copy of the executeActivityParameters and set input to that copy so activity input won't be attached to the parameters that is attached to workflow context.
