### PR TITLE
 Add get memo inside workflow and test support

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -544,6 +544,7 @@ func (wth *workflowTaskHandlerImpl) createWorkflowContext(task *s.PollForDecisio
 		ContinuedExecutionRunID:             attributes.ContinuedExecutionRunId,
 		ParentWorkflowDomain:                attributes.ParentWorkflowDomain,
 		ParentWorkflowExecution:             parentWorkflowExecution,
+		Memo:                                attributes.Memo,
 		SearchAttributes:                    attributes.SearchAttributes,
 	}
 

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -1209,51 +1209,6 @@ func (s *WorkflowTestSuiteUnitTest) Test_MockGetVersion() {
 	env.AssertExpectations(s.T())
 }
 
-func (s *WorkflowTestSuiteUnitTest) Test_MockUpsertSearchAttributes() {
-	workflowFn := func(ctx Context) error {
-		attr := map[string]interface{}{}
-		err := UpsertSearchAttributes(ctx, attr)
-		s.Error(err)
-
-		wfInfo := GetWorkflowInfo(ctx)
-		s.Nil(wfInfo.SearchAttributes)
-
-		attr["CustomIntField"] = 1
-		err = UpsertSearchAttributes(ctx, attr)
-		s.NoError(err)
-
-		wfInfo = GetWorkflowInfo(ctx)
-		s.NotNil(wfInfo.SearchAttributes)
-		valBytes := wfInfo.SearchAttributes.IndexedFields["CustomIntField"]
-		var result int
-		NewValue(valBytes).Get(&result)
-		s.Equal(1, result)
-
-		return nil
-	}
-	RegisterWorkflow(workflowFn)
-
-	// no mock
-	env := s.NewTestWorkflowEnvironment()
-
-	env.ExecuteWorkflow(workflowFn)
-	s.True(env.IsWorkflowCompleted())
-	s.Nil(env.GetWorkflowError())
-	env.AssertExpectations(s.T())
-
-	// has mock
-	env = s.NewTestWorkflowEnvironment()
-	env.OnUpsertSearchAttributes(map[string]interface{}{}).Return(errors.New("empty")).Once()
-	env.OnUpsertSearchAttributes(map[string]interface{}{"CustomIntField": 1}).Return(nil).Once()
-
-	env.ExecuteWorkflow(workflowFn)
-	s.True(env.IsWorkflowCompleted())
-	s.Nil(env.GetWorkflowError())
-	env.AssertExpectations(s.T())
-
-	// mix no-mock and mock is not support
-}
-
 func (s *WorkflowTestSuiteUnitTest) Test_ActivityWithThriftTypes() {
 	actualValues := []string{}
 	retVal := &shared.WorkflowExecution{WorkflowId: common.StringPtr("retwID2"), RunId: common.StringPtr("retrID2")}

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -1209,6 +1209,51 @@ func (s *WorkflowTestSuiteUnitTest) Test_MockGetVersion() {
 	env.AssertExpectations(s.T())
 }
 
+func (s *WorkflowTestSuiteUnitTest) Test_MockUpsertSearchAttributes() {
+	workflowFn := func(ctx Context) error {
+		attr := map[string]interface{}{}
+		err := UpsertSearchAttributes(ctx, attr)
+		s.Error(err)
+
+		wfInfo := GetWorkflowInfo(ctx)
+		s.Nil(wfInfo.SearchAttributes)
+
+		attr["CustomIntField"] = 1
+		err = UpsertSearchAttributes(ctx, attr)
+		s.NoError(err)
+
+		wfInfo = GetWorkflowInfo(ctx)
+		s.NotNil(wfInfo.SearchAttributes)
+		valBytes := wfInfo.SearchAttributes.IndexedFields["CustomIntField"]
+		var result int
+		NewValue(valBytes).Get(&result)
+		s.Equal(1, result)
+
+		return nil
+	}
+	RegisterWorkflow(workflowFn)
+
+	// no mock
+	env := s.NewTestWorkflowEnvironment()
+
+	env.ExecuteWorkflow(workflowFn)
+	s.True(env.IsWorkflowCompleted())
+	s.Nil(env.GetWorkflowError())
+	env.AssertExpectations(s.T())
+
+	// has mock
+	env = s.NewTestWorkflowEnvironment()
+	env.OnUpsertSearchAttributes(map[string]interface{}{}).Return(errors.New("empty")).Once()
+	env.OnUpsertSearchAttributes(map[string]interface{}{"CustomIntField": 1}).Return(nil).Once()
+
+	env.ExecuteWorkflow(workflowFn)
+	s.True(env.IsWorkflowCompleted())
+	s.Nil(env.GetWorkflowError())
+	env.AssertExpectations(s.T())
+
+	// mix no-mock and mock is not support
+}
+
 func (s *WorkflowTestSuiteUnitTest) Test_ActivityWithThriftTypes() {
 	actualValues := []string{}
 	retVal := &shared.WorkflowExecution{WorkflowId: common.StringPtr("retwID2"), RunId: common.StringPtr("retrID2")}

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -642,6 +642,7 @@ type WorkflowInfo struct {
 	ContinuedExecutionRunID             *string
 	ParentWorkflowDomain                *string
 	ParentWorkflowExecution             *WorkflowExecution
+	Memo                                *s.Memo
 	SearchAttributes                    *s.SearchAttributes
 }
 

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -611,6 +611,16 @@ func (t *TestWorkflowEnvironment) SetLastCompletionResult(result interface{}) {
 	t.impl.setLastCompletionResult(result)
 }
 
+// SetMemoOnStart sets the memo when start workflow.
+func (t *TestWorkflowEnvironment) SetMemoOnStart(memo map[string]interface{}) error {
+	memoStruct, err := getWorkflowMemo(memo, t.impl.GetDataConverter())
+	if err != nil {
+		return err
+	}
+	t.impl.workflowInfo.Memo = memoStruct
+	return nil
+}
+
 // SetSearchAttributesOnStart sets the search attributes when start workflow.
 func (t *TestWorkflowEnvironment) SetSearchAttributesOnStart(searchAttributes map[string]interface{}) error {
 	attr, err := serializeSearchAttributes(searchAttributes)

--- a/internal/workflow_testsuite_test.go
+++ b/internal/workflow_testsuite_test.go
@@ -25,6 +25,25 @@ import (
 	"testing"
 )
 
+func TestSetMemoOnStart(t *testing.T) {
+	testSuite := &WorkflowTestSuite{}
+	env := testSuite.NewTestWorkflowEnvironment()
+
+	memo := map[string]interface{}{
+		"key": make(chan int),
+	}
+	err := env.SetMemoOnStart(memo)
+	require.Error(t, err)
+
+	memo = map[string]interface{}{
+		"memoKey": "memo",
+	}
+	require.Nil(t, env.impl.workflowInfo.Memo)
+	err = env.SetMemoOnStart(memo)
+	require.NoError(t, err)
+	require.NotNil(t, env.impl.workflowInfo.Memo)
+}
+
 func TestSetSearchAttributesOnStart(t *testing.T) {
 	testSuite := &WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()


### PR DESCRIPTION
Added memo in workflow.GetInfo. 
Support test memo with env.SetMemoOnStart.

https://github.com/uber-go/cadence-client/issues/791
https://github.com/uber-go/cadence-client/issues/745
