### PR TITLE
Change ExecuteUntilAllBlocked to return an error, rather than a pointer

### DIFF
--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -81,7 +81,7 @@ type (
 	dispatcher interface {
 		// ExecuteUntilAllBlocked executes coroutines one by one in deterministic order
 		// until all of them are completed or blocked on Channel or Selector
-		ExecuteUntilAllBlocked() (err *workflowPanicError)
+		ExecuteUntilAllBlocked() (err error)
 		// IsDone returns true when all of coroutines are completed
 		IsDone() bool
 		Close()             // Destroys all coroutines without waiting for their completion
@@ -849,7 +849,7 @@ func (d *dispatcherImpl) newState(name string) *coroutineState {
 	return c
 }
 
-func (d *dispatcherImpl) ExecuteUntilAllBlocked() (err *workflowPanicError) {
+func (d *dispatcherImpl) ExecuteUntilAllBlocked() (err error) {
 	d.mutex.Lock()
 	if d.closed {
 		panic("dispatcher is closed")


### PR DESCRIPTION
While going through these tests, I reached a “…. huh.  probably not a good thing” point.
`internal_coroutines_test.go` calls `*dispatcherImpl.ExecuteUntilAllBlocked`, which is defined as:
`func (d *dispatcherImpl) ExecuteUntilAllBlocked() (err *workflowPanicError)`
that means that `require.NoError(t, d.ExecuteUntilAllBlocked())` will fail if this func returns nil
(like it noramlly does) - it’s a typed nil, and `*workflowPanicError` implements `Error()`, so a nil
is an error.

This seems like it could pretty easily surprise anyone who tries to use it as `if err == nil { ...`
after passing through an error interface conversion.  Utility code very frequently does this, so it
feels like a landmine waiting to go off in the future, though it currently works fine.