### PR TITLE
Dynamic retry policy for Cadence service API calls

### DIFF
--- a/internal/activity_test.go
+++ b/internal/activity_test.go
@@ -22,10 +22,8 @@ package internal
 
 import (
 	"context"
-	"testing"
-	"time"
-
 	"fmt"
+	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -33,7 +31,6 @@ import (
 	"go.uber.org/cadence/.gen/go/cadence/workflowservicetest"
 	"go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/internal/common"
-	"go.uber.org/cadence/internal/common/backoff"
 	"go.uber.org/yarpc"
 )
 
@@ -72,13 +69,8 @@ func (s *activityTestSuite) TestActivityHeartbeat() {
 }
 
 func (s *activityTestSuite) TestActivityHeartbeat_InternalError() {
-	p := backoff.NewExponentialRetryPolicy(time.Millisecond)
-	p.SetMaximumInterval(100 * time.Millisecond)
-	p.SetExpirationInterval(100 * time.Millisecond)
-
 	ctx, cancel := context.WithCancel(context.Background())
 	invoker := newServiceInvoker([]byte("task-token"), "identity", s.service, cancel, 1)
-	invoker.(*cadenceInvoker).retryPolicy = p
 	ctx = context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{
 		serviceInvoker: invoker,
 		logger:         getLogger()})

--- a/internal/internal_retry.go
+++ b/internal/internal_retry.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+// All code in this file is private to the package.
+
+import (
+	"context"
+	"time"
+
+	s "go.uber.org/cadence/.gen/go/shared"
+	"go.uber.org/cadence/internal/common/backoff"
+)
+
+const (
+	retryServiceOperationInitialInterval    = 20 * time.Millisecond
+	retryServiceOperationExpirationInterval = 60 * time.Second
+	retryServiceOperationBackoff            = 1.2
+)
+
+// Creates a retry policy which allows appropriate retries for the deadline passed in as context.
+// It uses the context deadline to set MaxInterval as 1/10th of context timeout
+// MaxInterval = Max(context_timeout/10, 20ms)
+// defaults to ExpirationInterval of 60 seconds, or uses context deadline as expiration interval
+func createDynamicServiceRetryPolicy(ctx context.Context) backoff.RetryPolicy {
+	timeout := retryServiceOperationExpirationInterval
+	if ctx != nil {
+		now := time.Now()
+		if expiration, ok := ctx.Deadline(); ok && expiration.After(now) {
+			timeout = expiration.Sub(now)
+		}
+	}
+	initialInterval := retryServiceOperationInitialInterval
+	maximumInterval := timeout / 10
+	if maximumInterval < retryServiceOperationInitialInterval {
+		maximumInterval = retryServiceOperationInitialInterval
+	}
+
+	policy := backoff.NewExponentialRetryPolicy(initialInterval)
+	policy.SetBackoffCoefficient(retryServiceOperationBackoff)
+	policy.SetMaximumInterval(maximumInterval)
+	policy.SetExpirationInterval(timeout)
+	return policy
+}
+
+func isServiceTransientError(err error) bool {
+	// Retrying by default so it covers all transport errors.
+	switch err.(type) {
+	case *s.BadRequestError,
+	*s.EntityNotExistsError,
+	*s.WorkflowExecutionAlreadyStartedError,
+	*s.DomainAlreadyExistsError,
+	*s.QueryFailedError,
+	*s.DomainNotActiveError,
+	*s.CancellationAlreadyRequestedError:
+		return false
+	}
+
+	// s.InternalServiceError
+	// s.ServiceBusyError
+	// s.LimitExceededError
+	return true
+}

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -789,19 +789,18 @@ type deadlineTest struct {
 	err              error
 }
 
-var deadlineTests = []deadlineTest{
-	{time.Duration(0), time.Now(), 3, time.Now(), 3, nil},
-	{time.Duration(0), time.Now(), 4, time.Now(), 3, nil},
-	{time.Duration(0), time.Now(), 3, time.Now(), 4, nil},
-	{time.Duration(0), time.Now().Add(-1 * time.Second), 1, time.Now(), 1, context.DeadlineExceeded},
-	{time.Duration(0), time.Now(), 1, time.Now().Add(-1 * time.Second), 1, context.DeadlineExceeded},
-	{time.Duration(0), time.Now().Add(-1 * time.Second), 1, time.Now().Add(-1 * time.Second), 1, context.DeadlineExceeded},
-	{time.Duration(1 * time.Second), time.Now(), 1, time.Now(), 1, context.DeadlineExceeded},
-	{time.Duration(1 * time.Second), time.Now(), 2, time.Now(), 1, context.DeadlineExceeded},
-	{time.Duration(1 * time.Second), time.Now(), 1, time.Now(), 2, context.DeadlineExceeded},
-}
-
 func (t *TaskHandlersTestSuite) TestActivityExecutionDeadline() {
+	deadlineTests := []deadlineTest{
+		{time.Duration(0), time.Now(), 3, time.Now(), 3, nil},
+		{time.Duration(0), time.Now(), 4, time.Now(), 3, nil},
+		{time.Duration(0), time.Now(), 3, time.Now(), 4, nil},
+		{time.Duration(0), time.Now().Add(-1 * time.Second), 1, time.Now(), 1, context.DeadlineExceeded},
+		{time.Duration(0), time.Now(), 1, time.Now().Add(-1 * time.Second), 1, context.DeadlineExceeded},
+		{time.Duration(0), time.Now().Add(-1 * time.Second), 1, time.Now().Add(-1 * time.Second), 1, context.DeadlineExceeded},
+		{time.Duration(1 * time.Second), time.Now(), 1, time.Now(), 1, context.DeadlineExceeded},
+		{time.Duration(1 * time.Second), time.Now(), 2, time.Now(), 1, context.DeadlineExceeded},
+		{time.Duration(1 * time.Second), time.Now(), 1, time.Now(), 2, context.DeadlineExceeded},
+	}
 	a := &testActivityDeadline{logger: t.logger}
 	hostEnv := getHostEnvironment()
 	hostEnv.addActivity(a.ActivityType().Name, a)

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -140,9 +140,10 @@ func (lat *localActivityTunnel) sendTask(task *localActivityTask) {
 }
 
 func createServiceRetryPolicy() backoff.RetryPolicy {
-	policy := backoff.NewExponentialRetryPolicy(retryServiceOperationInitialInterval)
-	policy.SetMaximumInterval(retryServiceOperationMaxInterval)
-	policy.SetExpirationInterval(retryServiceOperationExpirationInterval)
+	policy := backoff.NewExponentialRetryPolicy(20 * time.Millisecond)
+	policy.SetBackoffCoefficient(1.1)
+	policy.SetMaximumInterval(50 * time.Millisecond)
+	policy.SetExpirationInterval(3 * time.Second)
 	return policy
 }
 

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -135,14 +135,6 @@ func (lat *localActivityTunnel) sendTask(task *localActivityTask) {
 	lat.taskCh <- task
 }
 
-func createServiceRetryPolicy() backoff.RetryPolicy {
-	policy := backoff.NewExponentialRetryPolicy(20 * time.Millisecond)
-	policy.SetBackoffCoefficient(1.2)
-	policy.SetMaximumInterval(50 * time.Millisecond)
-	policy.SetExpirationInterval(3 * time.Second)
-	return policy
-}
-
 func createDynamicServiceRetryPolicy(ctx context.Context) backoff.RetryPolicy {
 	timeout := retryServiceOperationExpirationInterval
 	if ctx != nil {

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -105,13 +105,13 @@ func newChannelContext(ctx context.Context, options ...func(builder *contextBuil
 		now := time.Now()
 		if expiration, ok := ctx.Deadline(); ok && expiration.After(now) {
 			timeout := expiration.Sub(now) / 2
-			fmt.Printf("Context Timeout: %v, rpc timeout: %v", timeout, rpcTimeout)
+			fmt.Printf("Context Timeout: %v, rpc timeout: %v\n", timeout, rpcTimeout)
 			if timeout < minRPCTimeout {
 				rpcTimeout = minRPCTimeout
 			}
 		}
 	}
-	fmt.Printf("rpc timeout: %v", rpcTimeout)
+	fmt.Printf("rpc timeout: %v\n", rpcTimeout)
 	builder := &contextBuilder{Timeout: rpcTimeout}
 	if ctx != nil {
 		builder.ParentContext = ctx

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -60,6 +60,8 @@ const (
 	defaultRPCTimeout = 10 * time.Second
 	//minRPCTimeout is minimum rpc call timeout allowed
 	minRPCTimeout = 1 * time.Second
+	//maxRPCTimeout is maximum rpc call timeout allowed
+	maxRPCTimeout = 20 * time.Second
 )
 
 var (
@@ -109,6 +111,8 @@ func newChannelContext(ctx context.Context, options ...func(builder *contextBuil
 			// Make sure to not set rpc timeout lower than minRPCTimeout
 			if rpcTimeout < minRPCTimeout {
 				rpcTimeout = minRPCTimeout
+			} else if rpcTimeout > maxRPCTimeout {
+				rpcTimeout = maxRPCTimeout
 			}
 		}
 	}

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -57,7 +57,7 @@ const (
 	clientImplHeaderValue = "uber-go"
 
 	// defaultRPCTimeout is the default tchannel rpc call timeout
-	defaultRPCTimeout = 10 * time.Second
+	defaultRPCTimeout = 1 * time.Second
 )
 
 var (

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -105,11 +105,13 @@ func newChannelContext(ctx context.Context, options ...func(builder *contextBuil
 		now := time.Now()
 		if expiration, ok := ctx.Deadline(); ok && expiration.After(now) {
 			timeout := expiration.Sub(now) / 2
+			fmt.Printf("Context Timeout: %v, rpc timeout: %v", timeout, rpcTimeout)
 			if timeout < minRPCTimeout {
 				rpcTimeout = minRPCTimeout
 			}
 		}
 	}
+	fmt.Printf("rpc timeout: %v", rpcTimeout)
 	builder := &contextBuilder{Timeout: rpcTimeout}
 	if ctx != nil {
 		builder.ParentContext = ctx

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -104,14 +104,12 @@ func newChannelContext(ctx context.Context, options ...func(builder *contextBuil
 	if ctx != nil {
 		now := time.Now()
 		if expiration, ok := ctx.Deadline(); ok && expiration.After(now) {
-			timeout := expiration.Sub(now) / 2
-			fmt.Printf("Context Timeout: %v, rpc timeout: %v\n", timeout, rpcTimeout)
-			if timeout < minRPCTimeout {
+			rpcTimeout = expiration.Sub(now) / 2
+			if rpcTimeout < minRPCTimeout {
 				rpcTimeout = minRPCTimeout
 			}
 		}
 	}
-	fmt.Printf("rpc timeout: %v\n", rpcTimeout)
 	builder := &contextBuilder{Timeout: rpcTimeout}
 	if ctx != nil {
 		builder.ParentContext = ctx

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -106,7 +106,7 @@ func newChannelContext(ctx context.Context, options ...func(builder *contextBuil
 		if expiration, ok := ctx.Deadline(); ok && expiration.After(now) {
 			timeout := expiration.Sub(now) / 2
 			if timeout < minRPCTimeout {
-				timeout = minRPCTimeout
+				rpcTimeout = minRPCTimeout
 			}
 		}
 	}

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -102,9 +102,11 @@ func chanTimeout(timeout time.Duration) func(builder *contextBuilder) {
 func newChannelContext(ctx context.Context, options ...func(builder *contextBuilder)) (context.Context, context.CancelFunc, []yarpc.CallOption) {
 	rpcTimeout := defaultRPCTimeout
 	if ctx != nil {
+		// Set rpc timeout less than context timeout to allow for retries when call gets lost
 		now := time.Now()
 		if expiration, ok := ctx.Deadline(); ok && expiration.After(now) {
 			rpcTimeout = expiration.Sub(now) / 2
+			// Make sure to not set rpc timeout lower than minRPCTimeout
 			if rpcTimeout < minRPCTimeout {
 				rpcTimeout = minRPCTimeout
 			}

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -229,7 +229,7 @@ func verifyDomainExist(client workflowserviceclient.Interface, domain string, lo
 	}
 
 	// exponential backoff retry for upto a minute
-	return backoff.Retry(ctx, descDomainOp, serviceOperationRetryPolicy, isServiceTransientError)
+	return backoff.Retry(ctx, descDomainOp, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
 }
 
 func newWorkflowWorkerInternal(

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -184,18 +184,23 @@ func (wc *workflowClient) StartWorkflow(
 
 	var response *s.StartWorkflowExecutionResponse
 
+	startTime := time.Now()
+	attempt := 0
 	// Start creating workflow request.
 	err = backoff.Retry(ctx,
 		func() error {
 			tchCtx, cancel, opt := newChannelContext(ctx)
 			defer cancel()
 
+			attempt++
 			var err1 error
 			response, err1 = wc.workflowService.StartWorkflowExecution(tchCtx, startRequest, opt...)
 			return err1
 		}, serviceOperationRetryPolicy, isServiceTransientError)
 
 	if err != nil {
+		elapsed := time.Since(startTime)
+		fmt.Printf("StartWorkflow failed.  ID: %v, Attempt: %v, Latency: %v", workflowID, attempt, elapsed)
 		return nil, err
 	}
 

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -196,7 +196,7 @@ func (wc *workflowClient) StartWorkflow(
 			var err1 error
 			response, err1 = wc.workflowService.StartWorkflowExecution(tchCtx, startRequest, opt...)
 			return err1
-		}, createDynamicServiceRetryPolicy(3 * time.Second), isServiceTransientError)
+		}, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
 
 	if err != nil {
 		elapsed := time.Since(startTime)
@@ -282,7 +282,7 @@ func (wc *workflowClient) SignalWorkflow(ctx context.Context, workflowID string,
 			tchCtx, cancel, opt := newChannelContext(ctx)
 			defer cancel()
 			return wc.workflowService.SignalWorkflowExecution(tchCtx, request, opt...)
-		}, serviceOperationRetryPolicy, isServiceTransientError)
+		}, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
 }
 
 // SignalWithStartWorkflow sends a signal to a running workflow.
@@ -349,7 +349,7 @@ func (wc *workflowClient) SignalWithStartWorkflow(ctx context.Context, workflowI
 			var err1 error
 			response, err1 = wc.workflowService.SignalWithStartWorkflowExecution(tchCtx, signalWithStartRequest, opt...)
 			return err1
-		}, serviceOperationRetryPolicy, isServiceTransientError)
+		}, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
 
 	if err != nil {
 		return nil, err
@@ -384,7 +384,7 @@ func (wc *workflowClient) CancelWorkflow(ctx context.Context, workflowID string,
 			tchCtx, cancel, opt := newChannelContext(ctx)
 			defer cancel()
 			return wc.workflowService.RequestCancelWorkflowExecution(tchCtx, request, opt...)
-		}, serviceOperationRetryPolicy, isServiceTransientError)
+		}, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
 }
 
 // TerminateWorkflow terminates a workflow execution.
@@ -406,7 +406,7 @@ func (wc *workflowClient) TerminateWorkflow(ctx context.Context, workflowID stri
 			tchCtx, cancel, opt := newChannelContext(ctx)
 			defer cancel()
 			return wc.workflowService.TerminateWorkflowExecution(tchCtx, request, opt...)
-		}, serviceOperationRetryPolicy, isServiceTransientError)
+		}, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
 
 	return err
 }
@@ -443,7 +443,7 @@ func (wc *workflowClient) GetWorkflowHistory(ctx context.Context, workflowID str
 					defer cancel()
 					response, err1 = wc.workflowService.GetWorkflowExecutionHistory(tchCtx, request, opt...)
 					return err1
-				}, serviceOperationRetryPolicy, isServiceTransientError)
+				}, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
 
 			if err != nil {
 				return nil, err
@@ -512,7 +512,7 @@ func (wc *workflowClient) RecordActivityHeartbeat(ctx context.Context, taskToken
 	if err != nil {
 		return err
 	}
-	return recordActivityHeartbeat(ctx, wc.workflowService, wc.identity, taskToken, data, serviceOperationRetryPolicy)
+	return recordActivityHeartbeat(ctx, wc.workflowService, wc.identity, taskToken, data)
 }
 
 // RecordActivityHeartbeatByID records heartbeat for an activity.
@@ -522,7 +522,7 @@ func (wc *workflowClient) RecordActivityHeartbeatByID(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	return recordActivityHeartbeatByID(ctx, wc.workflowService, wc.identity, domain, workflowID, runID, activityID, data, serviceOperationRetryPolicy)
+	return recordActivityHeartbeatByID(ctx, wc.workflowService, wc.identity, domain, workflowID, runID, activityID, data)
 }
 
 // ListClosedWorkflow gets closed workflow executions based on request filters
@@ -542,7 +542,7 @@ func (wc *workflowClient) ListClosedWorkflow(ctx context.Context, request *s.Lis
 			defer cancel()
 			response, err1 = wc.workflowService.ListClosedWorkflowExecutions(tchCtx, request, opt...)
 			return err1
-		}, serviceOperationRetryPolicy, isServiceTransientError)
+		}, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
 	if err != nil {
 		return nil, err
 	}
@@ -566,7 +566,7 @@ func (wc *workflowClient) ListOpenWorkflow(ctx context.Context, request *s.ListO
 			defer cancel()
 			response, err1 = wc.workflowService.ListOpenWorkflowExecutions(tchCtx, request, opt...)
 			return err1
-		}, serviceOperationRetryPolicy, isServiceTransientError)
+		}, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
 	if err != nil {
 		return nil, err
 	}
@@ -594,7 +594,7 @@ func (wc *workflowClient) DescribeWorkflowExecution(ctx context.Context, workflo
 			defer cancel()
 			response, err1 = wc.workflowService.DescribeWorkflowExecution(tchCtx, request, opt...)
 			return err1
-		}, serviceOperationRetryPolicy, isServiceTransientError)
+		}, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
 	if err != nil {
 		return nil, err
 	}
@@ -641,7 +641,7 @@ func (wc *workflowClient) QueryWorkflow(ctx context.Context, workflowID string, 
 			var err error
 			resp, err = wc.workflowService.QueryWorkflow(tchCtx, request, opt...)
 			return err
-		}, serviceOperationRetryPolicy, isServiceTransientError)
+		}, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
 	if err != nil {
 		return nil, err
 	}
@@ -672,7 +672,7 @@ func (wc *workflowClient) DescribeTaskList(ctx context.Context, tasklist string,
 			var err error
 			resp, err = wc.workflowService.DescribeTaskList(tchCtx, request, opt...)
 			return err
-		}, serviceOperationRetryPolicy, isServiceTransientError)
+		}, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
 	if err != nil {
 		return nil, err
 	}
