### PR TITLE
Handle connection error to Cadence FE gracefully

### DIFF
--- a/internal/internal_retry.go
+++ b/internal/internal_retry.go
@@ -24,8 +24,6 @@ package internal
 
 import (
 	"context"
-	"fmt"
-	"reflect"
 	"time"
 
 	s "go.uber.org/cadence/.gen/go/shared"

--- a/internal/internal_retry.go
+++ b/internal/internal_retry.go
@@ -24,10 +24,13 @@ package internal
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"time"
 
 	s "go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/internal/common/backoff"
+	"go.uber.org/yarpc/yarpcerrors"
 )
 
 const (
@@ -72,6 +75,12 @@ func isServiceTransientError(err error) bool {
 		*s.DomainNotActiveError,
 		*s.CancellationAlreadyRequestedError:
 		return false
+	}
+
+	if errStatus, ok := err.(*yarpcerrors.Status); ok {
+		if yarpcerrors.IsUnknown(errStatus) {
+			return false
+		}
 	}
 
 	if err == errShutdown {


### PR DESCRIPTION
With this change if cadence serve is not listening we would see error immediately rather than waiting forever.

Following is error you'd see if cadence is not running and you try to connect to it,

```
➜  cadence-samples git:(fail_fast) ✗ ./bin/helloworld
2019-10-17T00:27:16.939-0700	INFO	common/sample_helper.go:65	Logger created.
2019-10-17T00:27:16.940-0700	DEBUG	common/factory.go:131	Creating RPC dispatcher outbound	{"ServiceName": "cadence-frontend", "HostPort": "127.0.0.1:7933"}
isServiceTransientError
unknown error
2019-10-17T00:27:16.941-0700	FATAL	common/sample_helper.go:83	Error occurred while calling Describe API	{"Domain": "samples-domain", "error": "code:unknown message:received unknown error calling service: \"cadence-frontend\", procedure: \"WorkflowService::DescribeDomain\", err: dial tcp 127.0.0.1:7933: connect: connection refused"}
github.com/uber-common/cadence-samples/cmd/samples/common.(*SampleHelper).SetupServiceConfig
	/Users/ahafeez/src/go/src/github.com/uber-common/cadence-samples/cmd/samples/common/sample_helper.go:83
main.main
	/Users/ahafeez/src/go/src/github.com/uber-common/cadence-samples/cmd/samples/recipes/helloworld/main.go:40
runtime.main
	/usr/local/Cellar/go/1.12.9/libexec/src/runtime/proc.go:200
```

Without this change it would wait forever,

```
➜  cadence-samples git:(fail_fast) ✗ ./bin/helloworld
2019-10-17T00:27:07.908-0700	INFO	common/sample_helper.go:65	Logger created.
2019-10-17T00:27:07.914-0700	DEBUG	common/factory.go:131	Creating RPC dispatcher outbound	{"ServiceName": "cadence-frontend", "HostPort": "127.0.0.1:7933"}
^C
```