### PR TITLE
Improve error when workflow is missing arguments to an activity

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1138,6 +1138,9 @@ func (g jsonEncoding) Marshal(objs []interface{}) ([]byte, error) {
 	enc := json.NewEncoder(&buf)
 	for i, obj := range objs {
 		if err := enc.Encode(obj); err != nil {
+			if err == io.EOF {
+				return nil, fmt.Errorf("missing argument at index %d of type %T", i, obj)
+			}
 			return nil, fmt.Errorf(
 				"unable to encode argument: %d, %v, with json error: %v", i, reflect.TypeOf(obj), err)
 		}

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1274,7 +1274,7 @@ func (m *mockWrapper) getMockReturn(ctx interface{}, input []byte) (retArgs mock
 	fnType := reflect.TypeOf(m.fn)
 	reflectArgs, err := decodeArgs(m.dataConverter, fnType, input)
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("Decode error: %v in %v of type %T", err.Error(), m.name, m.fn))
 	}
 	realArgs := m.getCtxArg(ctx)
 	for _, arg := range reflectArgs {


### PR DESCRIPTION
Previously it would panic with a json EOF error without any indication of where that happened.
An even better way would be if it was possible to get the stacktrace from the workflow execution rather than the activity execution, but that didn't seem to be possible in any easy way.