### PR TITLE
Emit StickyCacheEvict metrics

### DIFF
--- a/internal/common/metrics/constants.go
+++ b/internal/common/metrics/constants.go
@@ -91,6 +91,7 @@ const (
 
 	StickyCacheHit   = CadenceMetricsPrefix + "sticky-cache-hit"
 	StickyCacheMiss  = CadenceMetricsPrefix + "sticky-cache-miss"
+	StickyCacheEvict = CadenceMetricsPrefix + "sticky-cache-evict"
 	StickyCacheStall = CadenceMetricsPrefix + "sticky-cache-stall"
 	StickyCacheSize  = CadenceMetricsPrefix + "sticky-cache-size"
 

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1413,7 +1413,7 @@ func (i *cadenceInvoker) internalHeartBeat(details []byte) (bool, error) {
 		i.cancelHandler()
 		isActivityCancelled = true
 
-	case *s.EntityNotExistsError,*s.DomainNotActiveError:
+	case *s.EntityNotExistsError, *s.DomainNotActiveError:
 		// We will pass these through as cancellation for now but something we can change
 		// later when we have setter on cancel handler.
 		i.cancelHandler()

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -578,7 +578,7 @@ func (t *TaskHandlersTestSuite) TestHeartBeat_NilResponseWithDomainNotActiveErro
 	mockService.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), callOptions...).Return(nil, domainNotActiveError)
 
 	called := false
-	cancelHandler := func () { called = true }
+	cancelHandler := func() { called = true }
 
 	cadenceInvoker := newServiceInvoker(
 		nil,

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -255,6 +255,7 @@ func (wtp *workflowTaskPoller) processWorkflowTask(workflowTask *workflowTask) e
 func (wtp *workflowTaskPoller) processResetStickinessTask(rst *resetStickinessTask) error {
 	tchCtx, cancel, opt := newChannelContext(context.Background())
 	defer cancel()
+	wtp.metricsScope.Counter(metrics.StickyCacheEvict).Inc(1)
 	if _, err := wtp.service.ResetStickyTaskList(tchCtx, rst.task, opt...); err != nil {
 		wtp.logger.Warn("ResetStickyTaskList failed",
 			zap.String(tagWorkflowID, rst.task.Execution.GetWorkflowId()),


### PR DESCRIPTION
Since we are now reset the stickiness when workflow context is evicted from the sticky cache on client side, so we almost never see sticky cache miss metrics anymore.
This is simply to emit the evict as a new metric.
