### PR TITLE
Wait for local activity while holding workflow context lock

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -422,6 +422,7 @@ func (wc *workflowEnvironmentImpl) ExecuteLocalActivity(params executeLocalActiv
 	activityID := wc.GenerateSequenceID()
 	task := newLocalActivityTask(params, callback, activityID)
 
+	fmt.Printf("scheduling local activity %v\n", activityID)
 	wc.pendingLaTasks[activityID] = task
 	wc.unstartedLaTasks[activityID] = struct{}{}
 	return &localActivityInfo{activityID: activityID}

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -422,7 +422,6 @@ func (wc *workflowEnvironmentImpl) ExecuteLocalActivity(params executeLocalActiv
 	activityID := wc.GenerateSequenceID()
 	task := newLocalActivityTask(params, callback, activityID)
 
-	fmt.Printf("scheduling local activity %v\n", activityID)
 	wc.pendingLaTasks[activityID] = task
 	wc.unstartedLaTasks[activityID] = struct{}{}
 	return &localActivityInfo{activityID: activityID}

--- a/internal/internal_public.go
+++ b/internal/internal_public.go
@@ -74,7 +74,7 @@ type (
 		// - RespondDecisionTaskCompletedRequest
 		// - RespondDecisionTaskFailedRequest
 		// - RespondQueryTaskCompletedRequest
-		ProcessWorkflowTask(task *workflowTask) (response interface{}, w WorkflowExecutionContext, locked bool, err error)
+		ProcessWorkflowTask(task *workflowTask) (response interface{}, w WorkflowExecutionContext, err error)
 	}
 
 	// ActivityTaskHandler represents activity task handlers.

--- a/internal/internal_public.go
+++ b/internal/internal_public.go
@@ -34,9 +34,7 @@ import (
 )
 
 type (
-	decisionHeartBeatFunc func(response interface{}, startTime time.Time) (*s.RespondDecisionTaskCompletedResponse, error)
-
-	workflowTaskFunc func(*s.RespondDecisionTaskCompletedResponse) *workflowTask
+	decisionHeartBeatFunc func(response interface{}, startTime time.Time) (*workflowTask, error)
 
 	// HistoryIterator iterator through history events
 	HistoryIterator interface {
@@ -81,7 +79,6 @@ type (
 		ProcessWorkflowTask(
 			task *workflowTask,
 			f decisionHeartBeatFunc,
-			w workflowTaskFunc,
 		) (response interface{}, err error)
 	}
 

--- a/internal/internal_public.go
+++ b/internal/internal_public.go
@@ -74,7 +74,7 @@ type (
 		// - RespondDecisionTaskCompletedRequest
 		// - RespondDecisionTaskFailedRequest
 		// - RespondQueryTaskCompletedRequest
-		ProcessWorkflowTask(task *workflowTask) (response interface{}, w WorkflowExecutionContext, err error)
+		ProcessWorkflowTask(task *workflowTask) (response interface{}, w WorkflowExecutionContext, locked bool, err error)
 	}
 
 	// ActivityTaskHandler represents activity task handlers.

--- a/internal/internal_public.go
+++ b/internal/internal_public.go
@@ -34,7 +34,7 @@ import (
 )
 
 type (
-	decisionHeartBeatFunc func(response interface{}, startTime time.Time) (*workflowTask, error)
+	decisionHeartbeatFunc func(response interface{}, startTime time.Time) (*workflowTask, error)
 
 	// HistoryIterator iterator through history events
 	HistoryIterator interface {
@@ -78,7 +78,7 @@ type (
 		// - RespondQueryTaskCompletedRequest
 		ProcessWorkflowTask(
 			task *workflowTask,
-			f decisionHeartBeatFunc,
+			f decisionHeartbeatFunc,
 		) (response interface{}, err error)
 	}
 

--- a/internal/internal_public.go
+++ b/internal/internal_public.go
@@ -34,6 +34,10 @@ import (
 )
 
 type (
+	decisionHeartBeatFunc func(response interface{}, startTime time.Time) (*s.RespondDecisionTaskCompletedResponse, error)
+
+	workflowTaskFunc func(*s.RespondDecisionTaskCompletedResponse) *workflowTask
+
 	// HistoryIterator iterator through history events
 	HistoryIterator interface {
 		// GetNextPage returns next page of history events
@@ -74,7 +78,11 @@ type (
 		// - RespondDecisionTaskCompletedRequest
 		// - RespondDecisionTaskFailedRequest
 		// - RespondQueryTaskCompletedRequest
-		ProcessWorkflowTask(task *workflowTask) (response interface{}, w WorkflowExecutionContext, err error)
+		ProcessWorkflowTask(
+			task *workflowTask,
+			f decisionHeartBeatFunc,
+			w workflowTaskFunc,
+		) (response interface{}, err error)
 	}
 
 	// ActivityTaskHandler represents activity task handlers.

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -459,6 +460,7 @@ func (w *workflowExecutionContextImpl) queueResetStickinessTask() {
 			RunId:      common.StringPtr(w.workflowInfo.WorkflowExecution.RunID),
 		},
 	}
+	debug.PrintStack()
 	// w.laTunnel could be nil for worker.ReplayHistory() because there is no worker started, in that case we don't
 	// care about resetStickinessTask.
 	if w.laTunnel != nil && w.laTunnel.resultCh != nil {

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -400,6 +400,10 @@ func (w *workflowExecutionContextImpl) Lock() {
 }
 
 func (w *workflowExecutionContextImpl) Unlock(err error) {
+	if _, ok := err.(*localActivityTimedOutError); ok {
+		w.mutex.Unlock()
+		return
+	}
 	if err != nil || w.err != nil || w.isWorkflowCompleted || (w.wth.disableStickyExecution && !w.hasPendingLocalActivityWork()) {
 		// TODO: in case of closed, it asumes the close decision always succeed. need server side change to return
 		// error to indicate the close failure case. This should be rear case. For now, always remove the cache, and
@@ -642,6 +646,7 @@ func (w *workflowExecutionContextImpl) resetStateIfDestroyed(task *s.PollForDeci
 func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 	workflowTask *workflowTask,
 ) (completeRequest interface{}, context WorkflowExecutionContext, errRet error) {
+	startTime := time.Now()
 	if workflowTask == nil || workflowTask.task == nil {
 		return nil, nil, errors.New("nil workflow task provided")
 	}
@@ -670,7 +675,33 @@ func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 		return nil, nil, err
 	}
 
+	defer func() {
+		workflowContext.Unlock(errRet)
+	}()
+
 	response, err := workflowContext.ProcessWorkflowTask(workflowTask)
+	if err == nil && response == nil {
+	wait_LocalActivity_Loop:
+		for {
+			deadlineToTrigger := time.Duration(float32(ratioToForceCompleteDecisionTaskComplete) * float32(workflowContext.GetDecisionTimeout()))
+			delayDuration := startTime.Add(deadlineToTrigger).Sub(time.Now())
+			select {
+			case <-time.After(delayDuration):
+				// force complete
+				// return force decision task completed error
+				return response, workflowContext, &localActivityTimedOutError{Message: "local activity did not complete within decision timeout"}
+
+			case lar := <-workflowTask.laResultCh:
+				// local activity result ready
+				response, err = workflowContext.ProcessLocalActivityResult(workflowTask, lar)
+				if err == nil && response == nil {
+					// decision task is not done yet, still waiting for more local activities
+					continue wait_LocalActivity_Loop
+				}
+				break wait_LocalActivity_Loop
+			}
+		}
+	}
 	return response, workflowContext, err
 }
 

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -149,7 +149,7 @@ type (
 		next          []*s.HistoryEvent
 	}
 
-	decisionHeartBeatError struct {
+	decisionHeartbeatError struct {
 		Message string
 	}
 )
@@ -165,7 +165,7 @@ func newHistory(task *workflowTask, eventsHandler *workflowExecutionEventHandler
 	return result
 }
 
-func (e decisionHeartBeatError) Error() string {
+func (e decisionHeartbeatError) Error() string {
 	return e.Message
 }
 
@@ -641,7 +641,7 @@ func (w *workflowExecutionContextImpl) resetStateIfDestroyed(task *s.PollForDeci
 // ProcessWorkflowTask processes all the events of the workflow task.
 func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 	workflowTask *workflowTask,
-	heartbeatFunc decisionHeartBeatFunc,
+	heartbeatFunc decisionHeartbeatFunc,
 ) (completeRequest interface{}, errRet error) {
 	if workflowTask == nil || workflowTask.task == nil {
 		return nil, errors.New("nil workflow task provided")
@@ -693,7 +693,7 @@ process_Workflow_Loop:
 						startTime,
 					)
 					if err != nil {
-						return nil, &decisionHeartBeatError{Message: fmt.Sprintf("error sending decision heartbeat %v", err)}
+						return nil, &decisionHeartbeatError{Message: fmt.Sprintf("error sending decision heartbeat %v", err)}
 					}
 					if workflowTask == nil {
 						return nil, nil

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -641,9 +641,9 @@ func (w *workflowExecutionContextImpl) resetStateIfDestroyed(task *s.PollForDeci
 // ProcessWorkflowTask processes all the events of the workflow task.
 func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 	workflowTask *workflowTask,
-) (completeRequest interface{}, context WorkflowExecutionContext, locked bool, errRet error) {
+) (completeRequest interface{}, context WorkflowExecutionContext, errRet error) {
 	if workflowTask == nil || workflowTask.task == nil {
-		return nil, nil, false, errors.New("nil workflow task provided")
+		return nil, nil, errors.New("nil workflow task provided")
 	}
 	task := workflowTask.task
 	if task.History == nil || len(task.History.Events) == 0 {
@@ -652,7 +652,7 @@ func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 		}
 	}
 	if task.Query == nil && len(task.History.Events) == 0 {
-		return nil, nil, false, errors.New("nil or empty history")
+		return nil, nil, errors.New("nil or empty history")
 	}
 
 	runID := task.WorkflowExecution.GetRunId()
@@ -667,11 +667,11 @@ func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 
 	workflowContext, err := wth.getOrCreateWorkflowContext(task, workflowTask.historyIterator)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, err
 	}
 
 	response, err := workflowContext.ProcessWorkflowTask(workflowTask)
-	return response, workflowContext, true, err
+	return response, workflowContext, err
 }
 
 func (w *workflowExecutionContextImpl) ProcessWorkflowTask(workflowTask *workflowTask) (interface{}, error) {

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -28,8 +28,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/rand"
 	"reflect"
-	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -474,8 +474,6 @@ func (w *workflowExecutionContextImpl) clearState() {
 	w.err = nil
 	w.previousStartedEventID = 0
 	w.newDecisions = nil
-	fmt.Println("clearing state")
-	debug.PrintStack()
 	if w.eventHandler != nil {
 		// Set isReplay to true to prevent user code in defer guarded by !isReplaying() from running
 		w.eventHandler.isReplay = true
@@ -556,8 +554,16 @@ func (wth *workflowTaskHandlerImpl) createWorkflowContext(task *s.PollForDecisio
 	return workflowContext, nil
 }
 
-func (wth *workflowTaskHandlerImpl) getOrCreateWorkflowContext(task *s.PollForDecisionTaskResponse,
-	historyIterator HistoryIterator) (workflowContext *workflowExecutionContextImpl, err error) {
+func (wth *workflowTaskHandlerImpl) getOrCreateWorkflowContext(
+	task *s.PollForDecisionTaskResponse,
+	historyIterator HistoryIterator,
+) (workflowContext *workflowExecutionContextImpl, err error) {
+	rand.Seed(time.Now().UTC().UnixNano())
+	id := rand.Int31()
+	defer func() {
+		fmt.Printf("get workflow context completed %v\n", id)
+	}()
+	fmt.Printf("get workflow context 1 %v\n", id)
 	metricsScope := wth.metricsScope.GetTaggedScope(tagWorkflowType, task.WorkflowType.GetName())
 	defer func() {
 		if err == nil && workflowContext != nil && workflowContext.laTunnel == nil {
@@ -566,17 +572,21 @@ func (wth *workflowTaskHandlerImpl) getOrCreateWorkflowContext(task *s.PollForDe
 		metricsScope.Gauge(metrics.StickyCacheSize).Update(float64(getWorkflowCache().Size()))
 	}()
 
+	fmt.Printf("get workflow context 2 %v\n", id)
 	runID := task.WorkflowExecution.GetRunId()
 
 	history := task.History
 	isFullHistory := isFullHistory(history)
 
+	fmt.Printf("get workflow context 3 %v\n", id)
 	workflowContext = nil
 	if task.Query == nil || (task.Query != nil && !isFullHistory) {
 		workflowContext = getWorkflowContext(runID)
 	}
 
+	fmt.Printf("get workflow context 4 %v\n", id)
 	if workflowContext != nil {
+		fmt.Printf("get workflow context 5 %v\n", id)
 		workflowContext.Lock()
 		if task.Query != nil && !isFullHistory {
 			// query task and we have a valid cached state
@@ -589,6 +599,7 @@ func (wth *workflowTaskHandlerImpl) getOrCreateWorkflowContext(task *s.PollForDe
 			workflowContext.ResetIfStale(task, historyIterator)
 		}
 	} else {
+		fmt.Printf("get workflow context 6 %v\n", id)
 		if !isFullHistory {
 			// we are getting partial history task, but cached state was already evicted.
 			// we need to reset history so we get events from beginning to replay/rebuild the state
@@ -597,21 +608,25 @@ func (wth *workflowTaskHandlerImpl) getOrCreateWorkflowContext(task *s.PollForDe
 				return
 			}
 		}
+		fmt.Printf("get workflow context 7 %v\n", id)
 
 		if workflowContext, err = wth.createWorkflowContext(task); err != nil {
 			return
 		}
+		fmt.Printf("get workflow context 8 %v\n", id)
 
 		if !wth.disableStickyExecution && task.Query == nil {
 			workflowContext, _ = putWorkflowContext(runID, workflowContext)
 		}
 		workflowContext.Lock()
 	}
+	fmt.Printf("get workflow context 9 %v\n", id)
 
 	err = workflowContext.resetStateIfDestroyed(task, historyIterator)
 	if err != nil {
 		workflowContext.Unlock(err)
 	}
+	fmt.Printf("get workflow context 10 %v\n", id)
 
 	return
 }
@@ -643,21 +658,30 @@ func (w *workflowExecutionContextImpl) resetStateIfDestroyed(task *s.PollForDeci
 func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 	workflowTask *workflowTask,
 ) (completeRequest interface{}, context WorkflowExecutionContext, errRet error) {
-	//	fmt.Println("process workflow task again")
+	rand.Seed(time.Now().UTC().UnixNano())
+	id := rand.Int31()
+	defer func() {
+		fmt.Printf("process workflow task completed %v\n", id)
+	}()
+	fmt.Printf("process workflow task again %v\n", id)
 	startTime := time.Now()
 	if workflowTask == nil || workflowTask.task == nil {
+		fmt.Println("workflow task is nil")
 		return nil, nil, errors.New("nil workflow task provided")
 	}
+	fmt.Printf("process 1 - %v\n", id)
 	task := workflowTask.task
 	if task.History == nil || len(task.History.Events) == 0 {
 		task.History = &s.History{
 			Events: []*s.HistoryEvent{},
 		}
 	}
+	fmt.Printf("process 2 - %v\n", id)
 	if task.Query == nil && len(task.History.Events) == 0 {
 		return nil, nil, errors.New("nil or empty history")
 	}
 
+	fmt.Printf("process 3 - %v\n", id)
 	runID := task.WorkflowExecution.GetRunId()
 	workflowID := task.WorkflowExecution.GetWorkflowId()
 	traceLog(func() {
@@ -668,10 +692,13 @@ func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 			zap.Int64("PreviousStartedEventId", task.GetPreviousStartedEventId()))
 	})
 
+	fmt.Printf("process 4 - %v\n", id)
 	workflowContext, err := wth.getOrCreateWorkflowContext(task, workflowTask.historyIterator)
 	if err != nil {
+		fmt.Printf("got error while creating context %v\n", err)
 		return nil, nil, err
 	}
+	fmt.Printf("process 5 - %v\n", id)
 
 	defer func() {
 		workflowContext.Unlock(errRet)
@@ -681,17 +708,20 @@ func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 	if err == nil && response == nil {
 	wait_LocalActivity_Loop:
 		for {
+			fmt.Printf("process 6 - %v\n", id)
 			deadlineToTrigger := time.Duration(float32(ratioToForceCompleteDecisionTaskComplete) * float32(workflowContext.GetDecisionTimeout()))
 			delayDuration := startTime.Add(deadlineToTrigger).Sub(time.Now())
 			select {
 			case <-time.After(delayDuration):
 				// force complete
 				// return force decision task completed error
+				fmt.Printf("process 7 - %v\n", id)
 				return response, workflowContext, &localActivityTimedOutError{Message: "local activity did not complete within decision timeout"}
 
 			case lar := <-workflowTask.laResultCh:
 				//				fmt.Println("got result")
 				// local activity result ready
+				fmt.Printf("process 8 - %v\n", id)
 				response, err = workflowContext.ProcessLocalActivityResult(workflowTask, lar)
 				if err == nil && response == nil {
 					//					fmt.Println("not complete, continue")

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -641,9 +641,9 @@ func (w *workflowExecutionContextImpl) resetStateIfDestroyed(task *s.PollForDeci
 // ProcessWorkflowTask processes all the events of the workflow task.
 func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 	workflowTask *workflowTask,
-) (completeRequest interface{}, context WorkflowExecutionContext, errRet error) {
+) (completeRequest interface{}, context WorkflowExecutionContext, locked bool, errRet error) {
 	if workflowTask == nil || workflowTask.task == nil {
-		return nil, nil, errors.New("nil workflow task provided")
+		return nil, nil, false, errors.New("nil workflow task provided")
 	}
 	task := workflowTask.task
 	if task.History == nil || len(task.History.Events) == 0 {
@@ -652,7 +652,7 @@ func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 		}
 	}
 	if task.Query == nil && len(task.History.Events) == 0 {
-		return nil, nil, errors.New("nil or empty history")
+		return nil, nil, false, errors.New("nil or empty history")
 	}
 
 	runID := task.WorkflowExecution.GetRunId()
@@ -667,11 +667,11 @@ func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 
 	workflowContext, err := wth.getOrCreateWorkflowContext(task, workflowTask.historyIterator)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, false, err
 	}
 
 	response, err := workflowContext.ProcessWorkflowTask(workflowTask)
-	return response, workflowContext, err
+	return response, workflowContext, true, err
 }
 
 func (w *workflowExecutionContextImpl) ProcessWorkflowTask(workflowTask *workflowTask) (interface{}, error) {

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -648,7 +648,6 @@ func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 ) (completeRequest interface{}, context WorkflowExecutionContext, errRet error) {
 	startTime := time.Now()
 	if workflowTask == nil || workflowTask.task == nil {
-		fmt.Println("workflow task is nil")
 		return nil, nil, errors.New("nil workflow task provided")
 	}
 	task := workflowTask.task

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -400,6 +400,10 @@ func (w *workflowExecutionContextImpl) Lock() {
 }
 
 func (w *workflowExecutionContextImpl) Unlock(err error) {
+	if _, ok := err.(*localActivityTimedOutError); ok {
+		w.mutex.Unlock()
+		return
+	}
 	if err != nil || w.err != nil || w.isWorkflowCompleted || (w.wth.disableStickyExecution && !w.hasPendingLocalActivityWork()) {
 		// TODO: in case of closed, it asumes the close decision always succeed. need server side change to return
 		// error to indicate the close failure case. This should be rear case. For now, always remove the cache, and

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -997,10 +997,6 @@ func (w *workflowExecutionContextImpl) skipReplayCheck() bool {
 	return w.currentDecisionTask.Query != nil || !isFullHistory(w.currentDecisionTask.History)
 }
 
-func (w *workflowExecutionContextImpl) GetCurrentDecisionTask() *s.PollForDecisionTaskResponse {
-	return w.currentDecisionTask
-}
-
 func (w *workflowExecutionContextImpl) SetCurrentTask(task *s.PollForDecisionTaskResponse) {
 	w.currentDecisionTask = task
 	// do not update the previousStartedEventID for query task
@@ -1032,13 +1028,6 @@ func (w *workflowExecutionContextImpl) ResetIfStale(task *s.PollForDecisionTaskR
 
 func (w *workflowExecutionContextImpl) GetDecisionTimeout() time.Duration {
 	return time.Second * time.Duration(w.workflowInfo.TaskStartToCloseTimeoutSeconds)
-}
-
-func (w *workflowExecutionContextImpl) StackTrace() string {
-	if w.eventHandler == nil {
-		return "eventHandler is closed"
-	}
-	return w.eventHandler.StackTrace()
 }
 
 func skipDeterministicCheckForDecision(d *s.Decision) bool {

--- a/internal/internal_task_handlers_interfaces_test.go
+++ b/internal/internal_task_handlers_interfaces_test.go
@@ -47,7 +47,6 @@ type sampleWorkflowTaskHandler struct {
 func (wth sampleWorkflowTaskHandler) ProcessWorkflowTask(
 	workflowTask *workflowTask,
 	d decisionHeartBeatFunc,
-	w workflowTaskFunc,
 ) (interface{}, error) {
 	return &m.RespondDecisionTaskCompletedRequest{
 		TaskToken: workflowTask.task.TaskToken,
@@ -108,7 +107,7 @@ func (s *PollLayerInterfacesTestSuite) TestProcessWorkflowTaskInterface() {
 
 	// Process task and respond to the service.
 	taskHandler := newSampleWorkflowTaskHandler()
-	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: response}, nil, nil)
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: response}, nil)
 	completionRequest := request.(*m.RespondDecisionTaskCompletedRequest)
 	s.NoError(err)
 

--- a/internal/internal_task_handlers_interfaces_test.go
+++ b/internal/internal_task_handlers_interfaces_test.go
@@ -21,6 +21,8 @@
 package internal
 
 import (
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber/tchannel-go/thrift"
@@ -28,7 +30,6 @@ import (
 	m "go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/internal/common"
 	"golang.org/x/net/context"
-	"testing"
 )
 
 type (
@@ -44,10 +45,13 @@ type sampleWorkflowTaskHandler struct {
 }
 
 func (wth sampleWorkflowTaskHandler) ProcessWorkflowTask(
-	workflowTask *workflowTask) (interface{}, WorkflowExecutionContext, error) {
+	workflowTask *workflowTask,
+	d decisionHeartBeatFunc,
+	w workflowTaskFunc,
+) (interface{}, error) {
 	return &m.RespondDecisionTaskCompletedRequest{
 		TaskToken: workflowTask.task.TaskToken,
-	}, nil, nil
+	}, nil
 }
 
 func newSampleWorkflowTaskHandler() *sampleWorkflowTaskHandler {
@@ -104,7 +108,7 @@ func (s *PollLayerInterfacesTestSuite) TestProcessWorkflowTaskInterface() {
 
 	// Process task and respond to the service.
 	taskHandler := newSampleWorkflowTaskHandler()
-	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: response})
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: response}, nil, nil)
 	completionRequest := request.(*m.RespondDecisionTaskCompletedRequest)
 	s.NoError(err)
 

--- a/internal/internal_task_handlers_interfaces_test.go
+++ b/internal/internal_task_handlers_interfaces_test.go
@@ -46,7 +46,7 @@ type sampleWorkflowTaskHandler struct {
 
 func (wth sampleWorkflowTaskHandler) ProcessWorkflowTask(
 	workflowTask *workflowTask,
-	d decisionHeartBeatFunc,
+	d decisionHeartbeatFunc,
 ) (interface{}, error) {
 	return &m.RespondDecisionTaskCompletedRequest{
 		TaskToken: workflowTask.task.TaskToken,

--- a/internal/internal_task_handlers_interfaces_test.go
+++ b/internal/internal_task_handlers_interfaces_test.go
@@ -21,8 +21,6 @@
 package internal
 
 import (
-	"testing"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber/tchannel-go/thrift"
@@ -30,6 +28,7 @@ import (
 	m "go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/internal/common"
 	"golang.org/x/net/context"
+	"testing"
 )
 
 type (
@@ -45,10 +44,10 @@ type sampleWorkflowTaskHandler struct {
 }
 
 func (wth sampleWorkflowTaskHandler) ProcessWorkflowTask(
-	workflowTask *workflowTask) (interface{}, WorkflowExecutionContext, bool, error) {
+	workflowTask *workflowTask) (interface{}, WorkflowExecutionContext, error) {
 	return &m.RespondDecisionTaskCompletedRequest{
 		TaskToken: workflowTask.task.TaskToken,
-	}, nil, false, nil
+	}, nil, nil
 }
 
 func newSampleWorkflowTaskHandler() *sampleWorkflowTaskHandler {
@@ -105,7 +104,7 @@ func (s *PollLayerInterfacesTestSuite) TestProcessWorkflowTaskInterface() {
 
 	// Process task and respond to the service.
 	taskHandler := newSampleWorkflowTaskHandler()
-	request, _, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: response})
+	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: response})
 	completionRequest := request.(*m.RespondDecisionTaskCompletedRequest)
 	s.NoError(err)
 

--- a/internal/internal_task_handlers_interfaces_test.go
+++ b/internal/internal_task_handlers_interfaces_test.go
@@ -21,6 +21,8 @@
 package internal
 
 import (
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber/tchannel-go/thrift"
@@ -28,7 +30,6 @@ import (
 	m "go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/internal/common"
 	"golang.org/x/net/context"
-	"testing"
 )
 
 type (
@@ -44,10 +45,10 @@ type sampleWorkflowTaskHandler struct {
 }
 
 func (wth sampleWorkflowTaskHandler) ProcessWorkflowTask(
-	workflowTask *workflowTask) (interface{}, WorkflowExecutionContext, error) {
+	workflowTask *workflowTask) (interface{}, WorkflowExecutionContext, bool, error) {
 	return &m.RespondDecisionTaskCompletedRequest{
 		TaskToken: workflowTask.task.TaskToken,
-	}, nil, nil
+	}, nil, false, nil
 }
 
 func newSampleWorkflowTaskHandler() *sampleWorkflowTaskHandler {
@@ -104,7 +105,7 @@ func (s *PollLayerInterfacesTestSuite) TestProcessWorkflowTaskInterface() {
 
 	// Process task and respond to the service.
 	taskHandler := newSampleWorkflowTaskHandler()
-	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: response})
+	request, _, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: response})
 	completionRequest := request.(*m.RespondDecisionTaskCompletedRequest)
 	s.NoError(err)
 

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -234,7 +234,7 @@ func (t *TaskHandlersTestSuite) testWorkflowTaskWorkflowExecutionStartedHelper(p
 	}
 	task := createWorkflowTask(testEvents, 0, "HelloWorld_Workflow")
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
 	t.NotNil(response)
@@ -286,7 +286,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_ActivityTaskScheduled() {
 		Logger:   t.logger,
 	}
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 
 	t.NoError(err)
@@ -297,7 +297,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_ActivityTaskScheduled() {
 
 	// Schedule an activity and see if we complete workflow, Having only one last decision.
 	task = createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
-	request, _, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	response = request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
 	t.NotNil(response)
@@ -337,7 +337,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_Sticky() {
 	task := createWorkflowTask(testEvents[0:1], 0, "HelloWorld_Workflow")
 	task.StartedEventId = common.Int64Ptr(1)
 	task.WorkflowExecution = execution
-	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
 	t.NotNil(response)
@@ -348,7 +348,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_Sticky() {
 	// then check the current state using query task
 	task = createQueryTask([]*s.HistoryEvent{}, 6, "HelloWorld_Workflow", "test-query")
 	task.WorkflowExecution = execution
-	queryResp, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	queryResp, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	t.NoError(err)
 	t.verifyQueryResult(queryResp, "waiting-activity-result")
 }
@@ -380,30 +380,30 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_NonSticky() {
 	// query after first decision task (notice the previousStartEventID is always the last eventID for query task)
 	task := createQueryTask(testEvents[0:3], 3, "HelloWorld_Workflow", "test-query")
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	response, _, _ := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	response, _ := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	t.verifyQueryResult(response, "waiting-activity-result")
 
 	// query after activity task complete but before second decision task started
 	task = createQueryTask(testEvents[0:7], 7, "HelloWorld_Workflow", "test-query")
 	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	response, _, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	response, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	t.verifyQueryResult(response, "waiting-activity-result")
 
 	// query after second decision task
 	task = createQueryTask(testEvents[0:8], 8, "HelloWorld_Workflow", "test-query")
 	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	response, _, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	response, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	t.verifyQueryResult(response, "done")
 
 	// query after second decision task with extra events
 	task = createQueryTask(testEvents[0:9], 9, "HelloWorld_Workflow", "test-query")
 	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	response, _, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	response, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	t.verifyQueryResult(response, "done")
 
 	task = createQueryTask(testEvents[0:9], 9, "HelloWorld_Workflow", "invalid-query-type")
 	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	response, _, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	response, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	t.NotNil(response)
 	queryResp, ok := response.(*s.RespondQueryTaskCompletedRequest)
 	t.True(ok)
@@ -451,7 +451,7 @@ func (t *TaskHandlersTestSuite) TestCacheEvictionWhenErrorOccurs() {
 	// newWorkflowTaskWorkerInternal will set the laTunnel in taskHandler, without it, ProcessWorkflowTask()
 	// will fail as it can't find laTunnel in getWorkflowCache().
 	newWorkflowTaskWorkerInternal(taskHandler, t.service, testDomain, params, make(chan struct{}))
-	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 
 	t.Error(err)
 	t.Nil(request)
@@ -507,7 +507,7 @@ func (t *TaskHandlersTestSuite) testSideEffectDeferHelper(disableSticky bool) {
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
 	task := createWorkflowTask(testEvents, 0, workflowName)
-	_, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	_, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	t.Nil(err)
 
 	if !params.DisableStickyExecution {
@@ -549,7 +549,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	// there should be no error as the history events matched the decisions.
 	t.NoError(err)
@@ -561,7 +561,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	// newWorkflowTaskWorkerInternal will set the laTunnel in taskHandler, without it, ProcessWorkflowTask()
 	// will fail as it can't find laTunnel in getWorkflowCache().
 	newWorkflowTaskWorkerInternal(taskHandler, t.service, testDomain, params, stopC)
-	request, _, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	t.Error(err)
 	t.Nil(request)
 	t.Contains(err.Error(), "nondeterministic")
@@ -571,7 +571,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	params.NonDeterministicWorkflowPolicy = NonDeterministicWorkflowPolicyFailWorkflow
 	failOnNondeterminismTaskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
 	task = createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
-	request, _, err = failOnNondeterminismTaskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, err = failOnNondeterminismTaskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	// When FailWorkflow policy is set, task handler does not return an error,
 	// because it will indicate non determinism in the request.
 	t.NoError(err)
@@ -589,7 +589,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	// now with different package name to activity type
 	testEvents[4].ActivityTaskScheduledEventAttributes.ActivityType.Name = common.StringPtr("new-package.Greeter_Activity")
 	task = createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
-	request, _, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	t.NoError(err)
 	t.NotNil(request)
 }
@@ -610,7 +610,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowReturnsPanicError() {
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	t.NoError(err)
 	t.NotNil(request)
 	r, ok := request.(*s.RespondDecisionTaskCompletedRequest)
@@ -638,7 +638,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowPanics() {
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	t.NoError(err)
 	t.NotNil(request)
 	r, ok := request.(*s.RespondDecisionTaskFailedRequest)
@@ -690,7 +690,7 @@ func (t *TaskHandlersTestSuite) TestGetWorkflowInfo() {
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	t.NoError(err)
 	t.NotNil(request)
 	r, ok := request.(*s.RespondDecisionTaskCompletedRequest)
@@ -728,11 +728,10 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_CancelActivityBeforeSent() {
 		Logger:   t.logger,
 	}
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
 	t.NotNil(response)
-	//t.printAllDecisions(response.Decisions)
 	t.Equal(1, len(response.Decisions))
 	t.Equal(s.DecisionTypeCompleteWorkflowExecution, response.Decisions[0].GetDecisionType())
 	t.NotNil(response.Decisions[0].CompleteWorkflowExecutionDecisionAttributes)
@@ -764,7 +763,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_PageToken() {
 		},
 	}
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task, historyIterator: historyIterator})
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task, historyIterator: historyIterator}, nil, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
 	t.NotNil(response)

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -234,7 +234,7 @@ func (t *TaskHandlersTestSuite) testWorkflowTaskWorkflowExecutionStartedHelper(p
 	}
 	task := createWorkflowTask(testEvents, 0, "HelloWorld_Workflow")
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
 	t.NotNil(response)
@@ -286,7 +286,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_ActivityTaskScheduled() {
 		Logger:   t.logger,
 	}
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 
 	t.NoError(err)
@@ -297,7 +297,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_ActivityTaskScheduled() {
 
 	// Schedule an activity and see if we complete workflow, Having only one last decision.
 	task = createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
-	request, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	request, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	response = request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
 	t.NotNil(response)
@@ -337,7 +337,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_Sticky() {
 	task := createWorkflowTask(testEvents[0:1], 0, "HelloWorld_Workflow")
 	task.StartedEventId = common.Int64Ptr(1)
 	task.WorkflowExecution = execution
-	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
 	t.NotNil(response)
@@ -348,7 +348,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_Sticky() {
 	// then check the current state using query task
 	task = createQueryTask([]*s.HistoryEvent{}, 6, "HelloWorld_Workflow", "test-query")
 	task.WorkflowExecution = execution
-	queryResp, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	queryResp, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.NoError(err)
 	t.verifyQueryResult(queryResp, "waiting-activity-result")
 }
@@ -380,30 +380,30 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_NonSticky() {
 	// query after first decision task (notice the previousStartEventID is always the last eventID for query task)
 	task := createQueryTask(testEvents[0:3], 3, "HelloWorld_Workflow", "test-query")
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	response, _ := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	response, _ := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.verifyQueryResult(response, "waiting-activity-result")
 
 	// query after activity task complete but before second decision task started
 	task = createQueryTask(testEvents[0:7], 7, "HelloWorld_Workflow", "test-query")
 	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	response, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	response, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.verifyQueryResult(response, "waiting-activity-result")
 
 	// query after second decision task
 	task = createQueryTask(testEvents[0:8], 8, "HelloWorld_Workflow", "test-query")
 	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	response, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	response, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.verifyQueryResult(response, "done")
 
 	// query after second decision task with extra events
 	task = createQueryTask(testEvents[0:9], 9, "HelloWorld_Workflow", "test-query")
 	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	response, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	response, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.verifyQueryResult(response, "done")
 
 	task = createQueryTask(testEvents[0:9], 9, "HelloWorld_Workflow", "invalid-query-type")
 	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	response, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	response, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.NotNil(response)
 	queryResp, ok := response.(*s.RespondQueryTaskCompletedRequest)
 	t.True(ok)
@@ -451,7 +451,7 @@ func (t *TaskHandlersTestSuite) TestCacheEvictionWhenErrorOccurs() {
 	// newWorkflowTaskWorkerInternal will set the laTunnel in taskHandler, without it, ProcessWorkflowTask()
 	// will fail as it can't find laTunnel in getWorkflowCache().
 	newWorkflowTaskWorkerInternal(taskHandler, t.service, testDomain, params, make(chan struct{}))
-	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 
 	t.Error(err)
 	t.Nil(request)
@@ -507,7 +507,7 @@ func (t *TaskHandlersTestSuite) testSideEffectDeferHelper(disableSticky bool) {
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
 	task := createWorkflowTask(testEvents, 0, workflowName)
-	_, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	_, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.Nil(err)
 
 	if !params.DisableStickyExecution {
@@ -549,7 +549,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	// there should be no error as the history events matched the decisions.
 	t.NoError(err)
@@ -561,7 +561,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	// newWorkflowTaskWorkerInternal will set the laTunnel in taskHandler, without it, ProcessWorkflowTask()
 	// will fail as it can't find laTunnel in getWorkflowCache().
 	newWorkflowTaskWorkerInternal(taskHandler, t.service, testDomain, params, stopC)
-	request, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	request, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.Error(err)
 	t.Nil(request)
 	t.Contains(err.Error(), "nondeterministic")
@@ -571,7 +571,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	params.NonDeterministicWorkflowPolicy = NonDeterministicWorkflowPolicyFailWorkflow
 	failOnNondeterminismTaskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
 	task = createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
-	request, err = failOnNondeterminismTaskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	request, err = failOnNondeterminismTaskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	// When FailWorkflow policy is set, task handler does not return an error,
 	// because it will indicate non determinism in the request.
 	t.NoError(err)
@@ -589,7 +589,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	// now with different package name to activity type
 	testEvents[4].ActivityTaskScheduledEventAttributes.ActivityType.Name = common.StringPtr("new-package.Greeter_Activity")
 	task = createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
-	request, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	request, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.NoError(err)
 	t.NotNil(request)
 }
@@ -610,7 +610,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowReturnsPanicError() {
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.NoError(err)
 	t.NotNil(request)
 	r, ok := request.(*s.RespondDecisionTaskCompletedRequest)
@@ -638,7 +638,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowPanics() {
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.NoError(err)
 	t.NotNil(request)
 	r, ok := request.(*s.RespondDecisionTaskFailedRequest)
@@ -690,7 +690,7 @@ func (t *TaskHandlersTestSuite) TestGetWorkflowInfo() {
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.NoError(err)
 	t.NotNil(request)
 	r, ok := request.(*s.RespondDecisionTaskCompletedRequest)
@@ -728,7 +728,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_CancelActivityBeforeSent() {
 		Logger:   t.logger,
 	}
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
 	t.NotNil(response)
@@ -763,7 +763,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_PageToken() {
 		},
 	}
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task, historyIterator: historyIterator}, nil, nil)
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task, historyIterator: historyIterator}, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
 	t.NotNil(response)

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -234,10 +234,9 @@ func (t *TaskHandlersTestSuite) testWorkflowTaskWorkflowExecutionStartedHelper(p
 	}
 	task := createWorkflowTask(testEvents, 0, "HelloWorld_Workflow")
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, wc, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
-	wc.Unlock(err)
 	t.NotNil(response)
 	t.Equal(1, len(response.Decisions))
 	t.Equal(s.DecisionTypeScheduleActivityTask, response.Decisions[0].GetDecisionType())
@@ -287,11 +286,10 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_ActivityTaskScheduled() {
 		Logger:   t.logger,
 	}
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, wc, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 
 	t.NoError(err)
-	wc.Unlock(err)
 	t.NotNil(response)
 	t.Equal(1, len(response.Decisions))
 	t.Equal(s.DecisionTypeScheduleActivityTask, response.Decisions[0].GetDecisionType())
@@ -299,10 +297,9 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_ActivityTaskScheduled() {
 
 	// Schedule an activity and see if we complete workflow, Having only one last decision.
 	task = createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
-	request, wc, _, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, _, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	response = request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
-	wc.Unlock(err)
 	t.NotNil(response)
 	t.Equal(1, len(response.Decisions))
 	t.Equal(s.DecisionTypeCompleteWorkflowExecution, response.Decisions[0].GetDecisionType())
@@ -340,21 +337,19 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_Sticky() {
 	task := createWorkflowTask(testEvents[0:1], 0, "HelloWorld_Workflow")
 	task.StartedEventId = common.Int64Ptr(1)
 	task.WorkflowExecution = execution
-	request, wc, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
 	t.NotNil(response)
 	t.Equal(1, len(response.Decisions))
 	t.Equal(s.DecisionTypeScheduleActivityTask, response.Decisions[0].GetDecisionType())
 	t.NotNil(response.Decisions[0].ScheduleActivityTaskDecisionAttributes)
-	wc.Unlock(err)
 
 	// then check the current state using query task
 	task = createQueryTask([]*s.HistoryEvent{}, 6, "HelloWorld_Workflow", "test-query")
 	task.WorkflowExecution = execution
-	queryResp, wc, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	queryResp, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	t.NoError(err)
-	wc.Unlock(err)
 	t.verifyQueryResult(queryResp, "waiting-activity-result")
 }
 
@@ -385,35 +380,30 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_NonSticky() {
 	// query after first decision task (notice the previousStartEventID is always the last eventID for query task)
 	task := createQueryTask(testEvents[0:3], 3, "HelloWorld_Workflow", "test-query")
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	response, wc, _, _ := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	response, _, _ := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	t.verifyQueryResult(response, "waiting-activity-result")
-	wc.Unlock(nil)
 
 	// query after activity task complete but before second decision task started
 	task = createQueryTask(testEvents[0:7], 7, "HelloWorld_Workflow", "test-query")
 	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	response, wc, _, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	response, _, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	t.verifyQueryResult(response, "waiting-activity-result")
-	wc.Unlock(nil)
 
 	// query after second decision task
 	task = createQueryTask(testEvents[0:8], 8, "HelloWorld_Workflow", "test-query")
 	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	response, wc, _, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	response, _, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	t.verifyQueryResult(response, "done")
-	wc.Unlock(nil)
 
 	// query after second decision task with extra events
 	task = createQueryTask(testEvents[0:9], 9, "HelloWorld_Workflow", "test-query")
 	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	response, wc, _, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	response, _, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	t.verifyQueryResult(response, "done")
-	wc.Unlock(nil)
 
 	task = createQueryTask(testEvents[0:9], 9, "HelloWorld_Workflow", "invalid-query-type")
 	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	response, wc, _, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
-	wc.Unlock(nil)
+	response, _, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	t.NotNil(response)
 	queryResp, ok := response.(*s.RespondQueryTaskCompletedRequest)
 	t.True(ok)
@@ -461,12 +451,11 @@ func (t *TaskHandlersTestSuite) TestCacheEvictionWhenErrorOccurs() {
 	// newWorkflowTaskWorkerInternal will set the laTunnel in taskHandler, without it, ProcessWorkflowTask()
 	// will fail as it can't find laTunnel in getWorkflowCache().
 	newWorkflowTaskWorkerInternal(taskHandler, t.service, testDomain, params, make(chan struct{}))
-	request, wc, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 
 	t.Error(err)
 	t.Nil(request)
 	t.Contains(err.Error(), "nondeterministic")
-	wc.Unlock(err)
 
 	// There should be nothing in the cache.
 	t.EqualValues(getWorkflowCache().Size(), 0)
@@ -518,9 +507,8 @@ func (t *TaskHandlersTestSuite) testSideEffectDeferHelper(disableSticky bool) {
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
 	task := createWorkflowTask(testEvents, 0, workflowName)
-	_, wc, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	_, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	t.Nil(err)
-	wc.Unlock(err)
 
 	if !params.DisableStickyExecution {
 		// 1. We can't set cache size in the test to 1, otherwise other tests will break.
@@ -530,7 +518,6 @@ func (t *TaskHandlersTestSuite) testSideEffectDeferHelper(disableSticky bool) {
 	}
 	// Make sure the workflow coroutine has exited.
 	<-doneCh
-
 	// The side effect op should not be executed.
 	t.Equal(expectedValue, value)
 
@@ -562,12 +549,11 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, wc, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	// there should be no error as the history events matched the decisions.
 	t.NoError(err)
 	t.NotNil(response)
-	wc.Unlock(err)
 
 	// now change the history event so it does not match to decision produced via replay
 	testEvents[4].ActivityTaskScheduledEventAttributes.ActivityType.Name = common.StringPtr("some-other-activity")
@@ -575,18 +561,17 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	// newWorkflowTaskWorkerInternal will set the laTunnel in taskHandler, without it, ProcessWorkflowTask()
 	// will fail as it can't find laTunnel in getWorkflowCache().
 	newWorkflowTaskWorkerInternal(taskHandler, t.service, testDomain, params, stopC)
-	request, wc, _, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, _, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	t.Error(err)
 	t.Nil(request)
 	t.Contains(err.Error(), "nondeterministic")
-	wc.Unlock(err)
 
 	// now, create a new task handler with fail nondeterministic workflow policy
 	// and verify that it handles the mismatching history correctly.
 	params.NonDeterministicWorkflowPolicy = NonDeterministicWorkflowPolicyFailWorkflow
 	failOnNondeterminismTaskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
 	task = createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
-	request, wc, _, err = failOnNondeterminismTaskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, _, err = failOnNondeterminismTaskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	// When FailWorkflow policy is set, task handler does not return an error,
 	// because it will indicate non determinism in the request.
 	t.NoError(err)
@@ -600,15 +585,13 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	closeDecision := response.Decisions[len(response.Decisions)-1]
 	t.Equal(*closeDecision.DecisionType, s.DecisionTypeFailWorkflowExecution)
 	t.Contains(*closeDecision.FailWorkflowExecutionDecisionAttributes.Reason, "NonDeterministicWorkflowPolicyFailWorkflow")
-	wc.Unlock(err)
 
 	// now with different package name to activity type
 	testEvents[4].ActivityTaskScheduledEventAttributes.ActivityType.Name = common.StringPtr("new-package.Greeter_Activity")
 	task = createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
-	request, wc, _, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, _, err = taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	t.NoError(err)
 	t.NotNil(request)
-	wc.Unlock(err)
 }
 
 func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowReturnsPanicError() {
@@ -627,9 +610,8 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowReturnsPanicError() {
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, wc, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	t.NoError(err)
-	wc.Unlock(err)
 	t.NotNil(request)
 	r, ok := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.True(ok)
@@ -656,9 +638,8 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowPanics() {
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, wc, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	t.NoError(err)
-	wc.Unlock(err)
 	t.NotNil(request)
 	r, ok := request.(*s.RespondDecisionTaskFailedRequest)
 	t.True(ok)
@@ -709,9 +690,8 @@ func (t *TaskHandlersTestSuite) TestGetWorkflowInfo() {
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, wc, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	t.NoError(err)
-	wc.Unlock(err)
 	t.NotNil(request)
 	r, ok := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.True(ok)
@@ -748,10 +728,9 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_CancelActivityBeforeSent() {
 		Logger:   t.logger,
 	}
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, wc, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
+	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task})
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
-	wc.Unlock(err)
 	t.NotNil(response)
 	//t.printAllDecisions(response.Decisions)
 	t.Equal(1, len(response.Decisions))
@@ -785,10 +764,9 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_PageToken() {
 		},
 	}
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	request, wc, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task, historyIterator: historyIterator})
+	request, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task, historyIterator: historyIterator})
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
-	wc.Unlock(err)
 	t.NotNil(response)
 }
 

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -280,7 +280,7 @@ func (wtp *workflowTaskPoller) processWorkflowTask(task *workflowTask) error {
 		if completedRequest == nil && err == nil {
 			return nil
 		}
-		if _, ok := err.(decisionHeartBeatError); ok {
+		if _, ok := err.(decisionHeartbeatError); ok {
 			return err
 		}
 		response, err = wtp.RespondTaskCompletedWithMetrics(completedRequest, err, task.task, startTime)

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -261,7 +261,7 @@ process_WorkflowTask_Loop:
 		workflowTask.doneCh = doneCh
 		workflowTask.laResultCh = laResultCh
 		// the workflow context returned is locked, so needs to be unlocked by this routine
-		completedRequest, wc, locked, err := wtp.taskHandler.ProcessWorkflowTask(workflowTask)
+		completedRequest, wc, err := wtp.taskHandler.ProcessWorkflowTask(workflowTask)
 		if err == nil && completedRequest == nil {
 			// decision task cannot complete because it is waiting for local activity to finish
 			// we need a timer to force complete it to avoid the decision task timeout on server.
@@ -292,14 +292,10 @@ process_WorkflowTask_Loop:
 		}
 
 		if err != nil || response == nil || response.DecisionTask == nil {
-			if locked {
-				wc.Unlock(err)
-			}
+			wc.Unlock(err)
 			return err
 		}
-		if locked {
-			wc.Unlock(err)
-		}
+		wc.Unlock(err)
 
 		// we are getting new decision task, so reset the workflowTask and continue process the new one
 		workflowTask = wtp.toWorkflowTask(response.DecisionTask)

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -254,9 +254,10 @@ func (wtp *workflowTaskPoller) processWorkflowTask(workflowTask *workflowTask) e
 	doneCh := make(chan struct{})
 	laResultCh := make(chan *localActivityResult)
 	// close doneCh so local activity worker won't get blocked forever when trying to send back result to laResultCh.
+	rand.Seed(time.Now().UTC().UnixNano())
 	id := rand.Int31()
 	defer func() {
-		fmt.Println("closing stuff")
+		fmt.Printf("closing stuff %v\n", id)
 		close(doneCh)
 	}()
 
@@ -266,8 +267,9 @@ process_WorkflowTask_Loop:
 		startTime := time.Now()
 		workflowTask.doneCh = doneCh
 		workflowTask.laResultCh = laResultCh
-		//		fmt.Printf("going to process workflow task result %v\n", id)
+		fmt.Printf("going to process workflow task result %v\n", id)
 		completedRequest, wc, err := wtp.taskHandler.ProcessWorkflowTask(workflowTask)
+		fmt.Printf("returned from process workflow task %v\n", id)
 		if err != nil {
 			if _, ok := err.(*localActivityTimedOutError); ok {
 				// force complete
@@ -301,8 +303,8 @@ process_WorkflowTask_Loop:
 
 		// we are getting new decision task, so reset the workflowTask and continue process the new one
 		workflowTask = wtp.toWorkflowTask(response.DecisionTask)
-		continue process_WorkflowTask_Loop
 	}
+	fmt.Println("going to return from the function")
 	return nil
 }
 
@@ -480,7 +482,6 @@ func (latp *localActivityTaskPoller) ProcessTask(task interface{}) error {
 	}
 
 	result := latp.handler.executeLocalActivityTask(task.(*localActivityTask))
-	fmt.Println("returned local activity task")
 	// We need to send back the local activity result to unblock workflowTaskPoller.processWorkflowTask() which is
 	// synchronously listening on the laResultCh. We also want to make sure we don't block here forever in case
 	// processWorkflowTask() already returns and nobody is receiving from laResultCh. We guarantee that doneCh is closed

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -263,14 +263,17 @@ process_WorkflowTask_Loop:
 		completedRequest, wc, err := wtp.taskHandler.ProcessWorkflowTask(workflowTask)
 		if _, ok := err.(*localActivityTimedOutError); ok {
 			// force complete
+			fmt.Println("force complete")
 			response, err := wtp.forceRespondDecisionTaskCompleted(wc, workflowTask, startTime)
 			if err != nil {
 				return err
 			}
 			if response == nil || response.DecisionTask == nil {
+				fmt.Println("response is nil")
 				return nil
 			}
 
+			fmt.Println("got new decision")
 			// we are getting new decision task, so reset the workflowTask and continue process the new one
 			workflowTask = wtp.toWorkflowTask(response.DecisionTask)
 			continue process_WorkflowTask_Loop

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -25,6 +25,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -253,34 +254,45 @@ func (wtp *workflowTaskPoller) processWorkflowTask(workflowTask *workflowTask) e
 	doneCh := make(chan struct{})
 	laResultCh := make(chan *localActivityResult)
 	// close doneCh so local activity worker won't get blocked forever when trying to send back result to laResultCh.
-	defer close(doneCh)
+	id := rand.Int31()
+	defer func() {
+		fmt.Println("closing stuff")
+		close(doneCh)
+	}()
 
 process_WorkflowTask_Loop:
 	for {
+		//		fmt.Printf("starting new loop %v\n", id)
 		startTime := time.Now()
 		workflowTask.doneCh = doneCh
 		workflowTask.laResultCh = laResultCh
+		//		fmt.Printf("going to process workflow task result %v\n", id)
 		completedRequest, wc, err := wtp.taskHandler.ProcessWorkflowTask(workflowTask)
-		if _, ok := err.(*localActivityTimedOutError); ok {
-			// force complete
-			fmt.Println("force complete")
-			response, err := wtp.forceRespondDecisionTaskCompleted(wc, workflowTask, startTime)
-			if err != nil {
-				return err
-			}
-			if response == nil || response.DecisionTask == nil {
-				fmt.Println("response is nil")
-				return nil
-			}
+		if err != nil {
+			if _, ok := err.(*localActivityTimedOutError); ok {
+				// force complete
+				//				fmt.Printf("force complete %v\n", id)
+				response, err := wtp.forceRespondDecisionTaskCompleted(wc, workflowTask, startTime)
+				if err != nil {
+					fmt.Printf("force complete error %v\n", err)
+					return err
+				}
+				if response == nil || response.DecisionTask == nil {
+					fmt.Println("response is nil")
+					return nil
+				}
 
-			fmt.Println("got new decision")
-			// we are getting new decision task, so reset the workflowTask and continue process the new one
-			workflowTask = wtp.toWorkflowTask(response.DecisionTask)
-			continue process_WorkflowTask_Loop
+				fmt.Printf("got new decision %v\n", id)
+				// we are getting new decision task, so reset the workflowTask and continue process the new one
+				workflowTask = wtp.toWorkflowTask(response.DecisionTask)
+				continue process_WorkflowTask_Loop
+			}
 		}
 
+		//		fmt.Printf("respond task complete %v\n", id)
 		response, err := wtp.RespondTaskCompletedWithMetrics(completedRequest, err, workflowTask.task, startTime)
 		if err != nil {
+			//			fmt.Printf("respond task complete error %v\n", err)
 			return err
 		}
 		if response == nil || response.DecisionTask == nil {
@@ -291,6 +303,7 @@ process_WorkflowTask_Loop:
 		workflowTask = wtp.toWorkflowTask(response.DecisionTask)
 		continue process_WorkflowTask_Loop
 	}
+	return nil
 }
 
 func (wtp *workflowTaskPoller) processResetStickinessTask(rst *resetStickinessTask) error {
@@ -474,8 +487,10 @@ func (latp *localActivityTaskPoller) ProcessTask(task interface{}) error {
 	// before returning from workflowTaskPoller.processWorkflowTask().
 	select {
 	case result.task.workflowTask.laResultCh <- result:
+		fmt.Println("send back result")
 		return nil
 	case <-result.task.workflowTask.doneCh:
+		fmt.Println("already done")
 		// processWorkflowTask() already returns, just drop this local activity result.
 		return nil
 	}

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -254,52 +254,31 @@ func (wtp *workflowTaskPoller) processWorkflowTask(workflowTask *workflowTask) e
 	// close doneCh so local activity worker won't get blocked forever when trying to send back result to laResultCh.
 	defer close(doneCh)
 
-process_WorkflowTask_Loop:
 	for {
 		var response *s.RespondDecisionTaskCompletedResponse
 		startTime := time.Now()
 		workflowTask.doneCh = doneCh
 		workflowTask.laResultCh = laResultCh
-		// the workflow context returned is locked, so needs to be unlocked by this routine
 		completedRequest, wc, err := wtp.taskHandler.ProcessWorkflowTask(workflowTask)
-		if err == nil && completedRequest == nil {
-			// decision task cannot complete because it is waiting for local activity to finish
-			// we need a timer to force complete it to avoid the decision task timeout on server.
-		wait_LocalActivity_Loop:
-			for {
-				deadlineToTrigger := time.Duration(float32(ratioToForceCompleteDecisionTaskComplete) * float32(wc.GetDecisionTimeout()))
-				delayDuration := startTime.Add(deadlineToTrigger).Sub(time.Now())
-				select {
-				case <-time.After(delayDuration):
-					// force complete
-					response, err = wtp.forceRespondDecisionTaskCompleted(wc, workflowTask, startTime)
-					break wait_LocalActivity_Loop
-
-				case lar := <-laResultCh:
-					// local activity result ready
-					completedRequest, err := wc.ProcessLocalActivityResult(lar.task.workflowTask, lar)
-					if err == nil && completedRequest == nil {
-						// decision task is not done yet, still waiting for more local activities
-						continue wait_LocalActivity_Loop
-					}
-
-					response, err = wtp.RespondTaskCompletedWithMetrics(completedRequest, err, workflowTask.task, startTime)
-					break wait_LocalActivity_Loop
-				}
+		if _, ok := err.(*localActivityTimedOutError); ok {
+			// force complete
+			response, err = wtp.forceRespondDecisionTaskCompleted(wc, workflowTask, startTime)
+			if err != nil {
+				return err
 			}
 		} else {
 			response, err = wtp.RespondTaskCompletedWithMetrics(completedRequest, err, workflowTask.task, startTime)
+			if err != nil {
+				return err
+			}
 		}
 
-		if err != nil || response == nil || response.DecisionTask == nil {
-			wc.Unlock(err)
-			return err
+		if response == nil || response.DecisionTask == nil {
+			return nil
 		}
-		wc.Unlock(err)
 
 		// we are getting new decision task, so reset the workflowTask and continue process the new one
 		workflowTask = wtp.toWorkflowTask(response.DecisionTask)
-		continue process_WorkflowTask_Loop
 	}
 }
 
@@ -319,7 +298,13 @@ func (wtp *workflowTaskPoller) processResetStickinessTask(rst *resetStickinessTa
 }
 
 func (wtp *workflowTaskPoller) forceRespondDecisionTaskCompleted(wc WorkflowExecutionContext, workflowTask *workflowTask, startTime time.Time) (response *s.RespondDecisionTaskCompletedResponse, err error) {
-	// workflow context passed in must be locked to ensure the workflow still exists
+	wc.Lock()
+	defer wc.Unlock(nil)
+
+	if wc.IsDestroyed() {
+		return nil, &workflowContextAlreadyDestroyedError{Message: "workflow context already destroyed"}
+	}
+
 	currentTask := wc.GetCurrentDecisionTask()
 	if currentTask == nil || currentTask != workflowTask.task {
 		// decision task already completed
@@ -341,6 +326,28 @@ func (wtp *workflowTaskPoller) forceRespondDecisionTaskCompleted(wc WorkflowExec
 	wtp.metricsScope.Counter(metrics.DecisionTaskForceCompleted).Inc(1)
 
 	return wtp.RespondTaskCompletedWithMetrics(completeRequest, nil, workflowTask.task, startTime)
+}
+
+type workflowContextAlreadyDestroyedError struct {
+	Message string
+}
+
+func (e *workflowContextAlreadyDestroyedError) Error() string {
+	return e.Message
+}
+
+func (wtp *workflowTaskPoller) processLocalActivityResult(workflowTask *workflowTask, lar *localActivityResult) (interface{}, error) {
+	w := lar.task.wc
+	w.Lock()
+
+	defer w.Unlock(nil)
+
+	if w.IsDestroyed() {
+		// by the time local activity returns, the workflow context is already destroyed
+		return nil, &workflowContextAlreadyDestroyedError{Message: "workflow context already destroyed"}
+	}
+
+	return w.ProcessLocalActivityResult(workflowTask, lar)
 }
 
 func (wtp *workflowTaskPoller) RespondTaskCompletedWithMetrics(completedRequest interface{}, taskErr error, task *s.PollForDecisionTaskResponse, startTime time.Time) (response *s.RespondDecisionTaskCompletedResponse, err error) {

--- a/internal/internal_worker_interfaces_test.go
+++ b/internal/internal_worker_interfaces_test.go
@@ -22,7 +22,6 @@ package internal
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -177,5 +176,4 @@ func (s *InterfacesTestSuite) TestInterface() {
 	workflowClient := NewClient(s.service, domain, nil)
 	wfExecution, err := workflowClient.StartWorkflow(context.Background(), workflowOptions, "workflowType")
 	s.NoError(err)
-	fmt.Printf("Started workflow: %v \n", wfExecution)
 }

--- a/internal/internal_worker_interfaces_test.go
+++ b/internal/internal_worker_interfaces_test.go
@@ -174,6 +174,6 @@ func (s *InterfacesTestSuite) TestInterface() {
 		DecisionTaskStartToCloseTimeout: 10 * time.Second,
 	}
 	workflowClient := NewClient(s.service, domain, nil)
-	wfExecution, err := workflowClient.StartWorkflow(context.Background(), workflowOptions, "workflowType")
+	_, err := workflowClient.StartWorkflow(context.Background(), workflowOptions, "workflowType")
 	s.NoError(err)
 }

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -81,7 +81,7 @@ type internalWorkerTestSuite struct {
 	service  *workflowservicetest.MockClient
 }
 
-func TestInternalWorkferTestSuite(t *testing.T) {
+func TestInternalWorkerTestSuite(t *testing.T) {
 	s := new(internalWorkerTestSuite)
 	suite.Run(t, s)
 }
@@ -317,12 +317,8 @@ func (s *internalWorkerTestSuite) testDecisionTaskHandlerHelper(params workerExe
 	}
 
 	r := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	_, wc, err := r.ProcessWorkflowTask(&workflowTask{task: task})
+	_, err := r.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
 	s.NoError(err)
-	s.NotNil(wc)
-	stackTrace := wc.StackTrace()
-	require.NotEmpty(s.T(), stackTrace, stackTrace)
-	require.Contains(s.T(), stackTrace, "cadence/internal.(*decodeFutureImpl).Get")
 }
 
 func (s *internalWorkerTestSuite) TestDecisionTaskHandler() {

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -317,11 +317,10 @@ func (s *internalWorkerTestSuite) testDecisionTaskHandlerHelper(params workerExe
 	}
 
 	r := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	_, wc, _, err := r.ProcessWorkflowTask(&workflowTask{task: task})
+	_, wc, err := r.ProcessWorkflowTask(&workflowTask{task: task})
 	s.NoError(err)
 	s.NotNil(wc)
 	stackTrace := wc.StackTrace()
-	wc.Unlock(nil)
 	require.NotEmpty(s.T(), stackTrace, stackTrace)
 	require.Contains(s.T(), stackTrace, "cadence/internal.(*decodeFutureImpl).Get")
 }

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -317,10 +317,11 @@ func (s *internalWorkerTestSuite) testDecisionTaskHandlerHelper(params workerExe
 	}
 
 	r := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	_, wc, err := r.ProcessWorkflowTask(&workflowTask{task: task})
+	_, wc, _, err := r.ProcessWorkflowTask(&workflowTask{task: task})
 	s.NoError(err)
 	s.NotNil(wc)
 	stackTrace := wc.StackTrace()
+	wc.Unlock(nil)
 	require.NotEmpty(s.T(), stackTrace, stackTrace)
 	require.Contains(s.T(), stackTrace, "cadence/internal.(*decodeFutureImpl).Get")
 }

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -317,7 +317,7 @@ func (s *internalWorkerTestSuite) testDecisionTaskHandlerHelper(params workerExe
 	}
 
 	r := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
-	_, err := r.ProcessWorkflowTask(&workflowTask{task: task}, nil, nil)
+	_, err := r.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	s.NoError(err)
 }
 

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -317,7 +317,7 @@ func (s *WorkersTestSuite) TestLongRunningDecisionTask() {
 			s.Equal(m.DecisionTypeRecordMarker, request.Decisions[0].GetDecisionType())
 			*task.PreviousStartedEventId = 3
 			*task.StartedEventId = 7
-			task.History.Events = testEvents[3:7]
+			task.History.Events = testEvents[0:7]
 			return &m.RespondDecisionTaskCompletedResponse{DecisionTask: task}, nil
 		case 2:
 			fmt.Println("respond decision task - came in 2")
@@ -345,7 +345,7 @@ func (s *WorkersTestSuite) TestLongRunningDecisionTask() {
 	select {
 	case <-doneCh:
 		break
-	case <-time.After(time.Second * 1000):
+	case <-time.After(time.Second * 4):
 	}
 	worker.Stop()
 

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -317,7 +317,7 @@ func (s *WorkersTestSuite) TestLongRunningDecisionTask() {
 			s.Equal(m.DecisionTypeRecordMarker, request.Decisions[0].GetDecisionType())
 			*task.PreviousStartedEventId = 3
 			*task.StartedEventId = 7
-			task.History.Events = testEvents[0:7]
+			task.History.Events = testEvents[3:7]
 			return &m.RespondDecisionTaskCompletedResponse{DecisionTask: task}, nil
 		case 2:
 			fmt.Println("respond decision task - came in 2")

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -22,7 +22,6 @@ package internal
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -312,7 +311,6 @@ func (s *WorkersTestSuite) TestLongRunningDecisionTask() {
 		respondCounter++
 		switch respondCounter {
 		case 1:
-			fmt.Println("respond decision task - came in 1")
 			s.Equal(1, len(request.Decisions))
 			s.Equal(m.DecisionTypeRecordMarker, request.Decisions[0].GetDecisionType())
 			*task.PreviousStartedEventId = 3
@@ -320,7 +318,6 @@ func (s *WorkersTestSuite) TestLongRunningDecisionTask() {
 			task.History.Events = testEvents[3:7]
 			return &m.RespondDecisionTaskCompletedResponse{DecisionTask: task}, nil
 		case 2:
-			fmt.Println("respond decision task - came in 2")
 			s.Equal(2, len(request.Decisions))
 			s.Equal(m.DecisionTypeRecordMarker, request.Decisions[0].GetDecisionType())
 			s.Equal(m.DecisionTypeCompleteWorkflowExecution, request.Decisions[1].GetDecisionType())

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -22,6 +22,7 @@ package internal
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -311,6 +312,7 @@ func (s *WorkersTestSuite) TestLongRunningDecisionTask() {
 		respondCounter++
 		switch respondCounter {
 		case 1:
+			fmt.Println("respond decision task - came in 1")
 			s.Equal(1, len(request.Decisions))
 			s.Equal(m.DecisionTypeRecordMarker, request.Decisions[0].GetDecisionType())
 			*task.PreviousStartedEventId = 3
@@ -318,6 +320,7 @@ func (s *WorkersTestSuite) TestLongRunningDecisionTask() {
 			task.History.Events = testEvents[3:7]
 			return &m.RespondDecisionTaskCompletedResponse{DecisionTask: task}, nil
 		case 2:
+			fmt.Println("respond decision task - came in 2")
 			s.Equal(2, len(request.Decisions))
 			s.Equal(m.DecisionTypeRecordMarker, request.Decisions[0].GetDecisionType())
 			s.Equal(m.DecisionTypeCompleteWorkflowExecution, request.Decisions[1].GetDecisionType())

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -345,7 +345,7 @@ func (s *WorkersTestSuite) TestLongRunningDecisionTask() {
 	select {
 	case <-doneCh:
 		break
-	case <-time.After(time.Second * 10):
+	case <-time.After(time.Second * 1000):
 	}
 	worker.Stop()
 

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -353,6 +353,134 @@ func (s *WorkersTestSuite) TestLongRunningDecisionTask() {
 	s.Equal(2, localActivityCalledCount)
 }
 
+func (s *WorkersTestSuite) TestMultipleLocalActivities() {
+	localActivityCalledCount := 0
+	localActivitySleep := func(duration time.Duration) error {
+		time.Sleep(duration)
+		localActivityCalledCount++
+		return nil
+	}
+
+	doneCh := make(chan struct{})
+
+	isWorkflowCompleted := false
+	longDecisionWorkflowFn := func(ctx Context, input []byte) error {
+		lao := LocalActivityOptions{
+			ScheduleToCloseTimeout: time.Second * 2,
+		}
+		ctx = WithLocalActivityOptions(ctx, lao)
+		err := ExecuteLocalActivity(ctx, localActivitySleep, time.Second).Get(ctx, nil)
+
+		if err != nil {
+			return err
+		}
+
+		err = ExecuteLocalActivity(ctx, localActivitySleep, time.Second).Get(ctx, nil)
+		isWorkflowCompleted = true
+		return err
+	}
+
+	RegisterWorkflowWithOptions(
+		longDecisionWorkflowFn,
+		RegisterWorkflowOptions{Name: "multiple-local-activities-workflow-type"},
+	)
+
+	domain := "testDomain"
+	taskList := "multiple-local-activities-tl"
+	testEvents := []*m.HistoryEvent{
+		{
+			EventId:   common.Int64Ptr(1),
+			EventType: common.EventTypePtr(m.EventTypeWorkflowExecutionStarted),
+			WorkflowExecutionStartedEventAttributes: &m.WorkflowExecutionStartedEventAttributes{
+				TaskList:                            &m.TaskList{Name: &taskList},
+				ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(10),
+				TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(3),
+				WorkflowType:                        &m.WorkflowType{Name: common.StringPtr("multiple-local-activities-workflow-type")},
+			},
+		},
+		createTestEventDecisionTaskScheduled(2, &m.DecisionTaskScheduledEventAttributes{TaskList: &m.TaskList{Name: &taskList}}),
+		createTestEventDecisionTaskStarted(3),
+		createTestEventDecisionTaskCompleted(4, &m.DecisionTaskCompletedEventAttributes{ScheduledEventId: common.Int64Ptr(2)}),
+		{
+			EventId:   common.Int64Ptr(5),
+			EventType: common.EventTypePtr(m.EventTypeMarkerRecorded),
+			MarkerRecordedEventAttributes: &m.MarkerRecordedEventAttributes{
+				MarkerName:                   common.StringPtr(localActivityMarkerName),
+				Details:                      s.createLocalActivityMarkerDataForTest("0"),
+				DecisionTaskCompletedEventId: common.Int64Ptr(4),
+			},
+		},
+		createTestEventDecisionTaskScheduled(6, &m.DecisionTaskScheduledEventAttributes{TaskList: &m.TaskList{Name: &taskList}}),
+		createTestEventDecisionTaskStarted(7),
+		createTestEventDecisionTaskCompleted(8, &m.DecisionTaskCompletedEventAttributes{ScheduledEventId: common.Int64Ptr(2)}),
+		{
+			EventId:   common.Int64Ptr(9),
+			EventType: common.EventTypePtr(m.EventTypeMarkerRecorded),
+			MarkerRecordedEventAttributes: &m.MarkerRecordedEventAttributes{
+				MarkerName:                   common.StringPtr(localActivityMarkerName),
+				Details:                      s.createLocalActivityMarkerDataForTest("1"),
+				DecisionTaskCompletedEventId: common.Int64Ptr(8),
+			},
+		},
+		createTestEventDecisionTaskScheduled(10, &m.DecisionTaskScheduledEventAttributes{TaskList: &m.TaskList{Name: &taskList}}),
+		createTestEventDecisionTaskStarted(11),
+	}
+
+	s.service.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), callOptions...).Return(nil, nil).AnyTimes()
+	task := &m.PollForDecisionTaskResponse{
+		TaskToken: []byte("test-token"),
+		WorkflowExecution: &m.WorkflowExecution{
+			WorkflowId: common.StringPtr("multiple-local-activities-workflow-id"),
+			RunId:      common.StringPtr("multiple-local-activities-workflow-run-id"),
+		},
+		WorkflowType: &m.WorkflowType{
+			Name: common.StringPtr("multiple-local-activities-workflow-type"),
+		},
+		PreviousStartedEventId: common.Int64Ptr(0),
+		StartedEventId:         common.Int64Ptr(3),
+		History:                &m.History{Events: testEvents[0:3]},
+		NextPageToken:          nil,
+	}
+	s.service.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), callOptions...).Return(task, nil).Times(1)
+	s.service.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), callOptions...).Return(&m.PollForDecisionTaskResponse{}, &m.InternalServiceError{}).AnyTimes()
+
+	respondCounter := 0
+	s.service.EXPECT().RespondDecisionTaskCompleted(gomock.Any(), gomock.Any(), callOptions...).DoAndReturn(func(ctx context.Context, request *m.RespondDecisionTaskCompletedRequest, opts ...yarpc.CallOption,
+	) (success *m.RespondDecisionTaskCompletedResponse, err error) {
+		respondCounter++
+		switch respondCounter {
+		case 1:
+			s.Equal(3, len(request.Decisions))
+			s.Equal(m.DecisionTypeRecordMarker, request.Decisions[0].GetDecisionType())
+			*task.PreviousStartedEventId = 3
+			*task.StartedEventId = 7
+			task.History.Events = testEvents[3:11]
+			close(doneCh)
+			return nil, nil
+		default:
+			panic("unexpected RespondDecisionTaskCompleted")
+		}
+	}).Times(1)
+
+	options := WorkerOptions{
+		Logger:                zap.NewNop(),
+		DisableActivityWorker: true,
+		Identity:              "test-worker-identity",
+	}
+	worker := newAggregatedWorker(s.service, domain, taskList, options)
+	worker.Start()
+	// wait for test to complete
+	select {
+	case <-doneCh:
+		break
+	case <-time.After(time.Second * 5):
+	}
+	worker.Stop()
+
+	s.True(isWorkflowCompleted)
+	s.Equal(2, localActivityCalledCount)
+}
+
 func (s *WorkersTestSuite) createLocalActivityMarkerDataForTest(activityID string) []byte {
 	lamd := localActivityMarkerData{
 		ActivityID: activityID,

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -345,7 +345,7 @@ func (s *WorkersTestSuite) TestLongRunningDecisionTask() {
 	select {
 	case <-doneCh:
 		break
-	case <-time.After(time.Second * 5):
+	case <-time.After(time.Second * 10):
 	}
 	worker.Stop()
 

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -928,7 +928,6 @@ func (iter *historyEventIteratorImpl) HasNext() bool {
 func (iter *historyEventIteratorImpl) Next() (*s.HistoryEvent, error) {
 	// if caller call the Next() when iteration is over, just return nil, nil
 	if !iter.HasNext() {
-		// debug.PrintStack()
 		panic("HistoryEventIterator Next() called without checking HasNext()")
 	}
 

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -372,12 +372,7 @@ func replayWorkflowHistory(logger *zap.Logger, service workflowserviceclient.Int
 		Logger:   logger,
 	}
 	taskHandler := newWorkflowTaskHandler(domain, params, nil, getHostEnvironment())
-	resp, wc, locked, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task, historyIterator: iterator})
-	defer func() {
-		if locked {
-			wc.Unlock(err)
-		}
-	}()
+	resp, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task, historyIterator: iterator})
 	if err != nil {
 		return err
 	}

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -372,11 +372,7 @@ func replayWorkflowHistory(logger *zap.Logger, service workflowserviceclient.Int
 		Logger:   logger,
 	}
 	taskHandler := newWorkflowTaskHandler(domain, params, nil, getHostEnvironment())
-	resp, err := taskHandler.ProcessWorkflowTask(
-		&workflowTask{task: task, historyIterator: iterator},
-		nil,
-		nil,
-	)
+	resp, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task, historyIterator: iterator}, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -372,7 +372,11 @@ func replayWorkflowHistory(logger *zap.Logger, service workflowserviceclient.Int
 		Logger:   logger,
 	}
 	taskHandler := newWorkflowTaskHandler(domain, params, nil, getHostEnvironment())
-	resp, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task, historyIterator: iterator})
+	resp, err := taskHandler.ProcessWorkflowTask(
+		&workflowTask{task: task, historyIterator: iterator},
+		nil,
+		nil,
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -372,7 +372,12 @@ func replayWorkflowHistory(logger *zap.Logger, service workflowserviceclient.Int
 		Logger:   logger,
 	}
 	taskHandler := newWorkflowTaskHandler(domain, params, nil, getHostEnvironment())
-	resp, _, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task, historyIterator: iterator})
+	resp, wc, locked, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task, historyIterator: iterator})
+	defer func() {
+		if locked {
+			wc.Unlock(err)
+		}
+	}()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Move the wait for local activity to while holding the workflow context lock, to ensure that decision processing is serialized in the client

Fixes #742