### PR TITLE
Do not run local activity in query task

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -891,7 +891,11 @@ func (w *workflowExecutionContextImpl) CompleteDecisionTask(workflowTask *workfl
 }
 
 func (w *workflowExecutionContextImpl) hasPendingLocalActivityWork() bool {
-	return !w.isWorkflowCompleted && w.eventHandler != nil && len(w.eventHandler.pendingLaTasks) > 0
+	return !w.isWorkflowCompleted &&
+		w.currentDecisionTask != nil &&
+		w.currentDecisionTask.Query == nil && // don't run local activity for query task
+		w.eventHandler != nil &&
+		len(w.eventHandler.pendingLaTasks) > 0
 }
 
 func (w *workflowExecutionContextImpl) clearCurrentTask() {


### PR DESCRIPTION
If query request comes in while the decision task is started but not completed yet, in that case the query task will contains last DecisionTaskStarted event and it is not in replay. However, we don't want to run local activity in query task.