### PR TITLE
Panic test if attempt to run multiple workflows with same test env

### DIFF
--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -266,6 +266,7 @@ func Test_CustomError_Pointer(t *testing.T) {
 		return err2 // pointer in details
 	}
 	RegisterWorkflow(errorWorkflowFn2)
+	wfEnv = s.NewTestWorkflowEnvironment()
 	wfEnv.ExecuteWorkflow(errorWorkflowFn2)
 	err = wfEnv.GetWorkflowError()
 	require.Error(t, err)

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -1158,6 +1158,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowRegistration() {
 	env := s.NewTestWorkflowEnvironment()
 
 	env.ExecuteWorkflow(workflowFn)
+	env = s.NewTestWorkflowEnvironment()
 	env.ExecuteWorkflow(workflowAlias)
 }
 


### PR DESCRIPTION
Current TestWorkflowEnvironment only support to run one workflow.
Created task to support testing multiple workflows with one env instancehttps://github.com/uber-go/cadence-client/issues/616
This PR will detect the case and throw explicit message so we don't run into wired error (like data race issues).