### PR TITLE
Bump feature version to 1.2.0

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -42,4 +42,4 @@ const LibraryVersion = "0.8.3"
 // This can be used for client capability check, on
 // Cadence server, for backward compatibility
 // Format: MAJOR.MINOR.PATCH
-const FeatureVersion = "1.1.0"
+const FeatureVersion = "1.2.0"


### PR DESCRIPTION
Prepare release for 0.9.0
Related server change: https://github.com/uber/cadence/pull/2317