### PR TITLE
Local retry for local activity

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -48,7 +48,7 @@ type (
 		ScheduledTimestamp time.Time     // Time of activity scheduled by a workflow
 		StartedTimestamp   time.Time     // Time of activity start
 		Deadline           time.Time     // Time of activity timeout
-		Attempt            int           // Attempt starts from 0, and increased by 1 for every retry if retry policy is specified.
+		Attempt            int32         // Attempt starts from 0, and increased by 1 for every retry if retry policy is specified.
 	}
 
 	// RegisterActivityOptions consists of options for registering an activity
@@ -102,6 +102,10 @@ type (
 		// ScheduleToCloseTimeout - The end to end timeout for the local activity.
 		// This field is required.
 		ScheduleToCloseTimeout time.Duration
+
+		// RetryPolicy specify how to retry activity if error happens.
+		// Optional: default is no retry
+		RetryPolicy *RetryPolicy
 	}
 )
 
@@ -251,7 +255,7 @@ func WithActivityTask(
 		startedTimestamp:   started,
 		taskList:           taskList,
 		dataConverter:      dataConverter,
-		attempt:            int(task.GetAttempt()),
+		attempt:            task.GetAttempt(),
 	})
 }
 
@@ -281,6 +285,7 @@ func WithLocalActivityOptions(ctx Context, options LocalActivityOptions) Context
 	opts := getLocalActivityOptions(ctx1)
 
 	opts.ScheduleToCloseTimeoutSeconds = common.Int32Ceil(options.ScheduleToCloseTimeout.Seconds())
+	opts.RetryPolicy = options.RetryPolicy
 	return ctx1
 }
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -309,6 +309,11 @@ type (
 		MaximumAttempts int32
 
 		// Non-Retriable errors. Cadence server will stop retry if error reason matches this list.
+		// By default, all failures will be retried except SCHEDULE_TO_START timeout failure. For SCHEDULE_TO_START
+		// timeout, instead of retry, you should increase that timeout.
+		// Error reason for custom error is specified when your activity/workflow return cadence.NewCustomError(reason).
+		// Error reasons for timeouts are: "timeout:START_TO_CLOSE" and "timeout:SCHEDULE_TO_CLOSE".
+		// Note, cancellation is not a failure, so it won't be retried.
 		NonRetriableErrorReasons []string
 	}
 

--- a/internal/internal_activity.go
+++ b/internal/internal_activity.go
@@ -67,6 +67,7 @@ type (
 
 	localActivityOptions struct {
 		ScheduleToCloseTimeoutSeconds int32
+		RetryPolicy                   *RetryPolicy
 	}
 
 	executeActivityParams struct {
@@ -82,6 +83,8 @@ type (
 		InputArgs     []interface{}
 		WorkflowInfo  *WorkflowInfo
 		DataConverter encoded.DataConverter
+		Attempt       int32
+		ScheduledTime time.Time
 	}
 
 	// asyncActivityClient for requesting activity execution
@@ -99,7 +102,7 @@ type (
 
 	// localActivityClient for requesting local activity execution
 	localActivityClient interface {
-		ExecuteLocalActivity(params executeLocalActivityParams, callback resultHandler) *localActivityInfo
+		ExecuteLocalActivity(params executeLocalActivityParams, callback laResultHandler) *localActivityInfo
 
 		RequestCancelLocalActivity(activityID string)
 	}
@@ -119,7 +122,7 @@ type (
 		startedTimestamp   time.Time
 		taskList           string
 		dataConverter      encoded.DataConverter
-		attempt            int // starts from 0.
+		attempt            int32 // starts from 0.
 	}
 
 	// context.WithValue need this type instead of basic type string to avoid lint error

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -117,9 +117,10 @@ type (
 	}
 
 	localActivityResult struct {
-		result []byte
-		err    error
-		task   *localActivityTask
+		result  []byte
+		err     error
+		task    *localActivityTask
+		backoff time.Duration
 	}
 
 	localActivityTunnel struct {
@@ -480,6 +481,7 @@ func (lath *localActivityTaskHandler) executeLocalActivityTask(task *localActivi
 		metricsScope:      lath.metricsScope,
 		isLocalActivity:   true,
 		dataConverter:     lath.dataConverter,
+		attempt:           task.attempt,
 	})
 
 	// panic handler
@@ -505,6 +507,10 @@ func (lath *localActivityTaskHandler) executeLocalActivityTask(task *localActivi
 
 	timeoutDuration := time.Duration(task.params.ScheduleToCloseTimeoutSeconds) * time.Second
 	deadline := time.Now().Add(timeoutDuration)
+	if task.attempt > 0 && !task.expireTime.IsZero() && task.expireTime.Before(deadline) {
+		// this is attempt and expire time is before SCHEDULE_TO_CLOSE timeout
+		deadline = task.expireTime
+	}
 	ctx, cancel := context.WithDeadline(ctx, deadline)
 	task.Lock()
 	if task.canceled {

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -49,7 +49,15 @@ var (
 
 type (
 	// resultHandler that returns result
-	resultHandler func(result []byte, err error)
+	resultHandler   func(result []byte, err error)
+	laResultHandler func(lar *localActivityResultWrapper)
+
+	localActivityResultWrapper struct {
+		err     error
+		result  []byte
+		attempt int32
+		backoff time.Duration
+	}
 
 	// workflowEnvironment Represents the environment for workflow/decider.
 	// Should only be used within the scope of workflow definition


### PR DESCRIPTION
Add RetryPolicy to LocalActivityOption.
If the backoff duration is less than DecisionTaskTimeout, simply do the local retry. Otherwise, create a user timer on server and retry after that.

Here is how it works:
When local activity result is send back by local activity worker to workflow context, it checks if it succeed or failed. If it failed, it check if a retry is needed or not. If a retry is needed, it does not post the result/err to workflow, instead, it uses time.After() to schedule a backoff timer and when that local timer fires, it post the task (with increased attempt) to local activity worker. If the backoff is too large (larger than DecisionTaskTimeout), then it would post the local activity result/err with attempt and backoff to workflow which will store it as a marker. In workflow.ExecuteLocalActivity(), it checks the local activity result before set value to the future. If there is error and a valid backoff is present, it will call workflow.Sleep() and then do retry the local activity again.

Note: RetryPolicy is not supported by test framework yet, will address that separately.