### PR TITLE
allow activity logger to have workflow id and run id

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -272,6 +272,8 @@ func WithActivityTask(
 	}
 
 	logger.With(
+		zapcore.Field{Key: tagActivityID, Type: zapcore.StringType, String: *task.ActivityId},
+		zapcore.Field{Key: tagActivityType, Type: zapcore.StringType, String: *task.ActivityType.Name},
 		zapcore.Field{Key: tagWorkflowType, Type: zapcore.StringType, String: *task.WorkflowType.Name},
 		zapcore.Field{Key: tagWorkflowID, Type: zapcore.StringType, String: *task.WorkflowExecution.WorkflowId},
 		zapcore.Field{Key: tagRunID, Type: zapcore.StringType, String: *task.WorkflowExecution.RunId},

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/internal/common"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 type (
@@ -269,6 +270,13 @@ func WithActivityTask(
 	} else {
 		deadline = startToCloseDeadline
 	}
+
+	logger.With(
+		zapcore.Field{Key: tagWorkflowType, Type: zapcore.StringType, String: *task.WorkflowType.Name},
+		zapcore.Field{Key: tagWorkflowID, Type: zapcore.StringType, String: *task.WorkflowExecution.WorkflowId},
+		zapcore.Field{Key: tagRunID, Type: zapcore.StringType, String: *task.WorkflowExecution.RunId},
+	)
+
 	return context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{
 		taskToken:      task.TaskToken,
 		serviceInvoker: invoker,


### PR DESCRIPTION
This should fix https://github.com/uber-go/cadence-client/issues/637