### PR TITLE
fix invalid memory address or nil pointer dereference 

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -325,7 +325,7 @@ func newWorkflowTaskHandler(
 		hostEnv:                        hostEnv,
 		nonDeterministicWorkflowPolicy: params.NonDeterministicWorkflowPolicy,
 		dataConverter:                  params.DataConverter,
-		laTunnel: 						laTunnel,
+		laTunnel:                       laTunnel,
 	}
 }
 

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -309,6 +309,11 @@ func newWorkflowTaskHandler(
 	hostEnv *hostEnvImpl,
 ) WorkflowTaskHandler {
 	ensureRequiredParams(&params)
+	// laTunnel is needed for queueResetStickinessTask
+	laTunnel := &localActivityTunnel{
+		taskCh:   make(chan *localActivityTask, 1000),
+		resultCh: make(chan interface{}),
+	}
 	return &workflowTaskHandlerImpl{
 		domain:                         domain,
 		logger:                         params.Logger,
@@ -320,6 +325,7 @@ func newWorkflowTaskHandler(
 		hostEnv:                        hostEnv,
 		nonDeterministicWorkflowPolicy: params.NonDeterministicWorkflowPolicy,
 		dataConverter:                  params.DataConverter,
+		laTunnel: 						laTunnel,
 	}
 }
 


### PR DESCRIPTION
When an error occurred in replayworkflow or the workflow is not completed 

user will get 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x181ed7f]

goroutine 45 [running]:
code.uber.internal/infra/coconut/vendor/go.uber.org/cadence/internal.(*workflowExecutionContextImpl).queueResetStickinessTask(...)
	/Users/scotthornberger/gocode/src/code.uber.internal/infra/coconut/vendor/go.uber.org/cadence/internal/internal_task_handlers.go:442
code.uber.internal/infra/coconut/vendor/go.uber.org/cadence/internal.(*workflowExecutionContextImpl).onEviction(0xc0000e3550)
	/Users/scotthornberger/gocode/src/code.uber.internal/infra/coconut/vendor/go.uber.org/cadence/internal/internal_task_handlers.go:422 +0x1cf
code.uber.internal/infra/coconut/vendor/go.uber.org/cadence/internal.getWorkflowCache.func1.1(0x1bc8ee0, 0xc0000e3550)
	/Users/scotthornberger/gocode/src/code.uber.internal/infra/coconut/vendor/go.uber.org/cadence/internal/internal_task_handlers.go:355 +0x3c
created by code.uber.internal/infra/coconut/vendor/go.uber.org/cadence/internal/common/cache.(*lru).Delete
	/Users/scotthornberger/gocode/src/code.uber.internal/infra/coconut/vendor/go.uber.org/cadence/internal/common/cache/lru.go:139 +0x175

```
This is due to missing `laChannel` in WorkflowTaskHandler when in replay. This will fix the issue. 

related to https://github.com/uber-go/cadence-client/issues/687