### PR TITLE
fix decision state machine

### DIFF
--- a/internal/internal_decision_state_machine.go
+++ b/internal/internal_decision_state_machine.go
@@ -398,7 +398,7 @@ func (d *activityDecisionStateMachine) getDecision() *s.Decision {
 		decision := createNewDecision(s.DecisionTypeScheduleActivityTask)
 		decision.ScheduleActivityTaskDecisionAttributes = d.attributes
 		return decision
-	case decisionStateCanceledAfterInitiated:
+	case decisionStateCanceledAfterInitiated, decisionStateCanceledBeforeInitiated:
 		decision := createNewDecision(s.DecisionTypeRequestCancelActivityTask)
 		decision.RequestCancelActivityTaskDecisionAttributes = &s.RequestCancelActivityTaskDecisionAttributes{
 			ActivityId: d.attributes.ActivityId,
@@ -411,7 +411,7 @@ func (d *activityDecisionStateMachine) getDecision() *s.Decision {
 
 func (d *activityDecisionStateMachine) handleDecisionSent() {
 	switch d.state {
-	case decisionStateCanceledAfterInitiated:
+	case decisionStateCanceledAfterInitiated, decisionStateCanceledBeforeInitiated:
 		d.moveState(decisionStateCancellationDecisionSent, eventDecisionSent)
 	default:
 		d.decisionStateMachineBase.handleDecisionSent()
@@ -438,7 +438,7 @@ func (d *timerDecisionStateMachine) isDone() bool {
 
 func (d *timerDecisionStateMachine) handleDecisionSent() {
 	switch d.state {
-	case decisionStateCanceledAfterInitiated:
+	case decisionStateCanceledAfterInitiated, decisionStateCanceledBeforeInitiated:
 		d.moveState(decisionStateCancellationDecisionSent, eventDecisionSent)
 	default:
 		d.decisionStateMachineBase.handleDecisionSent()
@@ -460,7 +460,7 @@ func (d *timerDecisionStateMachine) getDecision() *s.Decision {
 		decision := createNewDecision(s.DecisionTypeStartTimer)
 		decision.StartTimerDecisionAttributes = d.attributes
 		return decision
-	case decisionStateCanceledAfterInitiated:
+	case decisionStateCanceledAfterInitiated, decisionStateCanceledBeforeInitiated:
 		decision := createNewDecision(s.DecisionTypeCancelTimer)
 		decision.CancelTimerDecisionAttributes = &s.CancelTimerDecisionAttributes{
 			TimerId: d.attributes.TimerId,

--- a/internal/internal_decision_state_machine_test.go
+++ b/internal/internal_decision_state_machine_test.go
@@ -75,19 +75,25 @@ func Test_TimerStateMachine_CompletedAfterCancel(t *testing.T) {
 	h := newDecisionsHelper()
 	d := h.startTimer(attributes)
 	require.Equal(t, decisionStateCreated, d.getState())
+
 	decisions := h.getDecisions(true)
 	require.Equal(t, decisionStateDecisionSent, d.getState())
 	require.Equal(t, 1, len(decisions))
 	require.Equal(t, s.DecisionTypeStartTimer, decisions[0].GetDecisionType())
+
 	h.cancelTimer(timerID)
 	require.Equal(t, decisionStateCanceledBeforeInitiated, d.getState())
-	require.Equal(t, 0, len(h.getDecisions(true)))
+	decisions = h.getDecisions(false)
+	require.Equal(t, 1, len(decisions))
+	require.Equal(t, s.DecisionTypeCancelTimer, decisions[0].GetDecisionType())
+
 	h.handleTimerStarted(timerID)
 	require.Equal(t, decisionStateCanceledAfterInitiated, d.getState())
 	decisions = h.getDecisions(true)
 	require.Equal(t, 1, len(decisions))
 	require.Equal(t, s.DecisionTypeCancelTimer, decisions[0].GetDecisionType())
 	require.Equal(t, decisionStateCancellationDecisionSent, d.getState())
+
 	h.handleTimerClosed(timerID)
 	require.Equal(t, decisionStateCompletedAfterCancellationDecisionSent, d.getState())
 }
@@ -216,7 +222,9 @@ func Test_ActivityStateMachine_CancelAfterSent(t *testing.T) {
 	// cancel activity
 	h.requestCancelActivityTask(activityID)
 	require.Equal(t, decisionStateCanceledBeforeInitiated, d.getState())
-	require.Equal(t, 0, len(h.getDecisions(true)))
+	decisions = h.getDecisions(false)
+	require.Equal(t, 1, len(decisions))
+	require.Equal(t, s.DecisionTypeRequestCancelActivityTask, decisions[0].GetDecisionType())
 
 	// activity scheduled
 	h.handleActivityTaskScheduled(1, activityID)
@@ -248,7 +256,9 @@ func Test_ActivityStateMachine_CompletedAfterCancel(t *testing.T) {
 	// cancel activity
 	h.requestCancelActivityTask(activityID)
 	require.Equal(t, decisionStateCanceledBeforeInitiated, d.getState())
-	require.Equal(t, 0, len(h.getDecisions(true)))
+	decisions = h.getDecisions(false)
+	require.Equal(t, 1, len(decisions))
+	require.Equal(t, s.DecisionTypeRequestCancelActivityTask, decisions[0].GetDecisionType())
 
 	// activity scheduled
 	h.handleActivityTaskScheduled(1, activityID)


### PR DESCRIPTION
This will fix the https://github.com/uber-go/cadence-client/issues/530

This fix will send both StartTimer and CancelTimer in one decision task.
This is to unblock autobots team. We can discuss further on what is the alternative/ideal solution for this issue.