### PR TITLE
fix memory leak from activity options

### DIFF
--- a/internal/error.go
+++ b/internal/error.go
@@ -118,9 +118,9 @@ type (
 
 	// ContinueAsNewError contains information about how to continue the workflow as new.
 	ContinueAsNewError struct {
-		wfn     interface{}
-		args    []interface{}
-		options *workflowOptions
+		wfn    interface{}
+		args   []interface{}
+		params *executeWorkflowParams
 	}
 )
 
@@ -210,9 +210,12 @@ func NewContinueAsNewError(ctx Context, wfn interface{}, args ...interface{}) *C
 		panic("invalid taskStartToCloseTimeoutSeconds provided")
 	}
 
-	options.workflowType = workflowType
-	options.input = input
-	return &ContinueAsNewError{wfn: wfn, args: args, options: options}
+	params := &executeWorkflowParams{
+		workflowOptions: *options,
+		workflowType:    workflowType,
+		input:           input,
+	}
+	return &ContinueAsNewError{wfn: wfn, args: args, params: params}
 }
 
 // Error from error interface

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -274,33 +274,33 @@ func (wc *workflowEnvironmentImpl) RegisterCancelHandler(handler func()) {
 }
 
 func (wc *workflowEnvironmentImpl) ExecuteChildWorkflow(
-	options workflowOptions, callback resultHandler, startedHandler func(r WorkflowExecution, e error)) error {
-	if options.workflowID == "" {
-		options.workflowID = wc.workflowInfo.WorkflowExecution.RunID + "_" + wc.GenerateSequenceID()
+	params executeWorkflowParams, callback resultHandler, startedHandler func(r WorkflowExecution, e error)) error {
+	if params.workflowID == "" {
+		params.workflowID = wc.workflowInfo.WorkflowExecution.RunID + "_" + wc.GenerateSequenceID()
 	}
 
 	attributes := &m.StartChildWorkflowExecutionDecisionAttributes{}
 
-	attributes.Domain = options.domain
-	attributes.TaskList = &m.TaskList{Name: options.taskListName}
-	attributes.WorkflowId = common.StringPtr(options.workflowID)
-	attributes.ExecutionStartToCloseTimeoutSeconds = options.executionStartToCloseTimeoutSeconds
-	attributes.TaskStartToCloseTimeoutSeconds = options.taskStartToCloseTimeoutSeconds
-	attributes.Input = options.input
-	attributes.WorkflowType = workflowTypePtr(*options.workflowType)
-	attributes.ChildPolicy = options.childPolicy.toThriftChildPolicyPtr()
-	attributes.WorkflowIdReusePolicy = options.workflowIDReusePolicy.toThriftPtr()
+	attributes.Domain = params.domain
+	attributes.TaskList = &m.TaskList{Name: params.taskListName}
+	attributes.WorkflowId = common.StringPtr(params.workflowID)
+	attributes.ExecutionStartToCloseTimeoutSeconds = params.executionStartToCloseTimeoutSeconds
+	attributes.TaskStartToCloseTimeoutSeconds = params.taskStartToCloseTimeoutSeconds
+	attributes.Input = params.input
+	attributes.WorkflowType = workflowTypePtr(*params.workflowType)
+	attributes.ChildPolicy = params.childPolicy.toThriftChildPolicyPtr()
+	attributes.WorkflowIdReusePolicy = params.workflowIDReusePolicy.toThriftPtr()
 
 	decision := wc.decisionsHelper.startChildWorkflowExecution(attributes)
 	decision.setData(&scheduledChildWorkflow{
 		resultCallback:      callback,
 		startedCallback:     startedHandler,
-		waitForCancellation: options.waitForCancellation,
+		waitForCancellation: params.waitForCancellation,
 	})
 
 	wc.logger.Debug("ExecuteChildWorkflow",
-		zap.String(tagChildWorkflowID, options.workflowID),
-		zap.String(tagWorkflowType, options.workflowType.Name))
+		zap.String(tagChildWorkflowID, params.workflowID),
+		zap.String(tagWorkflowType, params.workflowType.Name))
 
 	return nil
 }
@@ -341,7 +341,7 @@ func (wc *workflowEnvironmentImpl) CreateNewDecision(decisionType m.DecisionType
 	}
 }
 
