### PR TITLE
Handle illegal StateMachine transition as Non-Deterministic error

### DIFF
--- a/internal/error.go
+++ b/internal/error.go
@@ -113,7 +113,7 @@ type (
 
 	// PanicError contains information about panicked workflow/activity.
 	PanicError struct {
-		value      string
+		value      interface{}
 		stackTrace string
 	}
 
@@ -296,12 +296,12 @@ func (e *CanceledError) Details(d ...interface{}) error {
 }
 
 func newPanicError(value interface{}, stackTrace string) *PanicError {
-	return &PanicError{value: fmt.Sprintf("%v", value), stackTrace: stackTrace}
+	return &PanicError{value: value, stackTrace: stackTrace}
 }
 
 // Error from error interface
 func (e *PanicError) Error() string {
-	return e.value
+	return fmt.Sprintf("%v", e.value)
 }
 
 // StackTrace return stack trace of the panic

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -463,7 +463,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	t.True(len(response.Decisions) > 0)
 	closeDecision := response.Decisions[len(response.Decisions)-1]
 	t.Equal(*closeDecision.DecisionType, s.DecisionTypeFailWorkflowExecution)
-	t.Contains(*closeDecision.FailWorkflowExecutionDecisionAttributes.Reason, "nondeterministic")
+	t.Contains(*closeDecision.FailWorkflowExecutionDecisionAttributes.Reason, "NonDeterministicWorkflowPolicyFailWorkflow")
 
 	// now with different package name to activity type
 	testEvents[4].ActivityTaskScheduledEventAttributes.ActivityType.Name = common.StringPtr("new-package.Greeter_Activity")


### PR DESCRIPTION
Handle illegal state machine panic as non-deterministic error so it will be handled according to NonDeterministicWorkflowPolicy.
This change is needed to hook up the Reset API once it is ready on server side.