### PR TITLE
Expose workflowType and Args of ContinueAsNewError

### DIFF
--- a/internal/error.go
+++ b/internal/error.go
@@ -338,6 +338,16 @@ func (e *ContinueAsNewError) Error() string {
 	return "ContinueAsNew"
 }
 
+// WorkflowType return workflowType of the new run
+func (e *ContinueAsNewError) WorkflowType() *WorkflowType {
+	return e.params.workflowType
+}
+
+// Args return workflow argument of the new run
+func (e *ContinueAsNewError) Args() []interface{} {
+	return e.args
+}
+
 // newTerminatedError creates NewTerminatedError instance
 func newTerminatedError() *TerminatedError {
 	return &TerminatedError{}


### PR DESCRIPTION
https://github.com/uber-go/cadence-client/issues/726