### PR TITLE
Ignore result when error is not nil

### DIFF
--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -485,8 +485,8 @@ func (t *TestWorkflowEnvironment) GetWorkflowResult(valuePtr interface{}) error 
 	if !t.impl.isTestCompleted {
 		panic("workflow is not completed")
 	}
-	if t.impl.testResult == nil {
-		return nil
+	if t.impl.testError != nil || t.impl.testResult == nil || valuePtr == nil {
+		return t.impl.testError
 	}
 	return t.impl.testResult.Get(valuePtr)
 }


### PR DESCRIPTION
The Future.Get() will ignore the value if the err is not nil. This is also true for workflow. When workflow returns non-nil error, the worker only report the error to server and ignore the result. We should keep the test framework the same behavior to ignore the value when error is not nil.
