### PR TITLE
Bump Go tool version to 1.10 in travis.ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: go
 directories:
     - $HOME/.glide/cache
 go:
-  - 1.10
+  - 1.10.x
 
 go_import_path: go.uber.org/cadence
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: go
 directories:
     - $HOME/.glide/cache
 go:
-  - 1.9
+  - 1.10
 
 go_import_path: go.uber.org/cadence
 addons:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This doc is intended for contributors to `cadence-client` (hopefully that's you!
 
 ## Development Environment
 
-* Go. Install on OS X with `brew install go`. The minimum required Go version is 1.9.
+* Go. Install on OS X with `brew install go`. The minimum required Go version is 1.10.
 * `thrift`. Install on OS X with `brew install thrift`.
 * `thrift-gen`. Install with `go get github.com/uber/tchannel-go/thrift/thrift-gen`.
 


### PR DESCRIPTION
This commit bumps the minimum required Go tool version from 1.9 to 1.10 in travis.ci

Apart from a general effort to keep our Go tools up to date with the latest,
the reason for specific this bump is the go command below only works on 1.10:
   go test -coverprofile ./...

There was a change to our Makefile that invokes a command with the above syntax and it fails in travis.ci
because our travis environment uses 1.9 go tools.