### PR TITLE
Use the tagged logger instead of the original one

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -285,7 +285,7 @@ func WithActivityTask(
 		deadline = startToCloseDeadline
 	}
 
-	logger.With(
+	logger = logger.With(
 		zapcore.Field{Key: tagActivityID, Type: zapcore.StringType, String: *task.ActivityId},
 		zapcore.Field{Key: tagActivityType, Type: zapcore.StringType, String: *task.ActivityType.Name},
 		zapcore.Field{Key: tagWorkflowType, Type: zapcore.StringType, String: *task.WorkflowType.Name},


### PR DESCRIPTION
`logger.With` returns a new logger instance which will include the passed fields, it doesn't mutate the logger it's called on.
So previously this was effectively a no-op.