-func (wc *workflowEnvironmentImpl) ExecuteActivity(parameters executeActivityParameters, callback resultHandler) *activityInfo {
+func (wc *workflowEnvironmentImpl) ExecuteActivity(parameters executeActivityParams, callback resultHandler) *activityInfo {
 	scheduleTaskAttr := &m.ScheduleActivityTaskDecisionAttributes{}
 	if parameters.ActivityID == nil || *parameters.ActivityID == "" {
 		scheduleTaskAttr.ActivityId = common.StringPtr(wc.GenerateSequenceID())

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1024,11 +1024,11 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 		wth.metricsScope.Counter(metrics.WorkflowContinueAsNewCounter).Inc(1)
 		closeDecision = createNewDecision(s.DecisionTypeContinueAsNewWorkflowExecution)
 		closeDecision.ContinueAsNewWorkflowExecutionDecisionAttributes = &s.ContinueAsNewWorkflowExecutionDecisionAttributes{
-			WorkflowType: workflowTypePtr(*contErr.options.workflowType),
-			Input:        contErr.options.input,
-			TaskList:     common.TaskListPtr(s.TaskList{Name: contErr.options.taskListName}),
-			ExecutionStartToCloseTimeoutSeconds: contErr.options.executionStartToCloseTimeoutSeconds,
-			TaskStartToCloseTimeoutSeconds:      contErr.options.taskStartToCloseTimeoutSeconds,
+			WorkflowType: workflowTypePtr(*contErr.params.workflowType),
+			Input:        contErr.params.input,
+			TaskList:     common.TaskListPtr(s.TaskList{Name: contErr.params.taskListName}),
+			ExecutionStartToCloseTimeoutSeconds: contErr.params.executionStartToCloseTimeoutSeconds,
+			TaskStartToCloseTimeoutSeconds:      contErr.params.taskStartToCloseTimeoutSeconds,
 		}
 	} else if workflowContext.err != nil {
 		// Workflow failures

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -64,7 +64,7 @@ type (
 		RegisterCancelHandler(handler func())
 		RequestCancelChildWorkflow(domainName, workflowID string)
 		RequestCancelExternalWorkflow(domainName, workflowID, runID string, callback resultHandler)
-		ExecuteChildWorkflow(options workflowOptions, callback resultHandler, startedHandler func(r WorkflowExecution, e error)) error
+		ExecuteChildWorkflow(params executeWorkflowParams, callback resultHandler, startedHandler func(r WorkflowExecution, e error)) error
 		GetLogger() *zap.Logger
 		GetMetricsScope() tally.Scope
 		RegisterSignalHandler(handler func(name string, input []byte))

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -154,8 +154,6 @@ type (
 	// The current timeout resolution implementation is in seconds and uses math.Ceil() as the duration. But is
 	// subjected to change in the future.
 	workflowOptions struct {
-		workflowType                        *WorkflowType
-		input                               []byte
 		taskListName                        *string
 		executionStartToCloseTimeoutSeconds *int32
 		taskStartToCloseTimeoutSeconds      *int32
@@ -166,6 +164,12 @@ type (
 		signalChannels                      map[string]SignalChannel
 		queryHandlers                       map[string]func([]byte) ([]byte, error)
 		workflowIDReusePolicy               WorkflowIDReusePolicy
+	}
+
+	executeWorkflowParams struct {
+		workflowOptions
+		workflowType *WorkflowType
+		input        []byte
 	}
 
 	// decodeFutureImpl

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -397,10 +397,10 @@ func (s *WorkflowUnitTest) Test_ContinueAsNewWorkflow() {
 	s.True(env.IsWorkflowCompleted())
 	s.NotNil(env.GetWorkflowError())
 	resultErr := env.GetWorkflowError().(*ContinueAsNewError)
-	s.EqualValues("continueAsNewWorkflowTest", resultErr.options.workflowType.Name)
-	s.EqualValues(1, *resultErr.options.executionStartToCloseTimeoutSeconds)
-	s.EqualValues(1, *resultErr.options.taskStartToCloseTimeoutSeconds)
-	s.EqualValues("default-test-tasklist", *resultErr.options.taskListName)
+	s.EqualValues("continueAsNewWorkflowTest", resultErr.params.workflowType.Name)
+	s.EqualValues(1, *resultErr.params.executionStartToCloseTimeoutSeconds)
+	s.EqualValues(1, *resultErr.params.taskStartToCloseTimeoutSeconds)
+	s.EqualValues("default-test-tasklist", *resultErr.params.taskListName)
 }
 
 func cancelWorkflowTest(ctx Context) (string, error) {


### PR DESCRIPTION
activityOptions is attached to workflow context, which live as long as workflow is not closed.
We set the input to be part of activity options which prevent the input byte array from been reclaimed. This change separate the activity options from executeActivityParameters so the activity options could live for long, but the input could be GCed.
Apply same change to localActivity options and child workflow options.
