### PR TITLE
Minor: use correct testing.T in subtests / teardown

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -99,6 +99,7 @@ func (ts *IntegrationTestSuite) SetupSuite() {
 }
 
 func (ts *IntegrationTestSuite) TearDownSuite() {
+	ts.Assertions = require.New(ts.T())
 	ts.rpcClient.Close()
 	// sleep for a while to allow the pollers to shutdown
 	// then assert that there are no lingering go routines


### PR DESCRIPTION
Tests failed locally when running with docker-compose-local.yaml, with an error like this:
```
buildkite_integ-test-sticky-on_1 exited with code 2
integ-test-sticky-off_1  | --- FAIL: TestIntegrationSuite (139.30s)
integ-test-sticky-off_1  |     --- PASS: TestIntegrationSuite/TestActivityCancelRepro (7.86s)
...
integ-test-sticky-off_1  |     --- PASS: TestIntegrationSuite/TestChildWFWithParentClosePolicyAbandon (5.19s)
        Error Trace:    integration_test.go:3127:
integ-teError:      f_1 Should be true
integ-teTest:       f_1 TestIntegrationSuite
integ-test-sticky-off_1  |     --- FAIL: TestIntegrationSuite/TestChildWFWithParentClosePolicyTerminate (5.16s)
integ-test-sticky-off_1  |         testing.go:820: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
```

The cause is pretty straightforward: the testing.T in the assertions is owned by the parent, but being used in sub-tests
(like TestChildWFWithParentClosePolicy), which is incorrect, and can lead to the wrong test(s) being blamed.
It'll also lead to logs not being printed for the right test (if used).  So this should be better in pretty much every way.