### PR TITLE
Reduce defaultDecisionTaskTimeout to 10

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -269,7 +269,7 @@ type (
 		// DecisionTaskStartToCloseTimeout - The time out for processing decision task from the time the worker
 		// pulled this task.
 		// The resolution is seconds.
-		// Optional: defaulted to 20 secs.
+		// Optional: defaulted to 10 secs.
 		DecisionTaskStartToCloseTimeout time.Duration
 
 		// WorkflowIDReusePolicy - Whether server allow reuse of workflow ID, can be useful

--- a/internal/client.go
+++ b/internal/client.go
@@ -267,7 +267,7 @@ type (
 		ExecutionStartToCloseTimeout time.Duration
 
 		// DecisionTaskStartToCloseTimeout - The time out for processing decision task from the time the worker
-		// pulled this task.
+		// pulled this task. If a decision task is lost, it is retried after this timeout.
 		// The resolution is seconds.
 		// Optional: defaulted to 10 secs.
 		DecisionTaskStartToCloseTimeout time.Duration

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -43,7 +43,7 @@ var _ Client = (*workflowClient)(nil)
 var _ DomainClient = (*domainClient)(nil)
 
 const (
-	defaultDecisionTaskTimeoutInSecs = 20
+	defaultDecisionTaskTimeoutInSecs = 10
 	defaultGetHistoryTimeoutInSecs   = 25
 )
 


### PR DESCRIPTION
Original 20 sec is a little be too conservative and not necessary, change to 10s