### PR TITLE
Support for sending multiple signals from the same delayed callback

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -599,7 +599,7 @@ func (env *testWorkflowEnvironmentImpl) registerDelayedCallback(f func(), delayD
 	mainLoopCallback := func() {
 		env.newTimer(delayDuration, timerCallback, false)
 	}
-	env.postCallback(mainLoopCallback, false)
+	env.postCallback(mainLoopCallback, true)
 }
 
 func (c *testCallbackHandle) processCallback() {

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1758,15 +1758,13 @@ func (env *testWorkflowEnvironmentImpl) getActivityInfo(activityID, activityType
 }
 
 func (env *testWorkflowEnvironmentImpl) cancelWorkflow(callback resultHandler) {
-	env.postCallback(func() {
-		// RequestCancelWorkflow needs to be run in main thread
-		env.RequestCancelExternalWorkflow(
-			env.workflowInfo.Domain,
-			env.workflowInfo.WorkflowExecution.ID,
-			env.workflowInfo.WorkflowExecution.RunID,
-			callback,
-		)
-	}, true)
+	// RequestCancelWorkflow needs to be run in main thread
+	env.RequestCancelExternalWorkflow(
+		env.workflowInfo.Domain,
+		env.workflowInfo.WorkflowExecution.ID,
+		env.workflowInfo.WorkflowExecution.RunID,
+		callback,
+	)
 }
 
 func (env *testWorkflowEnvironmentImpl) signalWorkflow(name string, input interface{}) {
@@ -1774,9 +1772,7 @@ func (env *testWorkflowEnvironmentImpl) signalWorkflow(name string, input interf
 	if err != nil {
 		panic(err)
 	}
-	env.postCallback(func() {
-		env.signalHandler(name, data)
-	}, true)
+	env.signalHandler(name, data)
 }
 
 func (env *testWorkflowEnvironmentImpl) signalWorkflowByID(workflowID, signalName string, input interface{}) error {
@@ -1789,9 +1785,7 @@ func (env *testWorkflowEnvironmentImpl) signalWorkflowByID(workflowID, signalNam
 		if workflowHandle.handled {
 			return &shared.EntityNotExistsError{Message: fmt.Sprintf("Workflow %v already completed", workflowID)}
 		}
-		workflowHandle.env.postCallback(func() {
-			workflowHandle.env.signalHandler(signalName, data)
-		}, true)
+		workflowHandle.env.signalHandler(signalName, data)
 		return nil
 	}
 


### PR DESCRIPTION
Before this change the following unit test would fail as only the first signal would be delivered to the workflow before it exits. The change is valid as SendSignal is always called from a delayed callback which already executes in the event loop thread.

```
func (s *WorkflowTestSuiteUnitTest) Test_DrainSignalChannel() {
	workflowFn := func(ctx Context) (string, error) {

		signalCh := GetSignalChannel(ctx, "test-signal")
		var s1, s2, s3 string
		signalCh.Receive(ctx, &s1)
		if !signalCh.ReceiveAsync(&s2) {
			return "", errors.New("expected signal")
		}
		if signalCh.ReceiveAsync(&s3) {
			return "", errors.New("unexpected signal")
		}
		return s1 + s2, nil
	}

	RegisterWorkflow(workflowFn)
	env := s.NewTestWorkflowEnvironment()

	env.RegisterDelayedCallback(func() {
		env.SignalWorkflow("test-signal", "s1")
		env.SignalWorkflow("test-signal", "s2")
	}, time.Minute)

	env.ExecuteWorkflow(workflowFn)

	s.True(env.IsWorkflowCompleted())
	s.NoError(env.GetWorkflowError())
	var result string
	env.GetWorkflowResult(&result)
	s.Equal("s1s2", result)
}
```
