### PR TITLE
Adjust defaultMaxConcurrentTask from 50 to 1000

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -59,7 +59,7 @@ const (
 
 	defaultTaskListActivitiesPerSecond = 100000.0 // Large activity executions/sec (unlimited)
 
-	defaultMaxConcurrentTaskExecutionSize = 50     // hardcoded max task execution size.
+	defaultMaxConcurrentTaskExecutionSize = 1000   // hardcoded max task execution size.
 	defaultMaxTaskExecutionRate           = 100000 // Large task execution rate (unlimited)
 
 	defaultPollerRate = 1000


### PR DESCRIPTION
This commit adjusts defaultMaxConcurrentTaskSize from 50 to 1000.

The rationale was it was felt that 50 was too small that we might not
be taking advantage of the full worker capacity.