### PR TITLE
Make test suite respond with a typed error for unknown workflow execution

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1638,7 +1638,7 @@ func (env *testWorkflowEnvironmentImpl) SignalExternalWorkflow(domainName, workf
 		childEnv := childHandle.env
 		if childEnv.isTestCompleted {
 			// child already completed (NOTE: we have only one failed cause now)
-			err := fmt.Errorf("signal external workflow failed, %v", shared.SignalExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution)
+			err := newUnknownExternalWorkflowExecutionError()
 			callback(nil, err)
 		} else {
 			childEnv.signalHandler(signalName, input)
@@ -1650,7 +1650,7 @@ func (env *testWorkflowEnvironmentImpl) SignalExternalWorkflow(domainName, workf
 
 	// here we signal a child workflow but we cannot find it
 	if childWorkflowOnly {
-		err := fmt.Errorf("signal external workflow failed, %v", shared.SignalExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution)
+		err := newUnknownExternalWorkflowExecutionError()
 		callback(nil, err)
 		return
 	}


### PR DESCRIPTION
There is a typed error that indicates an external workflow doesn't exist. The error is already returned in `internal_event_handlers.go`:
```
func (weh *workflowExecutionEventHandlerImpl) handleSignalExternalWorkflowExecutionFailed
// ....
		err = newUnknownExternalWorkflowExecutionError()
```
This change makes a test suite return the same error.

it fixes #761 and is related to #368 