### PR TITLE
Fix service wrapper init for metrics

### DIFF
--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -178,7 +178,7 @@ func isClientSideError(err error) bool {
 func newWorkflowTaskPoller(taskHandler WorkflowTaskHandler, service workflowserviceclient.Interface,
 	domain string, params workerExecutionParameters) *workflowTaskPoller {
 	return &workflowTaskPoller{
-		service:      metrics.NewWorkflowServiceWrapper(service, params.MetricsScope),
+		service:      service,
 		domain:       domain,
 		taskListName: params.TaskList,
 		identity:     params.Identity,
@@ -756,7 +756,7 @@ func newActivityTaskPoller(taskHandler ActivityTaskHandler, service workflowserv
 	domain string, params workerExecutionParameters) *activityTaskPoller {
 	return &activityTaskPoller{
 		taskHandler:         taskHandler,
-		service:             metrics.NewWorkflowServiceWrapper(service, params.MetricsScope),
+		service:             service,
 		domain:              domain,
 		taskListName:        params.TaskList,
 		identity:            params.Identity,

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -42,6 +42,7 @@ import (
 	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/internal/common"
 	"go.uber.org/cadence/internal/common/backoff"
+	"go.uber.org/cadence/internal/common/metrics"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -944,6 +945,7 @@ func newAggregatedWorker(
 		zapcore.Field{Key: tagWorkerID, Type: zapcore.StringType, String: workerParams.Identity},
 	)
 	logger := workerParams.Logger
+	service = metrics.NewWorkflowServiceWrapper(service, workerParams.MetricsScope)
 
 	processTestTags(&wOptions, &workerParams)
 


### PR DESCRIPTION
Some components like ActivityTaskHandler are not using metrics wrapped service client. That's the reason we emit part of operation metrics. Fix this by init wrapped service client at worker init. 