### PR TITLE
Fix non-deterministic error caused by upsert search attributes

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1289,13 +1289,19 @@ func isDecisionMatchEvent(d *s.Decision, e *s.HistoryEvent, strictMode bool) boo
 		}
 		eventAttributes := e.UpsertWorkflowSearchAttributesEventAttributes
 		decisionAttributes := d.UpsertWorkflowSearchAttributesDecisionAttributes
-		if eventAttributes.SearchAttributes != decisionAttributes.SearchAttributes {
-			return false
-		}
-		return true
-
+		return isSearchAttributesMatched(eventAttributes.SearchAttributes, decisionAttributes.SearchAttributes)
 	}
 
+	return false
+}
+
+func isSearchAttributesMatched(attrFromEvent, attrFromDecision *s.SearchAttributes) bool {
+	if attrFromEvent == nil && attrFromDecision == nil {
+		return true
+	}
+	if attrFromEvent != nil && attrFromDecision != nil {
+		return reflect.DeepEqual(attrFromEvent.IndexedFields, attrFromDecision.IndexedFields)
+	}
 	return false
 }
 

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1296,13 +1296,10 @@ func isDecisionMatchEvent(d *s.Decision, e *s.HistoryEvent, strictMode bool) boo
 }
 
 func isSearchAttributesMatched(attrFromEvent, attrFromDecision *s.SearchAttributes) bool {
-	if attrFromEvent == nil && attrFromDecision == nil {
-		return true
-	}
 	if attrFromEvent != nil && attrFromDecision != nil {
 		return reflect.DeepEqual(attrFromEvent.IndexedFields, attrFromDecision.IndexedFields)
 	}
-	return false
+	return attrFromEvent == nil && attrFromDecision == nil
 }
 
 // return true if the check fails:

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -1075,6 +1075,7 @@ func Test_IsDecisionMatchEvent_UpsertWorkflowSearchAttributes(t *testing.T) {
 	}
 	historyEvent := &s.HistoryEvent{}
 	ok := isDecisionMatchEvent(decision, historyEvent, false)
