### PR TITLE
Correctly pass through WorkflowIDReusePolicy on SignalWithStart API

### DIFF
--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -343,6 +343,7 @@ func (wc *workflowClient) SignalWithStartWorkflow(ctx context.Context, workflowI
 		RetryPolicy:                         convertRetryPolicy(options.RetryPolicy),
 		CronSchedule:                        common.StringPtr(options.CronSchedule),
 		Memo:                                memo,
+		WorkflowIdReusePolicy:               options.WorkflowIDReusePolicy.toThriftPtr(),
 	}
 
 	var response *s.StartWorkflowExecutionResponse


### PR DESCRIPTION
Workflow client implementation does not pass on user specified
WorkflowIDReusePolicy to Cadence server on SignalWithStart API call
resulting in default policy 'WorkflowIDReusePolicyAllowDuplicate'
to be used for all calls.