### PR TITLE
Return WorkflowAlreadyStarted error from child workflow start failed

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -1005,7 +1005,9 @@ func (weh *workflowExecutionEventHandlerImpl) handleStartChildWorkflowExecutionF
 		return nil
 	}
 
-	err := fmt.Errorf("start child workflow failed: %v", attributes.GetCause())
+	err := &m.WorkflowExecutionAlreadyStartedError{
+		Message: common.StringPtr("Workflow execution already started"),
+	}
 	childWorkflow.startedCallback(WorkflowExecution{}, err)
 	childWorkflow.handle(nil, err)
 

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -312,13 +312,19 @@ func (env *testWorkflowEnvironmentImpl) newTestWorkflowEnvironmentForChild(param
 	if workflowHandler, ok := env.runningWorkflows[params.workflowID]; ok {
 		// duplicate workflow ID
 		if !workflowHandler.handled {
-			return nil, errors.New("child workflow already running")
+			return nil, &shared.WorkflowExecutionAlreadyStartedError{
+				Message: common.StringPtr("Workflow execution already started"),
+			}
 		}
 		if params.workflowIDReusePolicy == WorkflowIDReusePolicyRejectDuplicate {
-			return nil, errors.New("duplicate workflow id not allowed")
+			return nil, &shared.WorkflowExecutionAlreadyStartedError{
+				Message: common.StringPtr("Workflow execution already started"),
+			}
 		}
 		if workflowHandler.err == nil && params.workflowIDReusePolicy == WorkflowIDReusePolicyAllowDuplicateFailedOnly {
-			return nil, errors.New("child workflow with specified workflow id already completed")
+			return nil, &shared.WorkflowExecutionAlreadyStartedError{
+				Message: common.StringPtr("Workflow execution already started"),
+			}
 		}
 	}
 


### PR DESCRIPTION
Return WorkflowAlreadyStarted if start child workflow failed.