### PR TITLE
Evict execution context from cache when there is no workflow definition found

### DIFF
--- a/internal/common/metrics/capturingStatsReporter.go
+++ b/internal/common/metrics/capturingStatsReporter.go
@@ -21,9 +21,9 @@
 package metrics
 
 import (
+	"github.com/uber-go/tally"
 	"io"
 	"time"
-	"github.com/uber-go/tally"
 )
 
 func NewMetricsScope(isReplay *bool) (tally.Scope, io.Closer, *CapturingStatsReporter) {
@@ -213,4 +213,3 @@ func (r *CapturingStatsReporter) Tagging() bool {
 func (r *CapturingStatsReporter) Flush() {
 	r.flush++
 }
-

--- a/internal/common/metrics/scope_test.go
+++ b/internal/common/metrics/scope_test.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
-	"sync"
 	"io"
+	"sync"
 )
 
 func Test_Counter(t *testing.T) {

--- a/internal/internal_coroutines_test.go
+++ b/internal/internal_coroutines_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createRootTestContext()(ctx Context){
+func createRootTestContext() (ctx Context) {
 	env := new(WorkflowUnitTest).NewTestWorkflowEnvironment()
 	return newWorkflowContext(env.impl)
 }

--- a/internal/internal_public.go
+++ b/internal/internal_public.go
@@ -28,7 +28,6 @@ package internal
 // point of view only to access them from other packages.
 
 import (
-	"sync"
 	"time"
 
 	s "go.uber.org/cadence/.gen/go/shared"
@@ -48,7 +47,8 @@ type (
 	// WorkflowExecutionContext represents one instance of workflow execution state in memory. Lock must be obtained before
 	// calling into any methods.
 	WorkflowExecutionContext interface {
-		sync.Locker
+		Lock()
+		Unlock(err error)
 		ProcessWorkflowTask(task *s.PollForDecisionTaskResponse, historyIterator HistoryIterator) (completeRequest interface{}, err error)
 		ProcessLocalActivityResult(lar *localActivityResult) (interface{}, error)
 		// CompleteDecisionTask try to complete current decision task and get response that needs to be sent back to server.

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -616,6 +616,10 @@ func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 
 	workflowContext, err := wth.getOrCreateWorkflowContext(task, historyIterator)
 	if err != nil {
+		// The WorkflowContext will be removed from the cache if an error is found
+		// in workflowContext.err when calling Unlock() method.
+		workflowContext.err = err
+		defer workflowContext.Unlock()
 		return nil, nil, err
 	}
 	defer workflowContext.Unlock()

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -624,12 +624,11 @@ func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 		workflowContext.Unlock(err)
 	}()
 
-
 	response, err := workflowContext.ProcessWorkflowTask(task, historyIterator)
 	return response, workflowContext, err
 }
 
-func (w *workflowExecutionContextImpl)  ProcessWorkflowTask(task *s.PollForDecisionTaskResponse, historyIterator HistoryIterator) (completeRequest interface{}, err error) {
+func (w *workflowExecutionContextImpl) ProcessWorkflowTask(task *s.PollForDecisionTaskResponse, historyIterator HistoryIterator) (completeRequest interface{}, err error) {
 	if err = w.ResetIfStale(task, historyIterator); err != nil {
 		return
 	}

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -380,8 +380,8 @@ func (w *workflowExecutionContextImpl) Lock() {
 	w.mutex.Lock()
 }
 
-func (w *workflowExecutionContextImpl) Unlock() {
-	if w.err != nil || w.isWorkflowCompleted || (w.wth.disableStickyExecution && !w.hasPendingLocalActivityWork()) {
+func (w *workflowExecutionContextImpl) Unlock(err error) {
+	if err != nil || w.err != nil || w.isWorkflowCompleted || (w.wth.disableStickyExecution && !w.hasPendingLocalActivityWork()) {
 		// TODO: in case of closed, it asumes the close decision always succeed. need server side change to return
 		// error to indicate the close failure case. This should be rear case. For now, always remove the cache, and
 		// if the close decision failed, the next decision will have to rebuild the state.
@@ -499,6 +499,7 @@ func (wth *workflowTaskHandlerImpl) createWorkflowContext(task *s.PollForDecisio
 		TaskStartToCloseTimeoutSeconds:      attributes.GetTaskStartToCloseTimeoutSeconds(),
 		Domain: wth.domain,
 	}
+
 	wfStartTime := time.Unix(0, h.Events[0].GetTimestamp())
 	workflowContext := &workflowExecutionContextImpl{workflowStartTime: wfStartTime, workflowInfo: workflowInfo, wth: wth}
 	workflowContext.createEventHandler()
@@ -616,19 +617,19 @@ func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 
 	workflowContext, err := wth.getOrCreateWorkflowContext(task, historyIterator)
 	if err != nil {
-		// The WorkflowContext will be removed from the cache if an error is found
-		// in workflowContext.err when calling Unlock() method.
-		workflowContext.err = err
-		defer workflowContext.Unlock()
 		return nil, nil, err
 	}
-	defer workflowContext.Unlock()
+
+	defer func() {
+		workflowContext.Unlock(err)
+	}()
+
 
 	response, err := workflowContext.ProcessWorkflowTask(task, historyIterator)
 	return response, workflowContext, err
 }
 
-func (w *workflowExecutionContextImpl) ProcessWorkflowTask(task *s.PollForDecisionTaskResponse, historyIterator HistoryIterator) (completeRequest interface{}, err error) {
+func (w *workflowExecutionContextImpl)  ProcessWorkflowTask(task *s.PollForDecisionTaskResponse, historyIterator HistoryIterator) (completeRequest interface{}, err error) {
 	if err = w.ResetIfStale(task, historyIterator); err != nil {
 		return
 	}

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -45,6 +45,7 @@ type (
 	TaskHandlersTestSuite struct {
 		suite.Suite
 		logger *zap.Logger
+		service  *workflowservicetest.MockClient
 	}
 )
 
@@ -389,6 +390,8 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
 	}
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	newWorkflowTaskWorkerInternal(taskHandler, t.service,testDomain, params)
+
 	request, _, err := taskHandler.ProcessWorkflowTask(task, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	// there should be no error as the history events matched the decisions.

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -44,8 +44,8 @@ const (
 type (
 	TaskHandlersTestSuite struct {
 		suite.Suite
-		logger *zap.Logger
-		service  *workflowservicetest.MockClient
+		logger  *zap.Logger
+		service *workflowservicetest.MockClient
 	}
 )
 
@@ -369,6 +369,43 @@ func (t *TaskHandlersTestSuite) verifyQueryResult(response interface{}, expected
 	t.Equal(expectedResult, queryResult)
 }
 
+func (t *TaskHandlersTestSuite) TestCacheEvictionWhenErrorOccurs() {
+	taskList := "taskList"
+	testEvents := []*s.HistoryEvent{
+		createTestEventWorkflowExecutionStarted(1, &s.WorkflowExecutionStartedEventAttributes{TaskList: &s.TaskList{Name: &taskList}}),
+		createTestEventDecisionTaskScheduled(2, &s.DecisionTaskScheduledEventAttributes{TaskList: &s.TaskList{Name: &taskList}}),
+		createTestEventDecisionTaskStarted(3),
+		createTestEventDecisionTaskCompleted(4, &s.DecisionTaskCompletedEventAttributes{ScheduledEventId: common.Int64Ptr(2)}),
+		createTestEventActivityTaskScheduled(5, &s.ActivityTaskScheduledEventAttributes{
+			ActivityId:   common.StringPtr("0"),
+			ActivityType: &s.ActivityType{Name: common.StringPtr("pkg.Greeter_Activity")},
+			TaskList:     &s.TaskList{Name: &taskList},
+		}),
+	}
+	params := workerExecutionParameters{
+		TaskList: taskList,
+		Identity: "test-id-1",
+		Logger:   zap.NewNop(),
+		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+	}
+
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	// now change the history event so it does not match to decision produced via replay
+	testEvents[4].ActivityTaskScheduledEventAttributes.ActivityType.Name = common.StringPtr("some-other-activity")
+	task := createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
+	// newWorkflowTaskWorkerInternal will set the laTunnel in taskHandler, without it, ProcessWorkflowTask()
+	// will fail as it can't find laTunnel in getWorkflowCache().
+	newWorkflowTaskWorkerInternal(taskHandler, t.service, testDomain, params)
+	request, _, err := taskHandler.ProcessWorkflowTask(task, nil)
+
+	t.Error(err)
+	t.Nil(request)
+	t.Contains(err.Error(), "nondeterministic")
+
+	// There should be nothing in the cache.
+	t.EqualValues(getWorkflowCache().Size(), 0)
+}
+
 func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	taskList := "taskList"
 	testEvents := []*s.HistoryEvent{
@@ -389,9 +426,8 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 		Logger:   zap.NewNop(),
 		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
 	}
-	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	newWorkflowTaskWorkerInternal(taskHandler, t.service,testDomain, params)
 
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
 	request, _, err := taskHandler.ProcessWorkflowTask(task, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	// there should be no error as the history events matched the decisions.
@@ -401,6 +437,9 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	// now change the history event so it does not match to decision produced via replay
 	testEvents[4].ActivityTaskScheduledEventAttributes.ActivityType.Name = common.StringPtr("some-other-activity")
 	task = createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
+	// newWorkflowTaskWorkerInternal will set the laTunnel in taskHandler, without it, ProcessWorkflowTask()
+	// will fail as it can't find laTunnel in getWorkflowCache().
+	newWorkflowTaskWorkerInternal(taskHandler, t.service, testDomain, params)
 	request, _, err = taskHandler.ProcessWorkflowTask(task, nil)
 	t.Error(err)
 	t.Nil(request)

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -248,7 +248,7 @@ func (wtp *workflowTaskPoller) processWorkflowTask(workflowTask *workflowTask) e
 	}
 	if response != nil && response.DecisionTask != nil {
 		wc.Lock()
-		defer wc.Unlock()
+		defer wc.Unlock(nil)
 		return wtp.processCompleteDecisionResponseLocked(response, wc)
 	}
 
@@ -280,7 +280,7 @@ func (wtp *workflowTaskPoller) scheduleRespondDecisionTaskCompleted(wc WorkflowE
 
 func (wtp *workflowTaskPoller) forceRespondDecisionTaskCompleted(wc WorkflowExecutionContext, workflowTask *workflowTask, startTime time.Time) {
 	wc.Lock()
-	defer wc.Unlock()
+	defer wc.Unlock(nil)
 
 	currentTask := wc.GetCurrentDecisionTask()
 	if currentTask != workflowTask.task {
@@ -342,7 +342,7 @@ func (wtp *workflowTaskPoller) processCompleteDecisionResponseLocked(response *s
 func (wtp *workflowTaskPoller) processLocalActivityResult(lar *localActivityResult) error {
 	w := lar.task.wc
 	w.Lock()
-	defer w.Unlock()
+	defer w.Unlock(nil)
 
 	decisionStartTime := w.decisionStartTime
 	decisionTask := w.currentDecisionTask

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -32,13 +32,13 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/uber-go/tally"
 	"go.uber.org/atomic"
 	"go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/internal/common"
 	"go.uber.org/cadence/internal/common/metrics"
 	"go.uber.org/zap"
-	"github.com/uber-go/tally"
 )
 
 const (
@@ -107,8 +107,8 @@ type (
 		closed          bool                  // true if channel is closed.
 		recValue        *interface{}          // Used only while receiving value, this is used as pre-fetch buffer value from the channel.
 		dataConverter   encoded.DataConverter // for decode data
-		scope			tally.Scope			  // Used to send metrics
-		logger			*zap.Logger
+		scope           tally.Scope           // Used to send metrics
+		logger          *zap.Logger
 	}
 
 	// Single case statement of the Select
@@ -523,7 +523,7 @@ func (c *channelImpl) Receive(ctx Context, valuePtr interface{}) (more bool) {
 		}
 
 		if ok || !m {
-			err:= c.assignValue(v, valuePtr)
+			err := c.assignValue(v, valuePtr)
 			if err == nil {
 				state.unblocked()
 				return m
@@ -532,7 +532,7 @@ func (c *channelImpl) Receive(ctx Context, valuePtr interface{}) (more bool) {
 		}
 		for {
 			if hasResult {
-				err:= c.assignValue(result, valuePtr)
+				err := c.assignValue(result, valuePtr)
 				if err == nil {
 					state.unblocked()
 					return more
@@ -551,13 +551,13 @@ func (c *channelImpl) ReceiveAsync(valuePtr interface{}) (ok bool) {
 }
 
 func (c *channelImpl) ReceiveAsyncWithMoreFlag(valuePtr interface{}) (ok bool, more bool) {
-	for{
+	for {
 		v, ok, more := c.receiveAsyncImpl(nil)
 		if !ok && !more { //channel closed and empty
-			return ok,more
+			return ok, more
 		}
 
-		err:=c.assignValue(v, valuePtr)
+		err := c.assignValue(v, valuePtr)
 		if err != nil {
 			continue
 			// keep consuming until a good signal is hit or channel is drained
@@ -682,7 +682,7 @@ func (c *channelImpl) Close() {
 }
 
 // Takes a value and assigns that 'to' value. logs a metric if it is unable to deserialize
-func (c *channelImpl) assignValue(from interface{}, to interface{}) (error) {
+func (c *channelImpl) assignValue(from interface{}, to interface{}) error {
 	err := decodeAndAssignValue(c.dataConverter, from, to)
 	//add to metrics
 	if err != nil {

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/zap"
 	"go.uber.org/cadence/internal/common/metrics"
+	"go.uber.org/zap"
 )
 
 type WorkflowUnitTest struct {
@@ -549,7 +549,7 @@ func (s *WorkflowUnitTest) Test_SignalWorkflow() {
 	s.EqualValues(strings.Join(expected, ""), string(result))
 }
 
-type message struct{
+type message struct {
 	Value string
 }
 
@@ -559,7 +559,7 @@ func receive_CorruptSignalWorkflowTest(ctx Context) ([]message, error) {
 	var m message
 	ch.Receive(ctx, &m)
 	result = append(result, m)
-	return result,nil
+	return result, nil
 }
 
 func receive_CorruptSignalOnClosedChannelWorkflowTest(ctx Context) ([]message, error) {
@@ -569,7 +569,7 @@ func receive_CorruptSignalOnClosedChannelWorkflowTest(ctx Context) ([]message, e
 	ch.Close()
 	ch.Receive(ctx, &m)
 	result = append(result, m)
-	return result,nil
+	return result, nil
 }
 
 func receiveWithSelector_CorruptSignalWorkflowTest(ctx Context) ([]message, error) {
@@ -584,7 +584,7 @@ func receiveWithSelector_CorruptSignalWorkflowTest(ctx Context) ([]message, erro
 		result = append(result, m)
 	})
 	s.Select(ctx)
-	return result,nil
+	return result, nil
 }
 
 func receiveAsync_CorruptSignalOnClosedChannelWorkflowTest(ctx Context) ([]int, error) {
@@ -599,7 +599,7 @@ func receiveAsync_CorruptSignalOnClosedChannelWorkflowTest(ctx Context) ([]int, 
 		result = append(result, m)
 	}
 
-	return result,nil
+	return result, nil
 }
 
 func receiveAysnc_CorruptSignalWorkflowTest(ctx Context) ([]message, error) {
@@ -614,14 +614,14 @@ func receiveAysnc_CorruptSignalWorkflowTest(ctx Context) ([]message, error) {
 	}
 
 	ch.SendAsync("wrong again")
-	ch.SendAsync(message {
-		Value:"the right interface",
+	ch.SendAsync(message{
+		Value: "the right interface",
 	})
 	ok = ch.ReceiveAsync(&m)
 	if ok == true {
 		result = append(result, m)
 	}
-	return result,nil
+	return result, nil
 }
 
 func (s *WorkflowUnitTest) Test_CorruptedSignalWorkflow_ShouldLogMetricsAndNotPanic() {
@@ -635,8 +635,8 @@ func (s *WorkflowUnitTest) Test_CorruptedSignalWorkflow_ShouldLogMetricsAndNotPa
 	}, time.Millisecond)
 
 	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow("channelExpectingTypeMessage", message {
-			Value:"the right interface",
+		env.SignalWorkflow("channelExpectingTypeMessage", message{
+			Value: "the right interface",
 		})
 	}, time.Second)
 
@@ -647,14 +647,14 @@ func (s *WorkflowUnitTest) Test_CorruptedSignalWorkflow_ShouldLogMetricsAndNotPa
 	var result []message
 	env.GetWorkflowResult(&result)
 
-	s.EqualValues(1,len(result))
-	s.EqualValues("the right interface",result[0].Value)
+	s.EqualValues(1, len(result))
+	s.EqualValues("the right interface", result[0].Value)
 
 	closer.Close()
- 	counts := reporter.Counts()
- 	s.EqualValues(1, len(counts))
- 	s.EqualValues(metrics.CorruptedSignalsCounter, counts[0].Name())
- 	s.EqualValues(1, counts[0].Value())
+	counts := reporter.Counts()
+	s.EqualValues(1, len(counts))
+	s.EqualValues(metrics.CorruptedSignalsCounter, counts[0].Name())
+	s.EqualValues(1, counts[0].Value())
 }
 
 func (s *WorkflowUnitTest) Test_CorruptedSignalWorkflow_OnSelectorRead_ShouldLogMetricsAndNotPanic() {
@@ -668,8 +668,8 @@ func (s *WorkflowUnitTest) Test_CorruptedSignalWorkflow_OnSelectorRead_ShouldLog
 	}, time.Second)
 
 	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow("channelExpectingTypeMessage", message {
-			Value:"the right interface",
+		env.SignalWorkflow("channelExpectingTypeMessage", message{
+			Value: "the right interface",
 		})
 	}, 3*time.Second)
 
@@ -680,8 +680,8 @@ func (s *WorkflowUnitTest) Test_CorruptedSignalWorkflow_OnSelectorRead_ShouldLog
 	var result []message
 	env.GetWorkflowResult(&result)
 
-	s.EqualValues(1,len(result))
-	s.EqualValues("the right interface",result[0].Value)
+	s.EqualValues(1, len(result))
+	s.EqualValues("the right interface", result[0].Value)
 
 	closer.Close()
 	counts := reporter.Counts()
@@ -701,8 +701,8 @@ func (s *WorkflowUnitTest) Test_CorruptedSignalWorkflow_ReceiveAsync_ShouldLogMe
 
 	var result []message
 	env.GetWorkflowResult(&result)
-	s.EqualValues(1,len(result))
- 	s.EqualValues("the right interface",result[0].Value)
+	s.EqualValues(1, len(result))
+	s.EqualValues("the right interface", result[0].Value)
 
 	closer.Close()
 	counts := reporter.Counts()
@@ -720,7 +720,7 @@ func (s *WorkflowUnitTest) Test_CorruptedSignalOnClosedChannelWorkflow_ReceiveAs
 
 	var result []message
 	env.GetWorkflowResult(&result)
-	s.EqualValues(0,len(result))
+	s.EqualValues(0, len(result))
 }
 
 func (s *WorkflowUnitTest) Test_CorruptedSignalOnClosedChannelWorkflow_Receive_ShouldComplete() {
@@ -730,14 +730,14 @@ func (s *WorkflowUnitTest) Test_CorruptedSignalOnClosedChannelWorkflow_Receive_S
 	env.RegisterDelayedCallback(func() {
 		env.SignalWorkflow("channelExpectingTypeMessage", "wrong")
 	}, time.Second)
-	
+
 	env.ExecuteWorkflow(receiveAsync_CorruptSignalOnClosedChannelWorkflowTest)
 	s.True(env.IsWorkflowCompleted())
 	s.NoError(env.GetWorkflowError())
 
 	var result []message
 	env.GetWorkflowResult(&result)
-	s.EqualValues(0,len(result))
+	s.EqualValues(0, len(result))
 }
 
 func activityOptionsWorkflow(ctx Context) (result string, err error) {

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -242,21 +242,21 @@ func NewChannel(ctx Context) Channel {
 // NewNamedChannel create new Channel instance with a given human readable name.
 // Name appears in stack traces that are blocked on this channel.
 func NewNamedChannel(ctx Context, name string) Channel {
-	env:=getWorkflowEnvironment(ctx)
-	return &channelImpl{name: name, dataConverter: getDataConverterFromWorkflowContext(ctx), scope:env.GetMetricsScope(), logger: env.GetLogger()}
+	env := getWorkflowEnvironment(ctx)
+	return &channelImpl{name: name, dataConverter: getDataConverterFromWorkflowContext(ctx), scope: env.GetMetricsScope(), logger: env.GetLogger()}
 }
 
 // NewBufferedChannel create new buffered Channel instance
 func NewBufferedChannel(ctx Context, size int) Channel {
-	env:=getWorkflowEnvironment(ctx)
-	return &channelImpl{size: size, dataConverter: getDataConverterFromWorkflowContext(ctx), scope:env.GetMetricsScope(), logger: env.GetLogger()}
+	env := getWorkflowEnvironment(ctx)
+	return &channelImpl{size: size, dataConverter: getDataConverterFromWorkflowContext(ctx), scope: env.GetMetricsScope(), logger: env.GetLogger()}
 }
 
 // NewNamedBufferedChannel create new BufferedChannel instance with a given human readable name.
 // Name appears in stack traces that are blocked on this Channel.
 func NewNamedBufferedChannel(ctx Context, name string, size int) Channel {
-	env:=getWorkflowEnvironment(ctx)
-	return &channelImpl{name: name, size: size, dataConverter: getDataConverterFromWorkflowContext(ctx), scope:env.GetMetricsScope(), logger: env.GetLogger()}
+	env := getWorkflowEnvironment(ctx)
+	return &channelImpl{name: name, size: size, dataConverter: getDataConverterFromWorkflowContext(ctx), scope: env.GetMetricsScope(), logger: env.GetLogger()}
 }
 
 // NewSelector creates a new Selector instance.


### PR DESCRIPTION
Previously if there is error during **getOrCreateWorkflowContext**, the  local cache is not cleared. Once **set workflowContext.err** and **Unlock()** will evict the cache proactively.  


Issue:
https://github.com/uber-go/cadence-client/issues/497