### PR TITLE
Stop checking for goroutine leaks more quickly if possible

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -100,11 +100,30 @@ func (ts *IntegrationTestSuite) SetupSuite() {
 
 func (ts *IntegrationTestSuite) TearDownSuite() {
 	ts.rpcClient.Close()
-	// sleep for a while to allow the pollers to shutdown
-	// then assert that there are no lingering go routines
-	time.Sleep(1 * time.Minute)
-	// https://github.com/uber-go/cadence-client/issues/739
-	goleak.VerifyNoLeaks(ts.T(), goleak.IgnoreTopFunction("go.uber.org/cadence/internal.(*coroutineState).initialYield"))
+
+	// allow the pollers to shut down, and ensure there are no goroutine leaks.
+	// this will wait for up to 1 minute for leaks to subside, but exit relatively quickly if possible.
+	max := time.After(time.Minute)
+	var last error
+	for {
+		select {
+		case <-max:
+			if last != nil {
+				ts.NoError(last)
+				return
+			} else {
+				ts.FailNow("leaks timed out but no error, should be impossible")
+			}
+		case <-time.After(time.Second):
+			// https://github.com/uber-go/cadence-client/issues/739
+			last = goleak.FindLeaks(goleak.IgnoreTopFunction("go.uber.org/cadence/internal.(*coroutineState).initialYield"))
+			if last == nil {
+				// no leak, done waiting
+				return
+			}
+			// else wait for another check or the timeout (which will record the latest error)
+		}
+	}
 }
 
 func (ts *IntegrationTestSuite) SetupTest() {


### PR DESCRIPTION
goleak has controls for this, but they're not exported.
oh well.
this cuts the run-time of the integration tests almost in half on my machine though:
```
before:
ok  	go.uber.org/cadence/test	103.880s
after:
ok  	go.uber.org/cadence/test	57.182s
```