@@ -691,7 +691,7 @@ func (dc *domainClient) Register(ctx context.Context, request *s.RegisterDomainR
 			tchCtx, cancel, opt := newChannelContext(ctx)
 			defer cancel()
 			return dc.workflowService.RegisterDomain(tchCtx, request, opt...)
-		}, serviceOperationRetryPolicy, isServiceTransientError)
+		}, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
 }
 
 // Describe a domain. The domain has 3 part of information
@@ -715,7 +715,7 @@ func (dc *domainClient) Describe(ctx context.Context, name string) (*s.DescribeD
 			var err error
 			response, err = dc.workflowService.DescribeDomain(tchCtx, request, opt...)
 			return err
-		}, serviceOperationRetryPolicy, isServiceTransientError)
+		}, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
 	if err != nil {
 		return nil, err
 	}
@@ -734,7 +734,7 @@ func (dc *domainClient) Update(ctx context.Context, request *s.UpdateDomainReque
 			defer cancel()
 			_, err := dc.workflowService.UpdateDomain(tchCtx, request, opt...)
 			return err
-		}, serviceOperationRetryPolicy, isServiceTransientError)
+		}, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
 }
 
 func getRunID(runID string) *string {

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -184,23 +184,18 @@ func (wc *workflowClient) StartWorkflow(
 
 	var response *s.StartWorkflowExecutionResponse
 
-	startTime := time.Now()
-	attempt := 0
 	// Start creating workflow request.
 	err = backoff.Retry(ctx,
 		func() error {
 			tchCtx, cancel, opt := newChannelContext(ctx)
 			defer cancel()
 
-			attempt++
 			var err1 error
 			response, err1 = wc.workflowService.StartWorkflowExecution(tchCtx, startRequest, opt...)
 			return err1
 		}, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
 
 	if err != nil {
-		elapsed := time.Since(startTime)
-		fmt.Printf("StartWorkflow failed.  ID: %v, Attempt: %v, Latency: %v", workflowID, attempt, elapsed)
 		return nil, err
 	}
 

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -196,7 +196,7 @@ func (wc *workflowClient) StartWorkflow(
 			var err1 error
 			response, err1 = wc.workflowService.StartWorkflowExecution(tchCtx, startRequest, opt...)
 			return err1
-		}, serviceOperationRetryPolicy, isServiceTransientError)
+		}, createDynamicServiceRetryPolicy(3 * time.Second), isServiceTransientError)
 
 	if err != nil {
 		elapsed := time.Since(startTime)


### PR DESCRIPTION
We had a pretty static retry policy which gets used for all API calls to Cadence Server.  This works well with long context timeout but does not allow for appropriate number of retries when smaller timeouts.  This change is an attempt to make retry policy dynamic based on context deadline for the request passed in by client application.
Retry policy before this change:
```
InitialInterval = 200 * time.Millisecond
BackoffCoefficient = 2.0
MaxInterval        = 4 * time.Second	
ExpirationInterval = 60 * time.Second
```
Retry policy after this change:
```
InitialInterval    = 20 * time.Millisecond
BackoffCoefficient = 1.2
MaxInterval        = (context_timeout/10) or (InitialInterval)
ExpirationInterval = (context_timeout) or (60 * time.Second)
```

We also create a new context for rpc call to Cadence Server.  Previously it set static rpcTimeout of 10 seconds.  Updated it to use context timeout if available and set rpcTimeout to half of context timeout or 1 second, whichever is higher.

Reporting of activity heartbeat was not using any context.Background with no timeout.  Updated the logic to use heartbeat timeout as context timeout so new dynamic retry policy could provide better retry semantics for activity heartbeat.

Also found few places in the code, around activity completion, where we initialized rpcContext outside of the retry once rather than within retry. 