### PR TITLE
Add non-deterministic workflow option

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -141,6 +141,10 @@ type (
 		DisableStickyExecution bool
 
 		StickyScheduleToStartTimeout time.Duration
+
+		// NonDeterministicWorkflowPolicy is used for configuring how client's decision task handler deals with
+		// mismatched history events (presumably arising from non-deterministic workflow definitions).
+		NonDeterministicWorkflowPolicy NonDeterministicWorkflowPolicy
 	}
 )
 
@@ -1017,6 +1021,7 @@ func newAggregatedWorker(
 		DisableStickyExecution:               wOptions.DisableStickyExecution,
 		StickyScheduleToStartTimeout:         wOptions.StickyScheduleToStartTimeout,
 		TaskListActivitiesPerSecond:          wOptions.TaskListActivitiesPerSecond,
+		NonDeterministicWorkflowPolicy:       wOptions.NonDeterministicWorkflowPolicy,
 	}
 
 	ensureRequiredParams(&workerParams)

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -137,7 +137,30 @@ type (
 		// Optional: sets context for activity. The context can be used to pass any configuration to activity
 		// like common logger for all activities.
 		BackgroundActivityContext context.Context
+
+		// NonDeterministicWorkflowPolicy is used for configuring how decision worker deals with non-deterministic history events
+		// (presumably arising from non-deterministic workflow definitions or non-backward compatible workflow definition changes).
+		NonDeterministicWorkflowPolicy NonDeterministicWorkflowPolicy
 	}
+)
+
+// NonDeterministicWorkflowPolicy is an enum for configuring how client's decision task handler deals with
+// mismatched history events (presumably arising from non-deterministic workflow definitions).
+type NonDeterministicWorkflowPolicy int
+
+const (
+	// NonDeterministicWorkflowPolicyBlockWorkflow is the default policy for handling detected non-determinism.
+	// This option simply logs to console with an error message that non-determinism is detected, but
+	// does *NOT* reply anything back to the server.
+	// It is chosen as default for backward compatibility reasons because it preserves the old behavior
+	// for handling non-determinism that we had before NonDeterministicWorkflowPolicy type was added to
+	// allow more configurability.
+	NonDeterministicWorkflowPolicyBlockWorkflow NonDeterministicWorkflowPolicy = iota
+	// NonDeterministicWorkflowPolicyFailWorkflow behaves exactly the same as Ignore, up until the very
+	// end of processing a decision task.
+	// Whereas default does *NOT* reply anything back to the server, fail workflow replies back with a request
+	// to fail the workflow execution.
+	NonDeterministicWorkflowPolicyFailWorkflow
 )
 
 // NewWorker creates an instance of worker for managing workflow and activity executions.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -37,6 +37,25 @@ type (
 
 	// Options is used to configure a worker instance.
 	Options = internal.WorkerOptions
+
+	// NonDeterministicWorkflowPolicy is an enum for configuring how client's decision task handler deals with
+	// mismatched history events (presumably arising from non-deterministic workflow definitions).
+	NonDeterministicWorkflowPolicy = internal.NonDeterministicWorkflowPolicy
+)
+
+const (
+	// NonDeterministicWorkflowPolicyBlockWorkflow is the default policy for handling detected non-determinism.
+	// This option simply logs to console with an error message that non-determinism is detected, but
+	// does *NOT* reply anything back to the server.
+	// It is chosen as default for backward compatibility reasons because it preserves the old behavior
+	// for handling non-determinism that we had before NonDeterministicWorkflowPolicy type was added to
+	// allow more configurability.
+	NonDeterministicWorkflowPolicyBlockWorkflow = internal.NonDeterministicWorkflowPolicyBlockWorkflow
+	// NonDeterministicWorkflowPolicyFailWorkflow behaves exactly the same as Ignore, up until the very
+	// end of processing a decision task.
+	// Whereas default does *NOT* reply anything back to the server, fail workflow replies back with a request
+	// to fail the workflow execution.
+	NonDeterministicWorkflowPolicyFailWorkflow = internal.NonDeterministicWorkflowPolicyFailWorkflow
 )
 
 // New creates an instance of worker for managing workflow and activity executions.


### PR DESCRIPTION
This commit adds an option to configure how worker execution should
handle detection of a non-deterministic workflow.

Currently, when non-determinism is detected in execution history, the
task handler on the client simply logs the error to console *without*
replying back to the cadence server, which leads the server to think
the decision task has timed out and thus reschedules a new decsion task.

The currently behavior is less than satisfactory for 2 reasons:
1. From server side there's no indication of the non-determinism error.
   It simply looks like a timeout.
2. From the client side, there's no recover option in that the client
   will just pull off the new rescheduled decision task and fail again
   and again.

This commit adds a new option to cadence workers to explicit fail the
workflow where a mismatched history has been detected. This should
yield a more robust debugging experience for customers whose workflows
fail due to non-determinism.

Resolves #333 