### PR TITLE
Include LocalActivityType into the result marker

### DIFF
--- a/internal/internal_activity.go
+++ b/internal/internal_activity.go
@@ -80,6 +80,7 @@ type (
 	executeLocalActivityParams struct {
 		localActivityOptions
 		ActivityFn    interface{} // local activity function pointer
+		ActivityType  string      // local activity type
 		InputArgs     []interface{}
 		WorkflowInfo  *WorkflowInfo
 		DataConverter encoded.DataConverter

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -415,6 +415,7 @@ func ExecuteLocalActivity(ctx Context, activity interface{}, args ...interface{}
 	params := &executeLocalActivityParams{
 		localActivityOptions: *options,
 		ActivityFn:           activity,
+		ActivityType:         lastPartOfName(getFunctionName(activity)),
 		InputArgs:            args,
 		WorkflowInfo:         GetWorkflowInfo(ctx),
 		DataConverter:        getDataConverterFromWorkflowContext(ctx),


### PR DESCRIPTION
Add ActivityType to the local activity result marker, and check ActivityType during replay. 