### PR TITLE
Add an AfterFn mock-delay-returning function

### DIFF
--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -66,7 +66,7 @@ type (
 		env  *TestWorkflowEnvironment
 
 		runFn        func(args mock.Arguments)
-		waitDuration time.Duration
+		waitDuration func() time.Duration
 	}
 )
 
@@ -332,7 +332,13 @@ func (c *MockCallWrapper) Run(fn func(args mock.Arguments)) *MockCallWrapper {
 
 // After sets how long to wait on workflow's clock before the mock call returns.
 func (c *MockCallWrapper) After(d time.Duration) *MockCallWrapper {
-	c.waitDuration = d
+	c.waitDuration = func() time.Duration { return d }
+	return c
+}
+
+// AfterFn sets a function which will tell how long to wait on workflow's clock before the mock call returns.
+func (c *MockCallWrapper) AfterFn(fn func() time.Duration) *MockCallWrapper {
+	c.waitDuration = fn
 	return c
 }
 


### PR DESCRIPTION
When combined with a func provided to Return, this can be used to
simulate dynamic / open-ended respons and delay sequences on activity
and workflow functions.

This is particularly useful for running tests with randomized behavior,
as now another important piece of behavior can be varied.  Previously
only the number of calls and the return value could be changed easily.

---

Since the MockCallWrapper (and testify's mock.Call) don't appear to validate
that e.g. "Return" isn't called multiple times, I didn't add an error / panic to
After or AfterFn to prevent combining them.
I'd be happy to panic on misuse / make other changes if you'd prefer!
Tests are also fairly simple at this point, in part because there are few helpers,
and to do a lot better would mean a lot of copypasta.  I can also do that though,
and mirror all the After tests / add extras if you'd like.