### PR TITLE
Remove another un-locked access to activity func map

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1744,7 +1744,7 @@ func (ath *activityTaskHandlerImpl) getActivity(name string) activity {
 }
 
 func (ath *activityTaskHandlerImpl) getRegisteredActivityNames() (activityNames []string) {
-	for _, a := range ath.hostEnv.activityFuncMap {
+	for _, a := range ath.hostEnv.getRegisteredActivities() {
 		activityNames = append(activityNames, a.ActivityType().Name)
 	}
 	return


### PR DESCRIPTION
This is the only access outside internal_worker.go, so hopefully it's the last.
Regardless, this may be a fairly good argument for breaking up this single giant package,
if only to protect internal fields from un-guarded access.  Or for switching to something
that mandates using a lock to access the data (e.g. similar to uber/atomic, but for locks).

Fixes this race:
```
WARNING: DATA RACE
Write at 0x00c0002e2cf0 by goroutine 49:
  runtime.mapassign_faststr()
      /usr/local/Cellar/go/1.13.4/libexec/src/runtime/map_faststr.go:202 +0x0
  go.uber.org/cadence/internal.(*hostEnvImpl).addActivity()
      /Users/stevenl/gocode/src/go.uber.org/cadence/internal/internal_worker.go:651 +0xbc
  go.uber.org/cadence/internal.(*hostEnvImpl).RegisterActivityWithOptions()
      /Users/stevenl/gocode/src/go.uber.org/cadence/internal/internal_worker.go:655 +0x1cc
  go.uber.org/cadence/internal.RegisterActivityWithOptions()
      /Users/stevenl/gocode/src/go.uber.org/cadence/internal/activity.go:154 +0x60
  go.uber.org/cadence/internal.Test_CustomError_Pointer()
      /Users/stevenl/gocode/src/go.uber.org/cadence/internal/activity.go:134 +0xc41
  testing.tRunner()
      /usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909 +0x199

Previous read at 0x00c0002e2cf0 by goroutine 45:
  runtime.mapiterinit()
      /usr/local/Cellar/go/1.13.4/libexec/src/runtime/map.go:802 +0x0
  go.uber.org/cadence/internal.(*activityTaskHandlerImpl).getRegisteredActivityNames()
      /Users/stevenl/gocode/src/go.uber.org/cadence/internal/internal_task_handlers.go:1747 +0xc9
  go.uber.org/cadence/internal.(*activityTaskHandlerImpl).Execute()
      /Users/stevenl/gocode/src/go.uber.org/cadence/internal/internal_task_handlers.go:1683 +0x1b5f
  go.uber.org/cadence/internal.(*testWorkflowEnvironmentImpl).executeActivity()
      /Users/stevenl/gocode/src/go.uber.org/cadence/internal/internal_workflow_testsuite.go:508 +0x40a
  go.uber.org/cadence/internal.Test_ActivityNotRegistered()
      /Users/stevenl/gocode/src/go.uber.org/cadence/internal/workflow_testsuite.go:157 +0x2e7
  testing.tRunner()
      /usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909 +0x199
```