### PR TITLE
fix nil pointer in complete decision

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -741,6 +741,9 @@ func (w *workflowExecutionContextImpl) ProcessLocalActivityResult(lar *localActi
 }
 
 func (w *workflowExecutionContextImpl) CompleteDecisionTask(waitLocalActivities bool) interface{} {
+	if w.currentDecisionTask == nil {
+		return nil
+	}
 	if w.hasPendingLocalActivityWork() {
 		if len(w.eventHandler.unstartedLaTasks) > 0 {
 			// start new local activity tasks

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -283,7 +283,7 @@ func (wtp *workflowTaskPoller) forceRespondDecisionTaskCompleted(wc WorkflowExec
 	defer wc.Unlock(nil)
 
 	currentTask := wc.GetCurrentDecisionTask()
-	if currentTask != workflowTask.task {
+	if currentTask == nil || currentTask != workflowTask.task {
 		// decision task already completed
 		var currentTaskStartedEventID int64
 		if currentTask != nil {


### PR DESCRIPTION
when forceRespondDecisionTaskCompleted is called we need to check if currentDecisionTask is nil, if it is nil it means the task has already completed.