### PR TITLE
Expose worker option to set ConcurrentDecisionTaskExecutionSize

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -61,7 +61,7 @@ const (
 	defaultTaskListActivitiesPerSecond = 100000.0 // Large activity executions/sec (unlimited)
 
 	defaultMaxConcurrentTaskExecutionSize = 1000   // hardcoded max task execution size.
-	defaultMaxTaskExecutionRate           = 100000 // Large task execution rate (unlimited)
+	defaultWorkerTaskExecutionRate        = 100000 // Large task execution rate (unlimited)
 
 	defaultPollerRate = 1000
 
@@ -115,6 +115,12 @@ type (
 
 		// Defines rate limiting on number of activity tasks that can be executed per second per worker.
 		WorkerActivitiesPerSecond float64
+
+		// Defines how many concurrent decision task executions by this worker.
+		ConcurrentDecisionTaskExecutionSize int
+
+		// Defines rate limiting on number of decision tasks that can be executed per second per worker.
+		WorkerDecisionTasksPerSecond float64
 
 		// Defines how many concurrent local activity executions by this worker.
 		ConcurrentLocalActivityExecutionSize int
@@ -257,8 +263,8 @@ func newWorkflowTaskWorkerInternal(
 	worker := newBaseWorker(baseWorkerOptions{
 		pollerCount:       params.ConcurrentPollRoutineSize,
 		pollerRate:        defaultPollerRate,
-		maxConcurrentTask: defaultMaxConcurrentTaskExecutionSize,
-		maxTaskPerSecond:  defaultMaxTaskExecutionRate,
+		maxConcurrentTask: params.ConcurrentDecisionTaskExecutionSize,
+		maxTaskPerSecond:  params.WorkerDecisionTasksPerSecond,
 		taskWorker:        poller,
 		identity:          params.Identity,
 		workerType:        "DecisionWorker"},
@@ -931,6 +937,8 @@ func newAggregatedWorker(
 		WorkerActivitiesPerSecond:            wOptions.WorkerActivitiesPerSecond,
 		ConcurrentLocalActivityExecutionSize: wOptions.MaxConcurrentLocalActivityExecutionSize,
 		WorkerLocalActivitiesPerSecond:       wOptions.WorkerLocalActivitiesPerSecond,
+		ConcurrentDecisionTaskExecutionSize:  wOptions.MaxConcurrentDecisionTaskExecutionSize,
+		WorkerDecisionTasksPerSecond:         wOptions.WorkerDecisionTasksPerSecond,
 		Identity:                             wOptions.Identity,
 		MetricsScope:                         wOptions.MetricsScope,
 		Logger:                               wOptions.Logger,
@@ -1150,6 +1158,12 @@ func fillWorkerOptionsDefaults(options WorkerOptions) WorkerOptions {
 	}
 	if options.WorkerActivitiesPerSecond == 0 {
 		options.WorkerActivitiesPerSecond = defaultWorkerActivitiesPerSecond
+	}
+	if options.MaxConcurrentDecisionTaskExecutionSize == 0 {
+		options.MaxConcurrentDecisionTaskExecutionSize = defaultMaxConcurrentTaskExecutionSize
+	}
+	if options.WorkerDecisionTasksPerSecond == 0 {
+		options.WorkerDecisionTasksPerSecond = defaultWorkerTaskExecutionRate
 	}
 	if options.MaxConcurrentLocalActivityExecutionSize == 0 {
 		options.MaxConcurrentLocalActivityExecutionSize = defaultMaxConcurrentLocalActivityExecutionSize

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -90,6 +90,16 @@ type (
 		// The zero value of this uses the default value. Default: 100k
 		TaskListActivitiesPerSecond float64
 
+		// Optional: To set the maximum concurrent decision task executions this worker can have.
+		// The zero value of this uses the default value.
+		// default: defaultMaxConcurrentTaskExecutionSize(1k)
+		MaxConcurrentDecisionTaskExecutionSize int
+
+		// Optional: Sets the rate limiting on number of decision tasks that can be executed per second per
+		// worker. This can be used to limit resources used by the worker.
+		// The zero value of this uses the default value. Default: 100k
+		WorkerDecisionTasksPerSecond float64
+
 		// Optional: if the activities need auto heart beating for those activities
 		// by the framework
 		// default: false not to heartbeat.


### PR DESCRIPTION
Autobots needs a way to set max concurrent execution for decision task. The default limit is 1K and we currently don't expose nob to control this. Autobots uses 20 task lists which means 20 workers so max of 20K concurrent task executions. The problem is if the workers are down while ingesters are still running, this will accumulate decision tasks. After some time, when the worker get started, the first few workers will be overloaded and crashed quickly because it poll down a ton of decision tasks, faster then it should be. The crash reduced the working worker and worse the problem.