### PR TITLE
encoded: Unalias interfaces

### DIFF
--- a/encoded/encoded.go
+++ b/encoded/encoded.go
@@ -26,10 +26,20 @@ import "go.uber.org/cadence/internal"
 type (
 
 	// Value is used to encapsulate/extract encoded value from workflow/activity.
-	Value = internal.Value
+	Value interface {
+		// HasValue return whether there is value encoded.
+		HasValue() bool
+		// Get extract the encoded value into strong typed value pointer.
+		Get(valuePtr interface{}) error
+	}
 
 	// Values is used to encapsulate/extract encoded one or more values from workflow/activity.
-	Values = internal.Values
+	Values interface {
+		// HasValues return whether there are values encoded.
+		HasValues() bool
+		// Get extract the encoded values into strong typed value pointers.
+		Get(valuePtr ...interface{}) error
+	}
 
 	// DataConverter is used by the framework to serialize/deserialize input and output of activity/workflow
 	// that need to be sent over the wire.
@@ -41,7 +51,26 @@ type (
 	// and pass that context to ExecuteActivity/ExecuteChildWorkflow calls.
 	// Cadence support using different DataConverters for different activity/childWorkflow in same workflow.
 	//   2. Activity/Workflow worker that run these activity/childWorkflow, through worker.Options.
-	DataConverter = internal.DataConverter
+	DataConverter interface {
+		// ToData implements conversion of a list of values.
+		ToData(value ...interface{}) ([]byte, error)
+		// FromData implements conversion of an array of values of different types.
+		// Useful for deserializing arguments of function invocations.
+		FromData(input []byte, valuePtr ...interface{}) error
+	}
+)
+
+// Compile-time checks to verify that interfaces are in-sync in both
+// directions with internal variants.
+var (
+	_ Value          = (internal.Value)(nil)
+	_ internal.Value = (Value)(nil)
+
+	_ Values          = (internal.Values)(nil)
+	_ internal.Values = (Values)(nil)
+
+	_ DataConverter          = (internal.DataConverter)(nil)
+	_ internal.DataConverter = (DataConverter)(nil)
 )
 
 // GetDefaultDataConverter return default data converter used by Cadence worker


### PR DESCRIPTION
Per reasoning in #928, this redeclares all three interfaces in the
`encoded` package and adds bi-directional compile-time checks to verify
that the interfaces do not fall out-of-sync.

The only reason I could find for the interfaces to be aliased was
`client.Client`'s re-use of an `internal.Client`.

    package client

    type Client interface {
      ...
      QueryWorkflow(...) (encoded.Value, error)
    }

    func NewClient(...) Client {
      return internal.NewClient(...)
    }

Where,

    package internal

    type Client interface {
      ...
      QueryWorkflow(...) (internal.Value, error)
    }

This mismatch in `QueryWorkflow`'s return value makes `internal.Client`
not match `client.Client`.

To resolve this, we introduce a `clientAdapter` which adapts an
`internal.Client` into a `client.Client`. It does so by embedding
`internal.Client` and implementing the compliant version of
`QueryWorkflow`.

Resolves #928