### PR TITLE
Fix potential go-routine leak when retrying local activity

### DIFF
--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -153,10 +153,12 @@ func (lat *localActivityTunnel) getTask() *localActivityTask {
 	}
 }
 
-func (lat *localActivityTunnel) sendTask(task *localActivityTask) {
+func (lat *localActivityTunnel) sendTask(task *localActivityTask) bool {
 	select {
 	case lat.taskCh <- task:
+		return true
 	case <-lat.stopCh:
+		return false
 	}
 }
 

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -132,20 +132,32 @@ type (
 	localActivityTunnel struct {
 		taskCh   chan *localActivityTask
 		resultCh chan interface{}
+		stopCh   <-chan struct{}
 	}
 )
 
-func (lat *localActivityTunnel) getTask(stopC <-chan struct{}) *localActivityTask {
+func newLocalActivityTunnel(stopCh <-chan struct{}) *localActivityTunnel {
+	return &localActivityTunnel{
+		taskCh:   make(chan *localActivityTask, 1000),
+		resultCh: make(chan interface{}),
+		stopCh:   stopCh,
+	}
+}
+
+func (lat *localActivityTunnel) getTask() *localActivityTask {
 	select {
 	case task := <-lat.taskCh:
 		return task
-	case <-stopC:
+	case <-lat.stopCh:
 		return nil
 	}
 }
 
 func (lat *localActivityTunnel) sendTask(task *localActivityTask) {
-	lat.taskCh <- task
+	select {
+	case lat.taskCh <- task:
+	case <-lat.stopCh:
+	}
 }
 
 func isClientSideError(err error) bool {
@@ -412,7 +424,7 @@ func newLocalActivityPoller(params workerExecutionParameters, laTunnel *localAct
 }
 
 func (latp *localActivityTaskPoller) PollTask() (interface{}, error) {
-	return latp.laTunnel.getTask(latp.shutdownC), nil
+	return latp.laTunnel.getTask(), nil
 }
 
 func (latp *localActivityTaskPoller) ProcessTask(task interface{}) error {

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -308,10 +308,7 @@ func newWorkflowTaskWorkerInternal(
 	)
 
 	// laTunnel is the glue that hookup 3 parts
-	laTunnel := &localActivityTunnel{
-		taskCh:   make(chan *localActivityTask, 1000),
-		resultCh: make(chan interface{}),
-	}
+	laTunnel := newLocalActivityTunnel(params.WorkerStopChannel)
 
 	// 1) workflow handler will send local activity task to laTunnel
 	if handlerImpl, ok := taskHandler.(*workflowTaskHandlerImpl); ok {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -112,9 +112,8 @@ func (ts *IntegrationTestSuite) TearDownSuite() {
 			if last != nil {
 				ts.NoError(last)
 				return
-			} else {
-				ts.FailNow("leaks timed out but no error, should be impossible")
 			}
+			ts.FailNow("leaks timed out but no error, should be impossible")
 		case <-time.After(time.Second):
 			// https://github.com/uber-go/cadence-client/issues/739
 			last = goleak.FindLeaks(goleak.IgnoreTopFunction("go.uber.org/cadence/internal.(*coroutineState).initialYield"))


### PR DESCRIPTION
When retrying local activity a delayed callback will be scheduled to send the local activity task to task handler through the local activity tunnel. However, it's possible that when the callback is executed, the task handler has already shut down. If the task channel is already full, then it will cause the callback to be blocked and results in a go-routine leak. This pr fixes that.

Also fixed a lint issue which makes `make bins` fail.