### PR TITLE
Fix decision state machine

### DIFF
--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -98,10 +98,11 @@ func Test_TimeoutError(t *testing.T) {
 		decisionsHelper: newDecisionsHelper(),
 		dataConverter:   newDefaultDataConverter(),
 	}
+	h := newDecisionsHelper()
 	var actualErr error
 	activityID := "activityID"
 	context.decisionsHelper.scheduledEventIDToActivityID[5] = activityID
-	di := newActivityDecisionStateMachine(
+	di := h.newActivityDecisionStateMachine(
 		&shared.ScheduleActivityTaskDecisionAttributes{ActivityId: common.StringPtr(activityID)})
 	di.state = decisionStateInitiated
 	di.setData(&scheduledActivity{

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -593,9 +593,9 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessEvent(
 	event *m.HistoryEvent,
 	isReplay bool,
 	isLast bool,
-) (result []*m.Decision, err error) {
+) (err error) {
 	if event == nil {
-		return nil, errors.New("nil event provided")
+		return errors.New("nil event provided")
 	}
 	defer func() {
 		if p := recover(); p != nil {
@@ -746,7 +746,7 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessEvent(
 	}
 
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// When replaying histories to get stack trace or current state the last event might be not
@@ -756,7 +756,7 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessEvent(
 		weh.workflowDefinition.OnDecisionTaskStarted()
 	}
 
-	return weh.decisionsHelper.getDecisions(true), nil
+	return nil
 }
 
 func (weh *workflowExecutionEventHandlerImpl) ProcessQuery(queryType string, queryArgs []byte) ([]byte, error) {
@@ -928,7 +928,7 @@ func (weh *workflowExecutionEventHandlerImpl) handleLocalActivityMarker(markerDa
 	return nil
 }
 
-func (weh *workflowExecutionEventHandlerImpl) ProcessLocalActivityResult(lar *localActivityResult) ([]*m.Decision, error) {
+func (weh *workflowExecutionEventHandlerImpl) ProcessLocalActivityResult(lar *localActivityResult) error {
 	// convert local activity result and error to marker data
 	lamd := localActivityMarkerData{
 		ActivityID: lar.task.activityID,
@@ -945,7 +945,7 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessLocalActivityResult(lar *lo
 	// encode marker data
 	markerData, err := weh.encodeArg(lamd)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// create marker event for local activity result


### PR DESCRIPTION
I think this is a better fix for #530 
Once we have this landed, I will revert #531 
Here are the changes:
1) Do not return decisions from ProcessEvent(). Previously, we get decisions after apply every event. Now, we only get decisions after apply each batch of events (one batch for one DecisionTasStarted) during replay, and also get last new decisions before we try to complete the decision task.

2) Preload LocalActivity marker event but apply them after applied the decision task started event. This is needed because we need to unblock the completed local activities. This reordering events is similar to what we already done for SideEffect/Version markers. This will not cause non-deterministic error because it only move LocalActivity marker ahead of other DecisionEvents and we know that all decision events only drive decision state machine to Initiated state and does not unblock any future/channel so it won't affect new decisions.

3) Remove decision state machine from helper once it state is completed. This is needed because previously we would get decisions after every event which will remove completed state machines but now we only get decisions for each batch of events. So if user code try to reuse ActivityID immediately after one activity is completed, after apply the first activity's completed event, we need to remove the state machine for that activity. Otherwise, the next activity as it reuse the duplicate ActivityID will have the same ID for the state machine and will have issue.

