### PR TITLE
Fix an un-locked access to the activities map

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -670,6 +670,8 @@ func (th *hostEnvImpl) getActivityFn(fnName string) (interface{}, bool) {
 }
 
 func (th *hostEnvImpl) getRegisteredActivities() []activity {
+	th.Lock()
+	defer th.Unlock()
 	activities := make([]activity, 0, len(th.activityFuncMap))
 	for _, a := range th.activityFuncMap {
 		activities = append(activities, a)


### PR DESCRIPTION
Fixes this race:
```
WARNING: DATA RACE
Read at 0x00c00083fef8 by goroutine 45:
  go.uber.org/cadence/internal.(*hostEnvImpl).getRegisteredActivities()
      /Users/stevenl/gocode/src/go.uber.org/cadence/internal/internal_worker.go:674 +0x18a
  go.uber.org/cadence/internal.(*testWorkflowEnvironmentImpl).newTestActivityTaskHandler()
      /Users/stevenl/gocode/src/go.uber.org/cadence/internal/internal_workflow_testsuite.go:1495 +0x337
  go.uber.org/cadence/internal.(*testWorkflowEnvironmentImpl).executeActivity()
      /Users/stevenl/gocode/src/go.uber.org/cadence/internal/internal_workflow_testsuite.go:507 +0x3d4
  go.uber.org/cadence/internal.Test_ActivityNotRegistered()
      /Users/stevenl/gocode/src/go.uber.org/cadence/internal/workflow_testsuite.go:157 +0x2e7
  testing.tRunner()
      /usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909 +0x199

Previous write at 0x00c00083fef8 by goroutine 44:
  go.uber.org/cadence/internal.(*hostEnvImpl).addActivity()
      /Users/stevenl/gocode/src/go.uber.org/cadence/internal/internal_worker.go:651 +0xd1
  go.uber.org/cadence/internal.(*hostEnvImpl).RegisterActivityWithOptions()
      /Users/stevenl/gocode/src/go.uber.org/cadence/internal/internal_worker.go:655 +0x1cc
  go.uber.org/cadence/internal.RegisterActivityWithOptions()
      /Users/stevenl/gocode/src/go.uber.org/cadence/internal/activity.go:154 +0x60
  go.uber.org/cadence/internal.Test_GenericError()
      /Users/stevenl/gocode/src/go.uber.org/cadence/internal/activity.go:134 +0x75
  testing.tRunner()
      /usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909 +0x199
```