### PR TITLE
Handle timeout error construct by the old client version

### DIFF
--- a/internal/internal_utils_test.go
+++ b/internal/internal_utils_test.go
@@ -127,3 +127,28 @@ func TestGetErrorDetails_TimeoutError(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("%v %v", errReasonTimeout, s.TimeoutTypeHeartbeat), reason)
 	require.Equal(t, val2, data)
 }
+
+func TestConstructError_TimeoutError(t *testing.T) {
+	dc := getDefaultDataConverter()
+	details, err := dc.ToData(testErrorDetails1)
+	require.NoError(t, err)
+
+	reason := fmt.Sprintf("%v %v", errReasonTimeout, s.TimeoutTypeHeartbeat)
+	constructedErr := constructError(reason, details, dc)
+	timeoutErr, ok := constructedErr.(*TimeoutError)
+	require.True(t, ok)
+	require.True(t, timeoutErr.HasDetails())
+	var detailValue string
+	err = timeoutErr.Details(&detailValue)
+	require.NoError(t, err)
+	require.Equal(t, testErrorDetails1, detailValue)
+
+	// Backward compatibility test
+	reason = errReasonTimeout
+	details, err = dc.ToData(s.TimeoutTypeHeartbeat)
+	constructedErr = constructError(reason, details, dc)
+	timeoutErr, ok = constructedErr.(*TimeoutError)
+	require.True(t, ok)
+	require.Equal(t, s.TimeoutTypeHeartbeat, timeoutErr.TimeoutType())
+	require.False(t, timeoutErr.HasDetails())
+}


### PR DESCRIPTION
Old client version generate timeout error with error reason "CadenceInternal:Timeout" while reason generated by the current version is "CadenceInternal:Timeout TimeoutType". 

This pr enhanced backward compatibility so that the current client can recognize the timeout error reason generated by an old client.