### PR TITLE
remove SignalChannel

### DIFF
--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -1702,30 +1702,6 @@ func (s *WorkflowTestSuiteUnitTest) Test_Channel() {
 	s.True(ok)
 }
 
-func (s *WorkflowTestSuiteUnitTest) Test_SignalChannel() {
-	workflowFn := func(ctx Context) error {
-		signalCh := GetSignalChannel(ctx, "test-signal")
-		encodedValue, _ := signalCh.ReceiveEncodedValue(ctx)
-
-		var signal string
-		err := encodedValue.Get(&signal)
-		return err
-	}
-
-	RegisterWorkflow(workflowFn)
-	env := s.NewTestWorkflowEnvironment()
-
-	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow("test-signal", 123)
-	}, time.Minute)
-
-	env.ExecuteWorkflow(workflowFn)
-
-	s.True(env.IsWorkflowCompleted())
-	s.Error(env.GetWorkflowError())
-	s.Contains(env.GetWorkflowError().Error(), "decode")
-}
-
 func (s *WorkflowTestSuiteUnitTest) Test_ContextMisuse() {
 	workflowFn := func(ctx Context) error {
 		ch := NewChannel(ctx)

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -70,28 +70,6 @@ type (
 		Close()
 	}
 
-	// SignalChannel extends from Channel. It adds the ability to deal with corrupted signal data. Signal is sent to
-	// Cadence server as binary blob. When workflow try to receive signal data as strongly typed value, the Channel will
-	// try to decode that binary blob into that strongly typed value pointer. If that data is corrupted and cannot be
-	// decoded, the Receive call will panic which will block the workflow. That might not be expected behavior. This
-	// SignalChannel adds new methods so that workflow could receive signal as encoded.Value, and then extract that strongly
-	// typed value from encoded.Value. If the decoding fails, the encoded.Value will return error instead of panic.
-	SignalChannel interface {
-		Channel
-
-		// ReceiveEncodedValue blocks until it receives a value, and then return that value as encoded.Value.
-		// Returns false when Channel is closed.
-		ReceiveEncodedValue(ctx Context) (value encoded.Value, more bool)
-
-		// ReceiveEncodedValueAsync try to receive from Channel without blocking. If there is data available from the
-		// Channel, it returns the data as encoded.Value and true. Otherwise, it returns nil and false immediately.
-		ReceiveEncodedValueAsync() (value encoded.Value, ok bool)
-
-		// ReceiveEncodedValueAsyncWithMoreFlag is same as ReceiveEncodedValueAsync with extra return value more to
-		// indicate if there could be  more value from the Channel. The more is false when Channel is closed.
-		ReceiveEncodedValueAsyncWithMoreFlag() (value encoded.Value, ok bool, more bool)
-	}
-
 	// Selector must be used instead of native go select by workflow code.
 	// Use workflow.NewSelector(ctx) method to create a Selector instance.
 	Selector interface {
@@ -791,7 +769,7 @@ func WithDataConverter(ctx Context, dc encoded.DataConverter) Context {
 }
 
 // GetSignalChannel returns channel corresponding to the signal name.
-func GetSignalChannel(ctx Context, signalName string) SignalChannel {
+func GetSignalChannel(ctx Context, signalName string) Channel {
 	return getWorkflowEnvOptions(ctx).getSignalChannel(ctx, signalName)
 }
 

--- a/workflow/deterministic_wrappers.go
+++ b/workflow/deterministic_wrappers.go
@@ -32,14 +32,6 @@ type (
 	// Use workflow.NewChannel(ctx) method to create Channel instance.
 	Channel = internal.Channel
 
-	// SignalChannel extends from Channel. It adds the ability to deal with corrupted signal data. Signal is sent to
-	// Cadence server as binary blob. When workflow try to receive signal data as strongly typed value, the Channel will
-	// try to decode that binary blob into that strongly typed value pointer. If that data is corrupted and cannot be
-	// decoded, the Receive call will panic which will block the workflow. That might not be expected behavior. This
-	// SignalChannel adds new methods so that workflow could receive signal as encoded.Value, and then extract that strongly
-	// typed value from encoded.Value. If the decoding fails, the encoded.Value will return error instead of panic.
-	SignalChannel = internal.SignalChannel
-
 	// Selector must be used instead of native go select by workflow code.
 	// Use workflow.NewSelector(ctx) method to create a Selector instance.
 	Selector = internal.Selector


### PR DESCRIPTION
Since we now have data converter, we no longer need this SignalChannel.
We added SignalChannel to have the ability to handle corrupted data. With data converter, user could always extract signal as []byte, then use data converter to convert to the strong typed object, and if the convert failed, it would return error instead of panic.
