### PR TITLE
Work around pborman data race

### DIFF
--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -349,7 +349,7 @@ func (s *workflowRunSuite) TestExecuteWorkflowWorkflowExecutionAlreadyStartedErr
 	alreadyStartedErr := &shared.WorkflowExecutionAlreadyStartedError{
 		RunId:          common.StringPtr(runID),
 		Message:        common.StringPtr("Already Started"),
-		StartRequestId: common.StringPtr(uuid.NewUUID().String()),
+		StartRequestId: common.StringPtr(uuid.NewRandom().String()),
 	}
 	s.workflowServiceClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, alreadyStartedErr).Times(1)

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -347,7 +347,7 @@ func replayWorkflowHistory(logger *zap.Logger, service workflowserviceclient.Int
 	}
 	workflowType := attr.WorkflowType
 	execution := &shared.WorkflowExecution{
-		RunId:      common.StringPtr(uuid.NewUUID().String()),
+		RunId:      common.StringPtr(uuid.NewRandom().String()),
 		WorkflowId: common.StringPtr("ReplayId"),
 	}
 	if first.WorkflowExecutionStartedEventAttributes.GetOriginalExecutionRunId() != "" {


### PR DESCRIPTION
NewUUID contains a data race for v1 uuids, as it does not lock before
checking if nodeID is nil.
NewRandom returns a v4 uuid and does not have this flaw, plus it's
much more likely what is desired anyway, and matches the rest of the
code.  So it seems like a straightfoward replacement.

Original race captured while parallelizing some tests:
```
    WARNING: DATA RACE
    Write at 0x00c000029c77 by goroutine 16:
      runtime.slicecopy()
          /usr/local/Cellar/go/1.13.4/libexec/src/runtime/slice.go:197 +0x0
      github.com/pborman/uuid.setNodeInterface()
          /Users/stevenl/gocode/pkg/mod/github.com/pborman/uuid@v0.0.0-20160209185913-a97ce2ca70fa/node.go:104 +0x3b2
      github.com/pborman/uuid.SetNodeInterface()
          /Users/stevenl/gocode/pkg/mod/github.com/pborman/uuid@v0.0.0-20160209185913-a97ce2ca70fa/node.go:37 +0x8d
      github.com/pborman/uuid.NewUUID()
          /Users/stevenl/gocode/pkg/mod/github.com/pborman/uuid@v0.0.0-20160209185913-a97ce2ca70fa/version1.go:19 +0x2ea
      go.uber.org/cadence/internal.replayWorkflowHistory()
          /Users/stevenl/gocode/src/go.uber.org/cadence/internal/worker.go:350 +0x2a3
      go.uber.org/cadence/internal.ReplayPartialWorkflowHistoryFromJSONFile()
          /Users/stevenl/gocode/src/go.uber.org/cadence/internal/worker.go:326 +0x487
      go.uber.org/cadence/test/replaytests.TestReplayWorkflowHistoryFromFile.func1()
          /Users/stevenl/gocode/src/go.uber.org/cadence/internal/worker.go:303 +0xaf
      testing.tRunner()
          /usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909 +0x199

    Previous read at 0x00c000029c77 by goroutine 15:
      runtime.slicecopy()
          /usr/local/Cellar/go/1.13.4/libexec/src/runtime/slice.go:197 +0x0
      github.com/pborman/uuid.NewUUID()
          /Users/stevenl/gocode/pkg/mod/github.com/pborman/uuid@v0.0.0-20160209185913-a97ce2ca70fa/version1.go:38 +0x2ad
      go.uber.org/cadence/internal.replayWorkflowHistory()
          /Users/stevenl/gocode/src/go.uber.org/cadence/internal/worker.go:350 +0x2a3
      go.uber.org/cadence/internal.ReplayPartialWorkflowHistoryFromJSONFile()
          /Users/stevenl/gocode/src/go.uber.org/cadence/internal/worker.go:326 +0x487
      go.uber.org/cadence/test/replaytests.TestReplayWorkflowHistoryFromFile.func1()
          /Users/stevenl/gocode/src/go.uber.org/cadence/internal/worker.go:303 +0xaf
      testing.tRunner()
          /usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909 +0x199
```

---

Newer versions might not have this issue, as it generally seems to defer to github.com/google/uuid