### PR TITLE
Properly call ResetStickyTaskList when sticky entry is evicted from cache

### DIFF
--- a/evictiontest/workflow_cache_eviction_test.go
+++ b/evictiontest/workflow_cache_eviction_test.go
@@ -164,7 +164,7 @@ func (s *CacheEvictionSuite) TestResetStickyOnEviction() {
 	// this is the critical point of the test.
 	// ResetSticky should be called exactly once because our workflow cache evicts when full
 	// so if our worker puts *cacheSize* entries in the cache, it should evict exactly one
-	s.service.EXPECT().ResetStickyTaskList(gomock.Any(), gomock.Any()).DoAndReturn(mockResetStickyTaskList).Times(1)
+	s.service.EXPECT().ResetStickyTaskList(gomock.Any(), gomock.Any(), callOptions...).DoAndReturn(mockResetStickyTaskList).Times(1)
 
 	workflowWorker := internal.NewWorker(s.service, "test-domain", "tasklist", worker.Options{DisableActivityWorker: true})
 


### PR DESCRIPTION
The context was not properly set so the call always fail with error camplaining the TTL is not set. It looks like this code was never tested end to end, that is sad. :(