+	require.False(t, ok)
 
 	eType := s.EventTypeUpsertWorkflowSearchAttributes
 	historyEvent = &s.HistoryEvent{
@@ -1085,8 +1086,38 @@ func Test_IsDecisionMatchEvent_UpsertWorkflowSearchAttributes(t *testing.T) {
 	require.False(t, ok)
 
 	historyEvent.UpsertWorkflowSearchAttributesEventAttributes = &s.UpsertWorkflowSearchAttributesEventAttributes{
-		SearchAttributes: searchAttr,
+		SearchAttributes: &s.SearchAttributes{},
 	}
 	ok = isDecisionMatchEvent(decision, historyEvent, false)
+	require.True(t, ok)
+}
+
+func Test_IsSearchAttributesMatched(t *testing.T) {
+	ok := isSearchAttributesMatched(nil, nil)
+	require.True(t, ok)
+
+	attr1 := &s.SearchAttributes{}
+	ok = isSearchAttributesMatched(attr1, nil)
+	require.False(t, ok)
+
+	attr2 := &s.SearchAttributes{}
+	ok = isSearchAttributesMatched(nil, attr2)
+	require.False(t, ok)
+
+	ok = isSearchAttributesMatched(attr1, attr2)
+	require.True(t, ok)
+
+	attr1.IndexedFields = map[string][]byte{
+		"key1": []byte("1"),
+		"key2": []byte("abc"),
+	}
+	ok = isSearchAttributesMatched(attr1, attr2)
+	require.False(t, ok)
+
+	attr2.IndexedFields = map[string][]byte{
+		"key2": []byte("abc"),
+		"key1": []byte("1"),
+	}
+	ok = isSearchAttributesMatched(attr1, attr2)
 	require.True(t, ok)
 }

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -1066,30 +1066,62 @@ func Test_NonDeterministicCheck(t *testing.T) {
 
 func Test_IsDecisionMatchEvent_UpsertWorkflowSearchAttributes(t *testing.T) {
 	diType := s.DecisionTypeUpsertWorkflowSearchAttributes
-	searchAttr := &s.SearchAttributes{}
-	decision := &s.Decision{
-		DecisionType: &diType,
-		UpsertWorkflowSearchAttributesDecisionAttributes: &s.UpsertWorkflowSearchAttributesDecisionAttributes{
-			SearchAttributes: searchAttr,
+	eType := s.EventTypeUpsertWorkflowSearchAttributes
+
+	testCases := []struct {
+		name     string
+		decision *s.Decision
+		event    *s.HistoryEvent
+		expected bool
+	}{
+		{
+			name: "event type not match",
+			decision: &s.Decision{
+				DecisionType: &diType,
+				UpsertWorkflowSearchAttributesDecisionAttributes: &s.UpsertWorkflowSearchAttributesDecisionAttributes{
+					SearchAttributes: &s.SearchAttributes{},
+				},
+			},
+			event:    &s.HistoryEvent{},
+			expected: false,
+		},
+		{
+			name: "attributes not match",
+			decision: &s.Decision{
+				DecisionType: &diType,
+				UpsertWorkflowSearchAttributesDecisionAttributes: &s.UpsertWorkflowSearchAttributesDecisionAttributes{
+					SearchAttributes: &s.SearchAttributes{},
+				},
+			},
+			event: &s.HistoryEvent{
+				EventType: &eType,
+				UpsertWorkflowSearchAttributesEventAttributes: &s.UpsertWorkflowSearchAttributesEventAttributes{},
+			},
+			expected: false,
+		},
+		{
+			name: "attributes match",
+			decision: &s.Decision{
+				DecisionType: &diType,
+				UpsertWorkflowSearchAttributesDecisionAttributes: &s.UpsertWorkflowSearchAttributesDecisionAttributes{
+					SearchAttributes: &s.SearchAttributes{},
+				},
+			},
+			event: &s.HistoryEvent{
+				EventType: &eType,
+				UpsertWorkflowSearchAttributesEventAttributes: &s.UpsertWorkflowSearchAttributesEventAttributes{
+					SearchAttributes: &s.SearchAttributes{},
+				},
+			},
+			expected: true,
 		},
 	}
-	historyEvent := &s.HistoryEvent{}
-	ok := isDecisionMatchEvent(decision, historyEvent, false)
-	require.False(t, ok)
 
-	eType := s.EventTypeUpsertWorkflowSearchAttributes
-	historyEvent = &s.HistoryEvent{
-		EventType: &eType,
-		UpsertWorkflowSearchAttributesEventAttributes: &s.UpsertWorkflowSearchAttributesEventAttributes{},
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expected, isDecisionMatchEvent(testCase.decision, testCase.event, false))
+		})
 	}
-	ok = isDecisionMatchEvent(decision, historyEvent, false)
-	require.False(t, ok)
-
-	historyEvent.UpsertWorkflowSearchAttributesEventAttributes = &s.UpsertWorkflowSearchAttributesEventAttributes{
-		SearchAttributes: &s.SearchAttributes{},
-	}
-	ok = isDecisionMatchEvent(decision, historyEvent, false)
-	require.True(t, ok)
 }
 
 func Test_IsSearchAttributesMatched(t *testing.T) {

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -1093,31 +1093,62 @@ func Test_IsDecisionMatchEvent_UpsertWorkflowSearchAttributes(t *testing.T) {
 }
 
 func Test_IsSearchAttributesMatched(t *testing.T) {
-	ok := isSearchAttributesMatched(nil, nil)
-	require.True(t, ok)
-
-	attr1 := &s.SearchAttributes{}
-	ok = isSearchAttributesMatched(attr1, nil)
-	require.False(t, ok)
-
-	attr2 := &s.SearchAttributes{}
-	ok = isSearchAttributesMatched(nil, attr2)
-	require.False(t, ok)
-
-	ok = isSearchAttributesMatched(attr1, attr2)
-	require.True(t, ok)
-
-	attr1.IndexedFields = map[string][]byte{
-		"key1": []byte("1"),
-		"key2": []byte("abc"),
+	testCases := []struct {
+		name     string
+		lhs      *s.SearchAttributes
+		rhs      *s.SearchAttributes
+		expected bool
+	}{
+		{
+			name:     "both nil",
+			lhs:      nil,
+			rhs:      nil,
+			expected: true,
+		},
+		{
+			name:     "left nil",
+			lhs:      nil,
+			rhs:      &s.SearchAttributes{},
+			expected: false,
+		},
+		{
+			name:     "right nil",
+			lhs:      &s.SearchAttributes{},
+			rhs:      nil,
+			expected: false,
+		},
+		{
+			name: "not match",
+			lhs: &s.SearchAttributes{
+				IndexedFields: map[string][]byte{
+					"key1": []byte("1"),
+					"key2": []byte("abc"),
+				},
+			},
+			rhs:      &s.SearchAttributes{},
+			expected: false,
+		},
+		{
+			name: "match",
+			lhs: &s.SearchAttributes{
+				IndexedFields: map[string][]byte{
+					"key1": []byte("1"),
+					"key2": []byte("abc"),
+				},
+			},
+			rhs: &s.SearchAttributes{
+				IndexedFields: map[string][]byte{
+					"key2": []byte("abc"),
+					"key1": []byte("1"),
+				},
+			},
+			expected: true,
+		},
 	}
-	ok = isSearchAttributesMatched(attr1, attr2)
-	require.False(t, ok)
 
-	attr2.IndexedFields = map[string][]byte{
-		"key2": []byte("abc"),
-		"key1": []byte("1"),
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expected, isSearchAttributesMatched(testCase.lhs, testCase.rhs))
+		})
 	}
-	ok = isSearchAttributesMatched(attr1, attr2)
-	require.True(t, ok)
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -73,7 +73,7 @@ func (ts *IntegrationTestSuite) SetupSuite() {
 func (ts *IntegrationTestSuite) TearDownSuite() {
 	// sleep for a while to allow the pollers to shutdown
 	// then assert that there are no lingering go routines
-	time.Sleep(11 * time.Second)
+	time.Sleep(20 * time.Second)
 	// https://github.com/uber-go/cadence-client/issues/739
 	goleak.VerifyNoLeaks(ts.T(), goleak.IgnoreTopFunction("go.uber.org/cadence/internal.(*coroutineState).initialYield"))
 }


### PR DESCRIPTION
Currently when replay with upsertSearchAttributes, decision will not match and cause non-deterministic error.

This PR fix the bug.