### PR TITLE
Enable signal to child workflow in test framework

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1584,18 +1584,18 @@ func (env *testWorkflowEnvironmentImpl) signalWorkflow(name string, input interf
 	}, true)
 }
 
-func (env *testWorkflowEnvironmentImpl) signalChildWorkflow(workflowID, signalName string, input interface{}) error {
+func (env *testWorkflowEnvironmentImpl) signalWorkflowByID(workflowID, signalName string, input interface{}) error {
 	data, err := encodeArg(env.GetDataConverter(), input)
 	if err != nil {
 		panic(err)
 	}
 
-	if childWorkflowHandle, ok := env.runningWorkflows[workflowID]; ok {
-		if childWorkflowHandle.handled {
+	if workflowHandle, ok := env.runningWorkflows[workflowID]; ok {
+		if workflowHandle.handled {
 			return &shared.EntityNotExistsError{Message: fmt.Sprintf("Workflow %v already completed", workflowID)}
 		}
-		childWorkflowHandle.env.postCallback(func() {
-			childWorkflowHandle.env.signalHandler(signalName, data)
+		workflowHandle.env.postCallback(func() {
+			workflowHandle.env.signalHandler(signalName, data)
 		}, true)
 		return nil
 	}

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -355,10 +355,10 @@ func (env *testWorkflowEnvironmentImpl) executeWorkflow(workflowFn interface{}, 
 	if err != nil {
 		panic(err)
 	}
-	env.executeWorkflowInternal(workflowType.Name, input)
+	env.executeWorkflowInternal(0, workflowType.Name, input)
 }
 
-func (env *testWorkflowEnvironmentImpl) executeWorkflowInternal(workflowType string, input []byte) {
+func (env *testWorkflowEnvironmentImpl) executeWorkflowInternal(delayStart time.Duration, workflowType string, input []byte) {
 	env.workflowInfo.WorkflowType.Name = workflowType
 	workflowDefinition, err := env.getWorkflowDefinition(env.workflowInfo.WorkflowType)
 	if err != nil {
@@ -371,7 +371,16 @@ func (env *testWorkflowEnvironmentImpl) executeWorkflowInternal(workflowType str
 	env.postCallback(func() {
 		env.workflowDef.Execute(env, input)
 		// kick off first decision task to start the workflow
-		env.startDecisionTask()
+		if delayStart == 0 {
+			env.startDecisionTask()
+		} else {
+			// we need to delayStart start workflow, decrease runningCount so mockClock could auto forward
+			env.runningCount--
+			env.registerDelayedCallback(func() {
+				env.runningCount++
+				env.startDecisionTask()
+			}, delayStart)
+		}
 	}, false)
 	env.startMainLoop()
 }
@@ -711,13 +720,11 @@ func (h *testWorkflowHandle) retryAsChild() bool {
 		}
 		backoff := getRetryBackoffFromThriftRetryPolicy(params.retryPolicy, env.workflowInfo.Attempt, errReason, env.Now(), expireTime)
 		if backoff > 0 {
-			env.registerDelayedCallback(func() {
-				// remove the current child workflow from the pending child workflow map because
-				// the childWorkflowID will be the same for retry run.
-				delete(env.runningWorkflows, env.workflowInfo.WorkflowExecution.ID)
-				params.attempt++
-				env.parentEnv.ExecuteChildWorkflow(*params, h.callback, nil /* child workflow already started */)
-			}, backoff)
+			// remove the current child workflow from the pending child workflow map because
+			// the childWorkflowID will be the same for retry run.
+			delete(env.runningWorkflows, env.workflowInfo.WorkflowExecution.ID)
+			params.attempt++
+			env.parentEnv.executeChildWorkflowWithDelay(backoff, *params, h.callback, nil /* child workflow already started */)
 
 			return true
 		}
@@ -1492,6 +1499,10 @@ func (env *testWorkflowEnvironmentImpl) SignalExternalWorkflow(domainName, workf
 }
 
 func (env *testWorkflowEnvironmentImpl) ExecuteChildWorkflow(params executeWorkflowParams, callback resultHandler, startedHandler func(r WorkflowExecution, e error)) error {
+	return env.executeChildWorkflowWithDelay(0, params, callback, startedHandler)
+}
+
+func (env *testWorkflowEnvironmentImpl) executeChildWorkflowWithDelay(delayStart time.Duration, params executeWorkflowParams, callback resultHandler, startedHandler func(r WorkflowExecution, e error)) error {
 	childEnv, err := env.newTestWorkflowEnvironmentForChild(&params, callback, startedHandler)
 	if err != nil {
 		env.logger.Sugar().Infof("ExecuteChildWorkflow failed: %v", err)
@@ -1502,7 +1513,7 @@ func (env *testWorkflowEnvironmentImpl) ExecuteChildWorkflow(params executeWorkf
 	env.runningCount++
 
 	// run child workflow in separate goroutinue
-	go childEnv.executeWorkflowInternal(params.workflowType.Name, params.input)
+	go childEnv.executeWorkflowInternal(delayStart, params.workflowType.Name, params.input)
 
 	return nil
 }
@@ -1571,6 +1582,25 @@ func (env *testWorkflowEnvironmentImpl) signalWorkflow(name string, input interf
 	env.postCallback(func() {
 		env.signalHandler(name, data)
 	}, true)
+}
+
+func (env *testWorkflowEnvironmentImpl) signalChildWorkflow(workflowID, signalName string, input interface{}) error {
+	data, err := encodeArg(env.GetDataConverter(), input)
+	if err != nil {
+		panic(err)
+	}
+
+	if childWorkflowHandle, ok := env.runningWorkflows[workflowID]; ok {
+		if childWorkflowHandle.handled {
+			return &shared.EntityNotExistsError{Message: fmt.Sprintf("Workflow %v already completed", workflowID)}
+		}
+		childWorkflowHandle.env.postCallback(func() {
+			childWorkflowHandle.env.signalHandler(signalName, data)
+		}, true)
+		return nil
+	}
+
+	return &shared.EntityNotExistsError{Message: fmt.Sprintf("Workflow %v not exists", workflowID)}
 }
 
 func (env *testWorkflowEnvironmentImpl) queryWorkflow(queryType string, args ...interface{}) (encoded.Value, error) {

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -769,7 +769,6 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflow_Clock() {
 	RegisterWorkflow(workflowFn)
 	RegisterWorkflow(childWorkflowFn)
 	env := s.NewTestWorkflowEnvironment()
-	env.SetTestTimeout(time.Hour)
 
 	env.ExecuteWorkflow(workflowFn)
 
@@ -1887,7 +1886,6 @@ func (s *WorkflowTestSuiteUnitTest) Test_LocalActivityRetry() {
 	}
 
 	env := s.NewTestWorkflowEnvironment()
-	env.SetTestTimeout(time.Hour)
 	RegisterWorkflow(workflowFn)
 	env.ExecuteWorkflow(workflowFn)
 
@@ -1931,7 +1929,6 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflowRetry() {
 	}
 
 	env := s.NewTestWorkflowEnvironment()
-	env.SetTestTimeout(time.Hour)
 	RegisterWorkflow(childWorkflowFn)
 	RegisterWorkflow(workflowFn)
 	env.ExecuteWorkflow(workflowFn)
@@ -1941,4 +1938,64 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflowRetry() {
 	var result string
 	s.NoError(env.GetWorkflowResult(&result))
 	s.Equal("retry-done", result)
+}
+
+func (s *WorkflowTestSuiteUnitTest) Test_SignalChildWorkflowRetry() {
+	childWorkflowFn := func(ctx Context) (string, error) {
+		info := GetWorkflowInfo(ctx)
+		if info.Attempt < 2 {
+			return "", NewCustomError("bad-luck")
+		}
+
+		ch := GetSignalChannel(ctx, "test-signal-name")
+		timeout := NewTimer(ctx, time.Second*3)
+		s := NewSelector(ctx)
+		var signal string
+		s.AddFuture(timeout, func(f Future) {
+			signal = "timeout"
+		}).AddReceive(ch, func(c Channel, more bool) {
+			c.Receive(ctx, &signal)
+		}).Select(ctx)
+
+		return signal, nil
+	}
+
+	workflowFn := func(ctx Context) (string, error) {
+		cwo := ChildWorkflowOptions{
+			WorkflowID:                   "test-retry-signal-child-workflow",
+			ExecutionStartToCloseTimeout: time.Minute,
+			RetryPolicy: &RetryPolicy{
+				MaximumAttempts:          3,
+				InitialInterval:          time.Second * 3,
+				MaximumInterval:          time.Second * 3,
+				BackoffCoefficient:       1,
+				NonRetriableErrorReasons: []string{"bad-bug"},
+				ExpirationInterval:       time.Minute,
+			},
+		}
+		ctx = WithChildWorkflowOptions(ctx, cwo)
+		var childResult string
+		err := ExecuteChildWorkflow(ctx, childWorkflowFn).Get(ctx, &childResult)
+		if err != nil {
+			return "", err
+		}
+
+		return childResult, nil
+	}
+
+	env := s.NewTestWorkflowEnvironment()
+	RegisterWorkflow(childWorkflowFn)
+	RegisterWorkflow(workflowFn)
+
+	env.RegisterDelayedCallback(func() {
+		env.SignalChildWorkflow("test-retry-signal-child-workflow", "test-signal-name", "test-signal-data")
+	}, time.Second*7 /* after 2nd attempt failed, but before 3rd attempt starts */)
+
+	env.ExecuteWorkflow(workflowFn)
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	var result string
+	s.NoError(env.GetWorkflowResult(&result))
+	s.Equal("test-signal-data", result)
 }

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -1988,7 +1988,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_SignalChildWorkflowRetry() {
 	RegisterWorkflow(workflowFn)
 
 	env.RegisterDelayedCallback(func() {
-		env.SignalChildWorkflow("test-retry-signal-child-workflow", "test-signal-name", "test-signal-data")
+		env.SignalWorkflowByID("test-retry-signal-child-workflow", "test-signal-name", "test-signal-data")
 	}, time.Second*7 /* after 2nd attempt failed, but before 3rd attempt starts */)
 
 	env.ExecuteWorkflow(workflowFn)

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -117,7 +117,7 @@ type (
 		//  }
 		GetChildWorkflowExecution() Future
 
-		// SignalChildWorkflow sends a signal to the child workflow. This call will block until child workflow is started.
+		// SignalWorkflowByID sends a signal to the child workflow. This call will block until child workflow is started.
 		SignalChildWorkflow(ctx Context, signalName string, data interface{}) Future
 	}
 

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -511,9 +511,9 @@ func (t *TestWorkflowEnvironment) SignalWorkflow(name string, input interface{})
 	t.impl.signalWorkflow(name, input)
 }
 
-// SignalWorkflow sends signal to the currently running test workflow.
-func (t *TestWorkflowEnvironment) SignalChildWorkflow(workflowID, signalName string, input interface{}) error {
-	return t.impl.signalChildWorkflow(workflowID, signalName, input)
+// SignalWorkflowByID sends signal to the currently running test workflow.
+func (t *TestWorkflowEnvironment) SignalWorkflowByID(workflowID, signalName string, input interface{}) error {
+	return t.impl.signalWorkflowByID(workflowID, signalName, input)
 }
 
 // QueryWorkflow queries to the currently running test workflow and returns result synchronously.

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -511,6 +511,11 @@ func (t *TestWorkflowEnvironment) SignalWorkflow(name string, input interface{})
 	t.impl.signalWorkflow(name, input)
 }
 
+// SignalWorkflow sends signal to the currently running test workflow.
+func (t *TestWorkflowEnvironment) SignalChildWorkflow(workflowID, signalName string, input interface{}) error {
+	return t.impl.signalChildWorkflow(workflowID, signalName, input)
+}
+
 // QueryWorkflow queries to the currently running test workflow and returns result synchronously.
 func (t *TestWorkflowEnvironment) QueryWorkflow(queryType string, args ...interface{}) (encoded.Value, error) {
 	return t.impl.queryWorkflow(queryType, args...)


### PR DESCRIPTION
Add TestWorkflowEnvironment.SignalChildWorlfow(). Also modify the retry for child workflow to make sure the signal send during backoff time is delivered to the next attempt.