### PR TITLE
fix nil pointer

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -667,6 +667,9 @@ ProcessEvents:
 
 func (wth *workflowTaskHandlerImpl) ProcessLocalActivityResult(lar *localActivityResult) (interface{}, error) {
 	workflowContext := lar.task.wc
+	workflowContext.Lock()
+	defer workflowContext.release()
+
 	if workflowContext.currentDecisionTask != lar.task.decisionTask {
 		// The possible case is decision task timeout while waiting for local activity to complete, then server would
 		// generate a new new decision task, which could be dispatched to this same worker. In that case, the cached
@@ -679,9 +682,6 @@ func (wth *workflowTaskHandlerImpl) ProcessLocalActivityResult(lar *localActivit
 			zap.Int32("ScheduleToCloseTimeoutSeconds", lar.task.params.ScheduleToCloseTimeoutSeconds))
 		return nil, nil
 	}
-
-	workflowContext.Lock()
-	defer workflowContext.release()
 
 	eventDecisions, err := workflowContext.eventHandler.ProcessLocalActivityResult(lar)
 	if err != nil {

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -239,6 +239,9 @@ func (wtp *workflowTaskPoller) processWorkflowTask(workflowTask *workflowTask) e
 }
 
 func (wtp *workflowTaskPoller) processLocalActivityResult(lar *localActivityResult) error {
+	workflowContext := lar.task.wc
+	decisionStartTime := workflowContext.decisionStartTime
+	decisionTask := workflowContext.currentDecisionTask
 	completedRequest, err := wtp.taskHandler.(*workflowTaskHandlerImpl).ProcessLocalActivityResult(lar)
 	if err != nil {
 		return err
@@ -247,11 +250,10 @@ func (wtp *workflowTaskPoller) processLocalActivityResult(lar *localActivityResu
 		return nil
 	}
 
-	workflowContext := lar.task.wc
-	wtp.metricsScope.Timer(metrics.DecisionExecutionLatency).Record(time.Now().Sub(workflowContext.decisionStartTime))
+	wtp.metricsScope.Timer(metrics.DecisionExecutionLatency).Record(time.Now().Sub(decisionStartTime))
 
 	responseStartTime := time.Now()
-	if err = wtp.RespondTaskCompleted(completedRequest, workflowContext.currentDecisionTask); err != nil {
+	if err = wtp.RespondTaskCompleted(completedRequest, decisionTask); err != nil {
 		return err
 	}
 	wtp.metricsScope.Timer(metrics.DecisionResponseLatency).Record(time.Now().Sub(responseStartTime))


### PR DESCRIPTION
We set the currentDecisionTask of cached workflowContext to nil when decision is completed. It worked fine for normal decision completed case. But caused a nil pointer error in FailDecision case because in fail decision case, the code try to access that current decision task to check the attempt count.