### PR TITLE
Fix max concurrent decision task

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -112,15 +112,16 @@ type (
 
 	localActivityTask struct {
 		sync.Mutex
-		activityID  string
-		params      *executeLocalActivityParams
-		callback    laResultHandler
-		wc          *workflowExecutionContextImpl
-		canceled    bool
-		cancelFunc  func()
-		attempt     int32 // attempt starting from 0
-		retryPolicy *RetryPolicy
-		expireTime  time.Time
+		workflowTask *workflowTask
+		activityID   string
+		params       *executeLocalActivityParams
+		callback     laResultHandler
+		wc           *workflowExecutionContextImpl
+		canceled     bool
+		cancelFunc   func()
+		attempt      int32 // attempt starting from 0
+		retryPolicy  *RetryPolicy
+		expireTime   time.Time
 	}
 
 	localActivityMarkerData struct {

--- a/internal/internal_public.go
+++ b/internal/internal_public.go
@@ -49,8 +49,8 @@ type (
 	WorkflowExecutionContext interface {
 		Lock()
 		Unlock(err error)
-		ProcessWorkflowTask(task *s.PollForDecisionTaskResponse, historyIterator HistoryIterator) (completeRequest interface{}, err error)
-		ProcessLocalActivityResult(lar *localActivityResult) (interface{}, error)
+		ProcessWorkflowTask(workflowTask *workflowTask) (completeRequest interface{}, err error)
+		ProcessLocalActivityResult(workflowTask *workflowTask, lar *localActivityResult) (interface{}, error)
 		// CompleteDecisionTask try to complete current decision task and get response that needs to be sent back to server.
 		// The waitLocalActivity is used to control if we should wait for outstanding local activities.
 		// If there is no outstanding local activities or if waitLocalActivity is false, the complete will return response
@@ -59,10 +59,11 @@ type (
 		// - RespondDecisionTaskFailedRequest
 		// - RespondQueryTaskCompletedRequest
 		// If waitLocalActivity is true, and there is outstanding local activities, this call will return nil.
-		CompleteDecisionTask(waitLocalActivity bool) interface{}
+		CompleteDecisionTask(workflowTask *workflowTask, waitLocalActivity bool) interface{}
 		// GetDecisionTimeout returns the TaskStartToCloseTimeout
 		GetDecisionTimeout() time.Duration
 		GetCurrentDecisionTask() *s.PollForDecisionTaskResponse
+		IsDestroyed() bool
 		StackTrace() string
 	}
 
@@ -73,9 +74,7 @@ type (
 		// - RespondDecisionTaskCompletedRequest
 		// - RespondDecisionTaskFailedRequest
 		// - RespondQueryTaskCompletedRequest
-		ProcessWorkflowTask(
-			task *s.PollForDecisionTaskResponse,
-			historyIterator HistoryIterator) (response interface{}, w WorkflowExecutionContext, err error)
+		ProcessWorkflowTask(task *workflowTask) (response interface{}, w WorkflowExecutionContext, err error)
 	}
 
 	// ActivityTaskHandler represents activity task handlers.

--- a/internal/internal_task_handlers_interfaces_test.go
+++ b/internal/internal_task_handlers_interfaces_test.go
@@ -44,10 +44,9 @@ type sampleWorkflowTaskHandler struct {
 }
 
 func (wth sampleWorkflowTaskHandler) ProcessWorkflowTask(
-	task *m.PollForDecisionTaskResponse,
-	historyIterator HistoryIterator) (interface{}, WorkflowExecutionContext, error) {
+	workflowTask *workflowTask) (interface{}, WorkflowExecutionContext, error) {
 	return &m.RespondDecisionTaskCompletedRequest{
-		TaskToken: task.TaskToken,
+		TaskToken: workflowTask.task.TaskToken,
 	}, nil, nil
 }
 
@@ -105,7 +104,7 @@ func (s *PollLayerInterfacesTestSuite) TestProcessWorkflowTaskInterface() {
 
 	// Process task and respond to the service.
 	taskHandler := newSampleWorkflowTaskHandler()
-	request, _, err := taskHandler.ProcessWorkflowTask(response, nil)
+	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: response})
 	completionRequest := request.(*m.RespondDecisionTaskCompletedRequest)
 	s.NoError(err)
 

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -137,10 +137,6 @@ func (lat *localActivityTunnel) sendTask(task *localActivityTask) {
 	lat.taskCh <- task
 }
 
-func (lat *localActivityTunnel) deliverResult(result *localActivityResult) {
-	lat.resultCh <- result
-}
-
 func createServiceRetryPolicy() backoff.RetryPolicy {
 	policy := backoff.NewExponentialRetryPolicy(retryServiceOperationInitialInterval)
 	policy.SetMaximumInterval(retryServiceOperationMaxInterval)
@@ -206,8 +202,6 @@ func (wtp *workflowTaskPoller) PollTask() (interface{}, error) {
 // ProcessTask processes a task which could be workflow task or local activity result
 func (wtp *workflowTaskPoller) ProcessTask(task interface{}) error {
 	switch task.(type) {
-	case *localActivityResult:
-		return wtp.processLocalActivityResult(task.(*localActivityResult))
 	case *workflowTask:
 		return wtp.processWorkflowTask(task.(*workflowTask))
 	case *resetStickinessTask:
@@ -227,26 +221,77 @@ func (wtp *workflowTaskPoller) processWorkflowTask(workflowTask *workflowTask) e
 		return nil
 	}
 
-	startTime := time.Now()
-	// Process the task.
-	completedRequest, wc, err := wtp.taskHandler.ProcessWorkflowTask(workflowTask.task, workflowTask.historyIterator)
-	if err == nil && completedRequest == nil {
-		if wc != nil {
-			// decision task cannot complete, we need a timer
-			wtp.scheduleRespondDecisionTaskCompleted(wc, workflowTask, startTime)
+	doneCh := make(chan struct{})
+	laResultCh := make(chan *localActivityResult)
+	// close doneCh so local activity worker won't get blocked forever when trying to send back result to laResultCh.
+	defer close(doneCh)
+
+process_WorkflowTask_Loop:
+	for {
+		startTime := time.Now()
+		workflowTask.doneCh = doneCh
+		workflowTask.laResultCh = laResultCh
+		completedRequest, wc, err := wtp.taskHandler.ProcessWorkflowTask(workflowTask)
+		if err == nil && completedRequest == nil {
+			// decision task cannot complete, we need a timer to force complete it
+		wait_LocalActivity_Loop:
+			for {
+				deadlineToTrigger := time.Duration(float32(0.8) * float32(wc.GetDecisionTimeout()))
+				delayDuration := startTime.Add(deadlineToTrigger).Sub(time.Now())
+				select {
+				case <-time.After(delayDuration):
+					// force complete
+					response, err := wtp.forceRespondDecisionTaskCompleted(wc, workflowTask, startTime)
+					if err != nil {
+						return err
+					}
+					if response == nil || response.DecisionTask == nil {
+						return nil
+					}
+
+					// we are getting new decision task, so reset the workflowTask and continue process the new one
+					workflowTask = wtp.toWorkflowTask(response.DecisionTask)
+					continue process_WorkflowTask_Loop
+
+				case lar := <-laResultCh:
+					// local activity result ready
+					completedRequest, err := wtp.processLocalActivityResult(lar.task.workflowTask, lar)
+
+					if _, ok := err.(*workflowContextAlreadyDestroyedError); ok {
+						return nil
+					}
+
+					if err == nil && completedRequest == nil {
+						// decision task is not done yet, still waiting for more local activities
+						continue wait_LocalActivity_Loop
+					}
+
+					response, err := wtp.RespondTaskCompletedWithMetrics(completedRequest, err, workflowTask.task, startTime)
+					if err != nil {
+						return err
+					}
+					if response == nil || response.DecisionTask == nil {
+						return nil
+					}
+
+					// we are getting new decision task, so reset the workflowTask and continue process the new one
+					workflowTask = wtp.toWorkflowTask(response.DecisionTask)
+					continue process_WorkflowTask_Loop
+				}
+			}
 		}
 
-		return nil
-	}
+		response, err := wtp.RespondTaskCompletedWithMetrics(completedRequest, err, workflowTask.task, startTime)
+		if err != nil {
+			return err
+		}
+		if response == nil || response.DecisionTask == nil {
+			return nil
+		}
 
-	response, err := wtp.RespondTaskCompletedWithMetrics(completedRequest, err, workflowTask.task, startTime)
-	if err != nil {
-		return err
-	}
-	if response != nil && response.DecisionTask != nil {
-		wc.Lock()
-		defer wc.Unlock(nil)
-		return wtp.processCompleteDecisionResponseLocked(response, wc)
+		// we are getting new decision task, so reset the workflowTask and continue process the new one
+		workflowTask = wtp.toWorkflowTask(response.DecisionTask)
+		continue process_WorkflowTask_Loop
 	}
 
 	return nil
@@ -267,29 +312,13 @@ func (wtp *workflowTaskPoller) processResetStickinessTask(rst *resetStickinessTa
 	return nil
 }
 
-func (wtp *workflowTaskPoller) scheduleRespondDecisionTaskCompleted(wc WorkflowExecutionContext, workflowTask *workflowTask, startTime time.Time) {
-	timeoutDuration := wc.GetDecisionTimeout()
-	deadlineToTrigger := time.Duration(float32(0.8) * float32(timeoutDuration))
-	delayDuration := startTime.Add(deadlineToTrigger).Sub(time.Now())
-	time.AfterFunc(delayDuration, func() {
-		defer func() {
-			if p := recover(); p != nil {
-				wtp.metricsScope.Counter(metrics.DecisionTaskPanicCounter).Inc(1)
-				st := getStackTraceRaw("forceRespondDecisionTaskCompleted [panic]:", 7, 0)
-				wtp.logger.Error("Unhandled panic.",
-					zap.String(tagWorkflowID, workflowTask.task.WorkflowExecution.GetWorkflowId()),
-					zap.String(tagRunID, workflowTask.task.WorkflowExecution.GetRunId()),
-					zap.String("PanicError", fmt.Sprintf("%v", p)),
-					zap.String("PanicStack", st))
-			}
-		}()
-		wtp.forceRespondDecisionTaskCompleted(wc, workflowTask, startTime)
-	})
-}
-
-func (wtp *workflowTaskPoller) forceRespondDecisionTaskCompleted(wc WorkflowExecutionContext, workflowTask *workflowTask, startTime time.Time) {
+func (wtp *workflowTaskPoller) forceRespondDecisionTaskCompleted(wc WorkflowExecutionContext, workflowTask *workflowTask, startTime time.Time) (response *s.RespondDecisionTaskCompletedResponse, err error) {
 	wc.Lock()
 	defer wc.Unlock(nil)
+
+	if wc.IsDestroyed() {
+		return nil, &workflowContextAlreadyDestroyedError{Message: "workflow context already destroyed"}
+	}
 
 	currentTask := wc.GetCurrentDecisionTask()
 	if currentTask == nil || currentTask != workflowTask.task {
@@ -299,73 +328,41 @@ func (wtp *workflowTaskPoller) forceRespondDecisionTaskCompleted(wc WorkflowExec
 			currentTaskStartedEventID = currentTask.GetStartedEventId()
 		}
 		wtp.logger.Debug("DecisionTask already completed when force responding timer fires.",
+			zap.String(tagWorkflowID, workflowTask.task.WorkflowExecution.GetWorkflowId()),
+			zap.String(tagRunID, workflowTask.task.WorkflowExecution.GetRunId()),
 			zap.Int64("TaskStartedEventID", workflowTask.task.GetStartedEventId()),
 			zap.Int64("CurrentStartedEventID", currentTaskStartedEventID))
-		return
+		return nil, nil
 	}
 
-	completeRequest := wc.CompleteDecisionTask(false)
+	completeRequest := wc.CompleteDecisionTask(workflowTask, false)
 	wtp.logger.Debug("Force RespondDecisionTaskCompleted.",
 		zap.Int64("TaskStartedEventID", workflowTask.task.GetStartedEventId()))
 	wtp.metricsScope.Counter(metrics.DecisionTaskForceCompleted).Inc(1)
 
-	response, err := wtp.RespondTaskCompletedWithMetrics(completeRequest, nil, workflowTask.task, startTime)
-	if err != nil {
-		return
-	}
-
-	wtp.processCompleteDecisionResponseLocked(response, wc)
-	return
+	return wtp.RespondTaskCompletedWithMetrics(completeRequest, nil, workflowTask.task, startTime)
 }
 
-func (wtp *workflowTaskPoller) processCompleteDecisionResponseLocked(response *s.RespondDecisionTaskCompletedResponse, w WorkflowExecutionContext) error {
-	if response == nil || response.DecisionTask == nil {
-		return nil
-	}
-
-	startTime := time.Now()
-	newTask := wtp.toWorkflowTask(response.DecisionTask)
-
-	// process new task
-	completedRequest, err := w.ProcessWorkflowTask(newTask.task, newTask.historyIterator)
-	if err == nil && completedRequest == nil {
-		// decision task cannot complete, we need a timer
-		wtp.scheduleRespondDecisionTaskCompleted(w, newTask, startTime)
-		return nil
-	}
-
-	response, err = wtp.RespondTaskCompletedWithMetrics(completedRequest, err, newTask.task, startTime)
-	if err != nil {
-		return err
-	}
-
-	return wtp.processCompleteDecisionResponseLocked(response, w)
+type workflowContextAlreadyDestroyedError struct {
+	Message string
 }
 
-func (wtp *workflowTaskPoller) processLocalActivityResult(lar *localActivityResult) error {
+func (e *workflowContextAlreadyDestroyedError) Error() string {
+	return e.Message
+}
+
+func (wtp *workflowTaskPoller) processLocalActivityResult(workflowTask *workflowTask, lar *localActivityResult) (interface{}, error) {
 	w := lar.task.wc
 	w.Lock()
+
 	defer w.Unlock(nil)
 
-	if w.isDestroyed() {
+	if w.IsDestroyed() {
 		// by the time local activity returns, the workflow context is already destroyed
-		return nil
+		return nil, &workflowContextAlreadyDestroyedError{Message: "workflow context already destroyed"}
 	}
 
-	decisionStartTime := w.decisionStartTime
-	decisionTask := w.currentDecisionTask
-	completedRequest, err := w.ProcessLocalActivityResult(lar)
-	if err == nil && completedRequest == nil {
-		return nil
-	}
-	response, err := wtp.RespondTaskCompletedWithMetrics(completedRequest, err, decisionTask, decisionStartTime)
-	if err != nil {
-		return err
-	}
-	if response != nil && response.DecisionTask != nil {
-		return wtp.processCompleteDecisionResponseLocked(response, w)
-	}
-	return nil
+	return w.ProcessLocalActivityResult(workflowTask, lar)
 }
 
 func (wtp *workflowTaskPoller) RespondTaskCompletedWithMetrics(completedRequest interface{}, taskErr error, task *s.PollForDecisionTaskResponse, startTime time.Time) (response *s.RespondDecisionTaskCompletedResponse, err error) {
@@ -467,7 +464,12 @@ func (latp *localActivityTaskPoller) PollTask() (interface{}, error) {
 
 func (latp *localActivityTaskPoller) ProcessTask(task interface{}) error {
 	result := latp.handler.executeLocalActivityTask(task.(*localActivityTask))
-	latp.laTunnel.deliverResult(result)
+	select {
+	case <-result.task.workflowTask.doneCh:
+		return nil
+	case result.task.workflowTask.laResultCh <- result:
+		return nil
+	}
 	return nil
 }
 

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -187,7 +187,7 @@ func (s *internalWorkerTestSuite) testDecisionTaskHandlerHelper(params workerExe
 	}
 
 	r := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	_, wc, err := r.ProcessWorkflowTask(task, nil)
+	_, wc, err := r.ProcessWorkflowTask(&workflowTask{task: task})
 	s.NoError(err)
 	s.NotNil(wc)
 	stackTrace := wc.StackTrace()

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -307,7 +307,7 @@ func replayWorkflowHistory(logger *zap.Logger, service workflowserviceclient.Int
 		Logger:   logger,
 	}
 	taskHandler := newWorkflowTaskHandler(domain, params, nil, getHostEnvironment())
-	_, _, err := taskHandler.ProcessWorkflowTask(task, iterator)
+	_, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task, historyIterator: iterator})
 	return err
 }
 


### PR DESCRIPTION
The assumption was that when the ProcessTask() method returns the work is done, so the scheduler will trigger another poll to get more work. This was true until the local activity come into place. The ProcessTask() could return with nothing when there is local activity running. 
This fix makes ProcessTask() block until all work is done so the max concurrent execution control could work and it won't poll down more work than it could handle.

From implementation, major change is that, when local activity is done by local activity worker, we need a way to send back the result to the ProcessTask() to unblock it. The way that is implemented is that the ProcessWorkflowTask() now take workflowTask struct which has a channel, so when we create local activity task before send it to local activity worker, we set that result channel to the task. So when local activity worker finishes process, it can send the result to that result channel which the ProcessTask() is waiting on. It also need a done channel, so that if the ProcessTask() return earlier, the local activity worker won't block for ever trying to send over the result.

