### PR TITLE
Introducing new error type for unknown external workflow execution

### DIFF
--- a/internal/error.go
+++ b/internal/error.go
@@ -123,6 +123,9 @@ type (
 		args   []interface{}
 		params *executeWorkflowParams
 	}
+
+	// UnknownExternalWorkflowExecutionError can be returned when external workflow doesn't exist
+	UnknownExternalWorkflowExecutionError struct{}
 )
 
 const (
@@ -322,4 +325,14 @@ func newTerminatedError() *TerminatedError {
 // Error from error interface
 func (e *TerminatedError) Error() string {
 	return "Terminated"
+}
+
+// newUnknownExternalWorkflowExecutionError creates UnknownExternalWorkflowExecutionError instance
+func newUnknownExternalWorkflowExecutionError() *UnknownExternalWorkflowExecutionError {
+	return &UnknownExternalWorkflowExecutionError{}
+}
+
+// Error from error interface
+func (e *UnknownExternalWorkflowExecutionError) Error() string {
+	return "UnknownExternalWorkflowExecution"
 }

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/uber-go/tally"
+	"go.uber.org/cadence/.gen/go/shared"
 	m "go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/internal/common"
@@ -1179,7 +1180,15 @@ func (weh *workflowExecutionEventHandlerImpl) handleSignalExternalWorkflowExecut
 	if signal.handled {
 		return nil
 	}
-	err := fmt.Errorf("signal external workflow failed, %v", attributes.GetCause())
+
+	var err error
+	switch attributes.GetCause() {
+	case shared.SignalExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution:
+		err = newUnknownExternalWorkflowExecutionError()
+	default:
+		err = fmt.Errorf("signal external workflow failed, %v", attributes.GetCause())
+	}
+
 	signal.handle(nil, err)
 
 	return nil

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -140,6 +140,14 @@ func createTestEventDecisionTaskCompleted(eventID int64, attr *s.DecisionTaskCom
 		DecisionTaskCompletedEventAttributes: attr}
 }
 
+func createTestEventSignalExternalWorkflowExecutionFailed(eventID int64, attr *s.SignalExternalWorkflowExecutionFailedEventAttributes) *s.HistoryEvent {
+	return &s.HistoryEvent{
+		EventId:   common.Int64Ptr(eventID),
+		EventType: common.EventTypePtr(s.EventTypeSignalExternalWorkflowExecutionFailed),
+		SignalExternalWorkflowExecutionFailedEventAttributes: attr,
+	}
+}
+
 func createWorkflowTask(
 	events []*s.HistoryEvent,
 	previousStartEventID int64,

--- a/workflow/error.go
+++ b/workflow/error.go
@@ -100,6 +100,9 @@ type (
 	// ContinueAsNewError can be returned by a workflow implementation function and indicates that
 	// the workflow should continue as new with the same WorkflowID, but new RunID and new history.
 	ContinueAsNewError = internal.ContinueAsNewError
+
+	// UnknownExternalWorkflowExecutionError can be returned when external workflow doesn't exist
+	UnknownExternalWorkflowExecutionError = internal.UnknownExternalWorkflowExecutionError
 )
 
 // NewContinueAsNewError creates ContinueAsNewError instance


### PR DESCRIPTION
While sending a signal to a workflow, it is difficult to distinguish between the fact that the workflow finished and other errors. This change introduces a new error type to handle this case. It resolves #638 

With this change the following is possible:
```
err := f.SignalChildWorkflow(ctx, channel, reason).Get(ctx, nil)
switch err.(type) {
case *workflow.UnknownExternalWorkflowExecutionError:
	workflow.GetLogger(ctx).Debug("Child workflow already finished its work", zap.Error(err))
default:
    # ...
}
```