### PR TITLE
RequestCancelActivityTaskFailedEvent is not decision event

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -191,7 +191,7 @@ func isDecisionEvent(eventType s.EventType) bool {
 		s.EventTypeWorkflowExecutionCanceled,
 		s.EventTypeWorkflowExecutionContinuedAsNew,
 		s.EventTypeActivityTaskScheduled,
-		s.EventTypeActivityTaskCancelRequested, s.EventTypeRequestCancelActivityTaskFailed,
+		s.EventTypeActivityTaskCancelRequested,
 		s.EventTypeTimerStarted,
 		s.EventTypeTimerCanceled, s.EventTypeCancelTimerFailed,
 		s.EventTypeMarkerRecorded,
@@ -1038,20 +1038,13 @@ func isDecisionMatchEvent(d *s.Decision, e *s.HistoryEvent, strictMode bool) boo
 		return true
 
 	case s.DecisionTypeRequestCancelActivityTask:
-		if e.GetEventType() != s.EventTypeActivityTaskCancelRequested && e.GetEventType() != s.EventTypeRequestCancelActivityTaskFailed {
+		if e.GetEventType() != s.EventTypeActivityTaskCancelRequested {
 			return false
 		}
 		decisionAttributes := d.RequestCancelActivityTaskDecisionAttributes
-		if e.GetEventType() == s.EventTypeActivityTaskCancelRequested {
-			eventAttributes := e.ActivityTaskCancelRequestedEventAttributes
-			if eventAttributes.GetActivityId() != decisionAttributes.GetActivityId() {
-				return false
-			}
-		} else if e.GetEventType() == s.EventTypeRequestCancelActivityTaskFailed {
-			eventAttributes := e.RequestCancelActivityTaskFailedEventAttributes
-			if eventAttributes.GetActivityId() != decisionAttributes.GetActivityId() {
-				return false
-			}
+		eventAttributes := e.ActivityTaskCancelRequestedEventAttributes
+		if eventAttributes.GetActivityId() != decisionAttributes.GetActivityId() {
+			return false
 		}
 
 		return true

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -690,7 +690,7 @@ func Test_NonDeterministicCheck(t *testing.T) {
 			decisionEventTypeCount++
 		}
 	}
-	// CancelTimer and CancelActivity each has 2 corresponding events.
-	require.Equal(t, len(decisionTypes)+2, decisionEventTypeCount, "Every decision type must have one matching event type. "+
+	// CancelTimer has 2 corresponding events.
+	require.Equal(t, len(decisionTypes)+1, decisionEventTypeCount, "Every decision type must have one matching event type. "+
 		"If you add new decision type, you need to update isDecisionEvent() method to include that new event type as well.")
 }


### PR DESCRIPTION
In https://github.com/uber-go/cadence-client/pull/545 we added RequestCancelActivityTaskFailedEvent as decision event (while fixing bug for EventTypeCancelTimerFailed). Turns out that RequestCancelActivityTaskFailedEvent is not decision event.