### PR TITLE
Fix heartbeat bug

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1422,12 +1422,6 @@ func (i *cadenceInvoker) Heartbeat(details []byte) error {
 				return
 			case <-i.workerStopChannel:
 				// Activity worker is close to stop. Send batched heartbeat.
-				if i.lastDetailsToReport != nil {
-					i.internalHeartBeat(*i.lastDetailsToReport)
-					i.lastDetailsToReport = nil
-					i.hbBatchEndTimer = nil
-				}
-				return
 			}
 
 			// We close the batch and report the progress.

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1417,11 +1417,11 @@ func (i *cadenceInvoker) Heartbeat(details []byte) error {
 			select {
 			case <-i.hbBatchEndTimer.C:
 				// We are close to deadline.
+			case <-i.workerStopChannel:
+				// Activity worker is close to stop. This does the same steps as batch timer ends.
 			case <-i.closeCh:
 				// We got closed.
 				return
-			case <-i.workerStopChannel:
-				// Activity worker is close to stop. Send batched heartbeat.
 			}
 
 			// We close the batch and report the progress.


### PR DESCRIPTION
Fix heartbeat race condition bug with worker stop channel. 

Remove the logic, the worker stop event should be treated the same as batch timer ends.