### PR TITLE
fix signal leak

### DIFF
--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -554,7 +554,7 @@ func (c *channelImpl) receiveAsyncImpl(callback *receiveCallback) (v interface{}
 	}
 	if len(c.buffer) > 0 {
 		r := c.buffer[0]
-		c.buffer = c.buffer[1:]
+		c.buffer = append([]interface{}{}, c.buffer[1:]...)
 		return r, true, true
 	}
 	if c.closed {
@@ -562,7 +562,7 @@ func (c *channelImpl) receiveAsyncImpl(callback *receiveCallback) (v interface{}
 	}
 	for len(c.blockedSends) > 0 {
 		b := c.blockedSends[0]
-		c.blockedSends = c.blockedSends[1:]
+		c.blockedSends = append([]*sendCallback{}, c.blockedSends[1:]...)
 		if b.fn() {
 			return b.value, true, true
 		}
@@ -629,7 +629,7 @@ func (c *channelImpl) sendAsyncImpl(v interface{}, pair *sendCallback) (ok bool)
 	}
 	for len(c.blockedReceives) > 0 {
 		blockedGet := c.blockedReceives[0].fn
-		c.blockedReceives = c.blockedReceives[1:]
+		c.blockedReceives = append([]*receiveCallback{}, c.blockedReceives[1:]...)
 		// false from callback indicates that value wasn't consumed
 		if blockedGet(v, true) {
 			return true


### PR DESCRIPTION
In Go, re-slicing a slice doesn't make a copy of the underlying array. The full array will be kept in memory until it is no longer referenced.
https://blog.golang.org/go-slices-usage-and-internals
