### PR TITLE
Sticky task list name

### DIFF
--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -361,7 +361,7 @@ func (wtp *workflowTaskPoller) RespondTaskCompleted(completedRequest interface{}
 			case *s.RespondDecisionTaskCompletedRequest:
 				if request.StickyAttributes == nil && !wtp.disableStickyExecution {
 					request.StickyAttributes = &s.StickyExecutionAttributes{
-						WorkerTaskList:                &s.TaskList{Name: common.StringPtr(getWorkerTaskList())},
+						WorkerTaskList:                &s.TaskList{Name: common.StringPtr(getWorkerTaskList(wtp.taskListName))},
 						ScheduleToStartTimeoutSeconds: common.Int32Ptr(common.Int32Ceil(wtp.StickyScheduleToStartTimeout.Seconds())),
 					}
 				}
@@ -582,7 +582,7 @@ func (wtp *workflowTaskPoller) getNextPollRequest() (request *s.PollForDecisionT
 		wtp.requestLock.Lock()
 		if wtp.stickyBacklog > 0 || wtp.pendingStickyPollCount <= wtp.pendingRegularPollCount {
 			wtp.pendingStickyPollCount++
-			taskListName = getWorkerTaskList()
+			taskListName = getWorkerTaskList(wtp.taskListName)
 			taskListKind = s.TaskListKindSticky
 		} else {
 			wtp.pendingRegularPollCount++

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -195,6 +195,7 @@ func (bp *basePoller) doPoll(pollFunc func(ctx context.Context) (interface{}, er
 	}
 }
 
+// newWorkflowTaskPoller creates a new workflow task poller which must have a one to one relationship to workflow worker
 func newWorkflowTaskPoller(
 	taskHandler WorkflowTaskHandler,
 	service workflowserviceclient.Interface,

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -212,7 +212,6 @@ func newWorkflowTaskPoller(
 		stickyUUID:                   uuid.New(),
 		disableStickyExecution:       params.DisableStickyExecution,
 		StickyScheduleToStartTimeout: params.StickyScheduleToStartTimeout,
-
 	}
 }
 

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/pborman/uuid"
 	"github.com/uber-go/tally"
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	s "go.uber.org/cadence/.gen/go/shared"
@@ -36,7 +37,7 @@ import (
 	"go.uber.org/cadence/internal/common/backoff"
 	"go.uber.org/cadence/internal/common/metrics"
 	"go.uber.org/zap"
-)
+)s
 
 const (
 	pollTaskServiceTimeOut = 3 * time.Minute // Server long poll is 1 * Minutes + delta
@@ -71,6 +72,7 @@ type (
 		metricsScope tally.Scope
 		logger       *zap.Logger
 
+		stickyUUID                   string
 		disableStickyExecution       bool
 		StickyScheduleToStartTimeout time.Duration
 
@@ -207,8 +209,10 @@ func newWorkflowTaskPoller(
 		taskHandler:                  taskHandler,
 		metricsScope:                 params.MetricsScope,
 		logger:                       params.Logger,
+		stickyUUID:                   uuid.New(),
 		disableStickyExecution:       params.DisableStickyExecution,
 		StickyScheduleToStartTimeout: params.StickyScheduleToStartTimeout,
+
 	}
 }
 
@@ -361,7 +365,7 @@ func (wtp *workflowTaskPoller) RespondTaskCompleted(completedRequest interface{}
 			case *s.RespondDecisionTaskCompletedRequest:
 				if request.StickyAttributes == nil && !wtp.disableStickyExecution {
 					request.StickyAttributes = &s.StickyExecutionAttributes{
-						WorkerTaskList:                &s.TaskList{Name: common.StringPtr(getWorkerTaskList(wtp.taskListName))},
+						WorkerTaskList:                &s.TaskList{Name: common.StringPtr(getWorkerTaskList(wtp.stickyUUID))},
 						ScheduleToStartTimeoutSeconds: common.Int32Ptr(common.Int32Ceil(wtp.StickyScheduleToStartTimeout.Seconds())),
 					}
 				}
@@ -582,7 +586,7 @@ func (wtp *workflowTaskPoller) getNextPollRequest() (request *s.PollForDecisionT
 		wtp.requestLock.Lock()
 		if wtp.stickyBacklog > 0 || wtp.pendingStickyPollCount <= wtp.pendingRegularPollCount {
 			wtp.pendingStickyPollCount++
-			taskListName = getWorkerTaskList(wtp.taskListName)
+			taskListName = getWorkerTaskList(wtp.stickyUUID)
 			taskListKind = s.TaskListKindSticky
 		} else {
 			wtp.pendingRegularPollCount++

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -37,7 +37,7 @@ import (
 	"go.uber.org/cadence/internal/common/backoff"
 	"go.uber.org/cadence/internal/common/metrics"
 	"go.uber.org/zap"
-)s
+)
 
 const (
 	pollTaskServiceTimeOut = 3 * time.Minute // Server long poll is 1 * Minutes + delta

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -144,9 +144,9 @@ func getHostName() string {
 // worker uuid per process
 var workerUUID = uuid.New()
 
-func getWorkerTaskList() string {
-	// includes hostname for debuggability, workerUUID guarantees the uniqueness
-	return fmt.Sprintf("%s:%s", getHostName(), workerUUID)
+func getWorkerTaskList(taskListName string) string {
+	// includes hostname and taskListName for debuggability, workerUUID guarantees the uniqueness
+	return fmt.Sprintf("%s:%s:%s", getHostName(), workerUUID, taskListName)
 }
 
 // ActivityTypePtr makes a copy and returns the pointer to a ActivityType.

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -32,7 +32,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/pborman/uuid"
 	"github.com/uber-go/tally"
 	s "go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/internal/common"
@@ -141,12 +140,9 @@ func getHostName() string {
 	return hostName
 }
 
-// worker uuid per process
-var workerUUID = uuid.New()
-
-func getWorkerTaskList(taskListName string) string {
-	// includes hostname and taskListName for debuggability, workerUUID guarantees the uniqueness
-	return fmt.Sprintf("%s:%s:%s", getHostName(), workerUUID, taskListName)
+func getWorkerTaskList(stickyUUID string) string {
+	// includes hostname for debuggability, stickyUUID guarantees the uniqueness
+	return fmt.Sprintf("%s:%s", getHostName(), stickyUUID)
 }
 
 // ActivityTypePtr makes a copy and returns the pointer to a ActivityType.


### PR DESCRIPTION
This fixes an issue where sticky task list name is not actually unique if multiple workers exist within the same process. This is most commonly an issue in tests. 