### PR TITLE
server side retry

### DIFF
--- a/cadence.go
+++ b/cadence.go
@@ -44,3 +44,8 @@
 //
 // testsuite - unit testing framework for activity and workflow testing.
 package cadence
+
+import "go.uber.org/cadence/internal"
+
+// RetryPolicy defines the retry policy for activity/workflow.
+type RetryPolicy = internal.RetryPolicy

--- a/internal/client.go
+++ b/internal/client.go
@@ -276,6 +276,40 @@ type (
 		// for dedup logic if set to WorkflowIdReusePolicyRejectDuplicate.
 		// Optional: defaulted to WorkflowIDReusePolicyAllowDuplicateFailedOnly.
 		WorkflowIDReusePolicy WorkflowIDReusePolicy
+
+		// RetryPolicy - Optional retry policy for workflow.
+		RetryPolicy *RetryPolicy
+	}
+
+	// RetryPolicy defines the retry policy
+	RetryPolicy struct {
+		// Backoff interval for the first retry. If coefficient is 1.0 then it is used for all retries.
+		// Required, no default value.
+		InitialInterval time.Duration
+
+		// Coefficient used to calculate the next retry backoff interval.
+		// The next retry interval is previous interval multiplied by this coefficient.
+		// Must be 1 or larger. Default is 2.0.
+		BackoffCoefficient float64
+
+		// Maximum backoff interval between retries. Exponential backoff leads to interval increase.
+		// This value is the cap of the interval. Default is 100x of initial interval.
+		MaximumInterval time.Duration
+
+		// Maximum time to retry.
+		// When exceeded the retries stop even if maximum retries is not reached yet.
+		// If not set, it means forever, and rely on MaximumAttempts to stop.
+		// It is not allowed to have both ExpirationInterval and MaximumAttempts not set.
+		ExpirationInterval time.Duration
+
+		// Maximum number of attempts. When exceeded the retries stop even if not expired yet.
+		// Must be 1 or bigger.
+		// If not set, it means unlimited, and rely on ExpirationInterval to stop.
+		// It is not allowed to have both ExpirationInterval and MaximumAttempts not set.
+		MaximumAttempts int32
+
+		// Non-Retriable errors. Will stop retrying if error reason matches this list.
+		NonRetriableErrorReasons []string
 	}
 
 	// DomainClient is the client for managing operations on the domain.

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -292,6 +292,7 @@ func (wc *workflowEnvironmentImpl) ExecuteChildWorkflow(
 	attributes.WorkflowType = workflowTypePtr(*params.workflowType)
 	attributes.ChildPolicy = params.childPolicy.toThriftChildPolicyPtr()
 	attributes.WorkflowIdReusePolicy = params.workflowIDReusePolicy.toThriftPtr()
+	attributes.RetryPolicy = params.retryPolicy
 
 	decision := wc.decisionsHelper.startChildWorkflowExecution(attributes)
 	decision.setData(&scheduledChildWorkflow{
@@ -362,6 +363,7 @@ func (wc *workflowEnvironmentImpl) ExecuteActivity(parameters executeActivityPar
 	scheduleTaskAttr.StartToCloseTimeoutSeconds = common.Int32Ptr(parameters.StartToCloseTimeoutSeconds)
 	scheduleTaskAttr.ScheduleToStartTimeoutSeconds = common.Int32Ptr(parameters.ScheduleToStartTimeoutSeconds)
 	scheduleTaskAttr.HeartbeatTimeoutSeconds = common.Int32Ptr(parameters.HeartbeatTimeoutSeconds)
+	scheduleTaskAttr.RetryPolicy = parameters.RetryPolicy
 
 	decision := wc.decisionsHelper.scheduleActivityTask(scheduleTaskAttr)
 	decision.setData(&scheduledActivity{

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -496,7 +496,8 @@ func (wth *workflowTaskHandlerImpl) createWorkflowContext(task *s.PollForDecisio
 		},
 		ExecutionStartToCloseTimeoutSeconds: attributes.GetExecutionStartToCloseTimeoutSeconds(),
 		TaskStartToCloseTimeoutSeconds:      attributes.GetTaskStartToCloseTimeoutSeconds(),
-		Domain: wth.domain,
+		Domain:  wth.domain,
+		Attempt: attributes.GetAttempt(),
 	}
 
 	wfStartTime := time.Unix(0, h.Events[0].GetTimestamp())

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -169,6 +169,7 @@ type (
 		queryHandlers                       map[string]func([]byte) ([]byte, error)
 		workflowIDReusePolicy               WorkflowIDReusePolicy
 		dataConverter                       encoded.DataConverter
+		retryPolicy                         *shared.RetryPolicy
 	}
 
 	executeWorkflowParams struct {
@@ -1090,6 +1091,9 @@ func getValidatedWorkflowOptions(ctx Context) (*workflowOptions, error) {
 	}
 	if p.executionStartToCloseTimeoutSeconds == nil || *p.executionStartToCloseTimeoutSeconds <= 0 {
 		return nil, errors.New("missing or invalid ExecutionStartToCloseTimeout")
+	}
+	if err := validateRetryPolicy(p.retryPolicy); err != nil {
+		return nil, err
 	}
 
 	return p, nil

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -178,6 +178,7 @@ func (wc *workflowClient) StartWorkflow(
 		TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(decisionTaskTimeout),
 		Identity:                            common.StringPtr(wc.identity),
 		WorkflowIdReusePolicy:               options.WorkflowIDReusePolicy.toThriftPtr(),
+		RetryPolicy:                         convertRetryPolicy(options.RetryPolicy),
 	}
 
 	var response *s.StartWorkflowExecutionResponse
@@ -327,6 +328,7 @@ func (wc *workflowClient) SignalWithStartWorkflow(ctx context.Context, workflowI
 		SignalName:                          common.StringPtr(signalName),
 		SignalInput:                         signalInput,
 		Identity:                            common.StringPtr(wc.identity),
+		RetryPolicy:                         convertRetryPolicy(options.RetryPolicy),
 	}
 
 	var response *s.StartWorkflowExecutionResponse

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -176,6 +176,10 @@ type (
 		// WorkflowIDReusePolicy - Whether server allow reuse of workflow ID, can be useful
 		// for dedup logic if set to WorkflowIdReusePolicyRejectDuplicate
 		WorkflowIDReusePolicy WorkflowIDReusePolicy
+
+		// RetryPolicy specify how to retry child workflow if error happens.
+		// Optional: default is no retry
+		RetryPolicy *RetryPolicy
 	}
 
 	// ChildWorkflowPolicy defines child workflow behavior when parent workflow is terminated.
@@ -534,6 +538,7 @@ type WorkflowInfo struct {
 	ExecutionStartToCloseTimeoutSeconds int32
 	TaskStartToCloseTimeoutSeconds      int32
 	Domain                              string
+	Attempt                             int32 // Attempt starts from 0 and increased by 1 for every retry if retry policy is specified.
 }
 
 // GetWorkflowInfo extracts info of a current workflow from a context.
@@ -711,6 +716,7 @@ func WithChildWorkflowOptions(ctx Context, cwo ChildWorkflowOptions) Context {
 	wfOptions.childPolicy = cwo.ChildPolicy
 	wfOptions.waitForCancellation = cwo.WaitForCancellation
 	wfOptions.workflowIDReusePolicy = cwo.WorkflowIDReusePolicy
+	wfOptions.retryPolicy = convertRetryPolicy(cwo.RetryPolicy)
 
 	return ctx1
 }


### PR DESCRIPTION
Expose RetryPolicy and add support for server side retry for activity and childWorkflow.
Also add RetryPolicy to start workflow options to support from StartWorkflow API.

LocalActivity will be handled separately.