### PR TITLE
Remove unused helper method in tests

### DIFF
--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -509,12 +509,3 @@ func (w *Workflows) defaultActivityOptionsWithRetry() workflow.ActivityOptions {
 		},
 	}
 }
-
-func (w *Workflows) activityOptions(
-	startTimeout time.Duration, scheduleToCloseTimeout time.Duration, startToCloseTimeout time.Duration) workflow.ActivityOptions {
-	return workflow.ActivityOptions{
-		ScheduleToStartTimeout: startTimeout,
-		ScheduleToCloseTimeout: scheduleToCloseTimeout,
-		StartToCloseTimeout:    startToCloseTimeout,
-	}
-}


### PR DESCRIPTION
Nothing calls it, and it seems relatively unlikely to be used in the future.