### PR TITLE
Fix doc typos

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -68,16 +68,16 @@ type (
 		// optional: The default task list with the same name as the workflow task list.
 		TaskList string
 
-		// ScheduleToCloseTimeout - The end to end time out for the activity needed.
+		// ScheduleToCloseTimeout - The end to end timeout for the activity needed.
 		// The zero value of this uses default value.
 		// Optional: The default value is the sum of ScheduleToStartTimeout and StartToCloseTimeout
 		ScheduleToCloseTimeout time.Duration
 
-		// ScheduleToStartTimeout - The queue time out before the activity starts executed.
+		// ScheduleToStartTimeout - The queue timeout before the activity starts executed.
 		// Mandatory: No default.
 		ScheduleToStartTimeout time.Duration
 
-		// StartToCloseTimeout - The time out from the start of execution to end of it.
+		// StartToCloseTimeout - The timeout from the start of execution to end of it.
 		// Mandatory: No default.
 		StartToCloseTimeout time.Duration
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -321,12 +321,12 @@ type (
 		// Mandatory: No default.
 		TaskList string
 
-		// ExecutionStartToCloseTimeout - The time out for duration of workflow execution.
+		// ExecutionStartToCloseTimeout - The timeout for duration of workflow execution.
 		// The resolution is seconds.
 		// Mandatory: No default.
 		ExecutionStartToCloseTimeout time.Duration
 
-		// DecisionTaskStartToCloseTimeout - The time out for processing decision task from the time the worker
+		// DecisionTaskStartToCloseTimeout - The timeout for processing decision task from the time the worker
 		// pulled this task. If a decision task is lost, it is retried after this timeout.
 		// The resolution is seconds.
 		// Optional: defaulted to 10 secs.

--- a/internal/error.go
+++ b/internal/error.go
@@ -199,7 +199,7 @@ func NewCanceledError(details ...interface{}) *CanceledError {
 // If the workflow main function returns this error then the current execution is ended and
 // the new execution with same workflow ID is started automatically with options
 // provided to this function.
-//  ctx - use context to override any options for the new workflow like execution time out, decision task time out, task list.
+//  ctx - use context to override any options for the new workflow like execution timeout, decision task timeout, task list.
 //	  if not mentioned it would use the defaults that the current workflow is using.
 //        ctx := WithExecutionStartToCloseTimeout(ctx, 30 * time.Minute)
 //        ctx := WithWorkflowTaskStartToCloseTimeout(ctx, time.Minute)

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -241,7 +241,7 @@ func (wtp *workflowTaskPoller) ProcessTask(task interface{}) error {
 
 func (wtp *workflowTaskPoller) processWorkflowTask(task *workflowTask) error {
 	if task.task == nil {
-		// We didn't have task, poll might have time out.
+		// We didn't have task, poll might have timeout.
 		traceLog(func() {
 			wtp.logger.Debug("Workflow task unavailable")
 		})
@@ -817,7 +817,7 @@ func (atp *activityTaskPoller) ProcessTask(task interface{}) error {
 
 	activityTask := task.(*activityTask)
 	if activityTask.task == nil {
-		// We didn't have task, poll might have time out.
+		// We didn't have task, poll might have timeout.
 		traceLog(func() {
 			atp.logger.Debug("Activity task unavailable")
 		})

--- a/workflow/doc.go
+++ b/workflow/doc.go
@@ -224,7 +224,7 @@ for an activity it invoked.
 		WorkflowID:                   "BID-SIMPLE-CHILD-WORKFLOW",
 		ExecutionStartToCloseTimeout: time.Minute * 30,
 	}
-	ctx = workflow.WithChildWorkflowOptions(ctx, cwo)
+	ctx = workflow.WithChildOptions(ctx, cwo)
 
 	var result string
 	future := workflow.ExecuteChildWorkflow(ctx, SimpleChildWorkflow, value)

--- a/workflow/error.go
+++ b/workflow/error.go
@@ -109,7 +109,7 @@ type (
 // If the workflow main function returns this error then the current execution is ended and
 // the new execution with same workflow ID is started automatically with options
 // provided to this function.
-//  ctx - use context to override any options for the new workflow like execution time out, decision task time out, task list.
+//  ctx - use context to override any options for the new workflow like execution timeout, decision task timeout, task list.
 //	  if not mentioned it would use the defaults that the current workflow is using.
 //        ctx := WithExecutionStartToCloseTimeout(ctx, 30 * time.Minute)
 //        ctx := WithWorkflowTaskStartToCloseTimeout(ctx, time.Minute)


### PR DESCRIPTION
The docs on [Child Workflow](https://godoc.org/go.uber.org/cadence/workflow#hdr-Child_Workflow) use `workflow.WithChildWorkflowOptions` instead of `workflow.WildChildOptions`.

Also, replaced `time out` where it seemed that the the intention was to use the noun, `timeout`.