### PR TITLE
PR937 followup: remove breaking change, add integration test

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -537,7 +537,7 @@ func (env *testWorkflowEnvironmentImpl) executeActivity(
 func (env *testWorkflowEnvironmentImpl) executeLocalActivity(
 	activityFn interface{},
 	args ...interface{},
-) (val Value, result *localActivityResult, err error) {
+) (val Value, err error) {
 	params := executeLocalActivityParams{
 		localActivityOptions: localActivityOptions{
 			ScheduleToCloseTimeoutSeconds: common.Int32Ceil(env.testTimeout.Seconds()),
@@ -559,11 +559,11 @@ func (env *testWorkflowEnvironmentImpl) executeLocalActivity(
 		tracer:       opentracing.NoopTracer{},
 	}
 
-	result = taskHandler.executeLocalActivityTask(task)
+	result := taskHandler.executeLocalActivityTask(task)
 	if result.err != nil {
-		return nil, nil, result.err
+		return nil, result.err
 	}
-	return newEncodedValue(result.result, env.GetDataConverter()), result, nil
+	return newEncodedValue(result.result, env.GetDataConverter()), nil
 }
 
 func (env *testWorkflowEnvironmentImpl) startDecisionTask() {

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -1616,11 +1616,8 @@ func (s *WorkflowTestSuiteUnitTest) Test_LocalActivity() {
 	}
 
 	env := s.NewTestActivityEnvironment()
-	result, localActivity, err := env.ExecuteLocalActivity(localActivityFn, "local_activity")
+	result, err := env.ExecuteLocalActivity(localActivityFn, "local_activity")
 	s.NoError(err)
-	s.Equal(WorkflowType{Name: workflowTypeNotSpecified}, localActivity.task.params.WorkflowInfo.WorkflowType)
-	s.Equal(defaultTestDomain, localActivity.task.params.WorkflowInfo.Domain)
-	s.Equal(defaultTestTaskList, localActivity.task.params.WorkflowInfo.TaskListName)
 	var laResult string
 	err = result.Get(&laResult)
 	s.NoError(err)

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -159,7 +159,7 @@ func (t *TestActivityEnvironment) ExecuteActivity(activityFn interface{}, args .
 
 // ExecuteLocalActivity executes a local activity. The tested activity will be executed synchronously in the calling goroutinue.
 // Caller should use Value.Get() to extract strong typed result value.
-func (t *TestActivityEnvironment) ExecuteLocalActivity(activityFn interface{}, args ...interface{}) (val Value, result *localActivityResult, err error) {
+func (t *TestActivityEnvironment) ExecuteLocalActivity(activityFn interface{}, args ...interface{}) (val Value, err error) {
 	return t.impl.executeLocalActivity(activityFn, args...)
 }
 

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -22,6 +22,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -88,6 +89,21 @@ func (a *Activities) Fail(ctx context.Context) error {
 	return errFailOnPurpose
 }
 
+func (a *Activities) InspectActivityInfo(ctx context.Context, domain, taskList, wfType string) error {
+	a.append("inspectActivityInfo")
+	info := activity.GetInfo(ctx)
+	if info.WorkflowDomain != domain {
+		return fmt.Errorf("expected domainName %v but got %v", domain, info.WorkflowDomain)
+	}
+	if info.WorkflowType == nil || info.WorkflowType.Name != wfType {
+		return fmt.Errorf("expected workflowType %v but got %v", wfType, info.WorkflowType)
+	}
+	if info.TaskList != taskList {
+		return fmt.Errorf("expected taskList %v but got %v", taskList, info.TaskList)
+	}
+	return nil
+}
+
 func (a *Activities) append(name string) {
 	a.Lock()
 	defer a.Unlock()
@@ -118,4 +134,5 @@ func (a *Activities) register() {
 	activity.RegisterWithOptions(a.HeartbeatAndSleep, activity.RegisterOptions{Name: "heartbeatAndSleep"})
 	activity.RegisterWithOptions(a.GetMemoAndSearchAttr, activity.RegisterOptions{Name: "getMemoAndSearchAttr"})
 	activity.RegisterWithOptions(a.RetryTimeoutStableErrorActivity, activity.RegisterOptions{Name: "retryTimeoutStableErrorActivity"})
+	activity.RegisterWithOptions(a.InspectActivityInfo, activity.RegisterOptions{Name: "inspectActivityInfo"})
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -401,6 +401,16 @@ func (ts *IntegrationTestSuite) TestLargeQueryResultError() {
 	ts.Nil(value)
 }
 
+func (ts *IntegrationTestSuite) TestInspectActivityInfo() {
+	err := ts.executeWorkflow("test-activity-info", ts.workflows.InspectActivityInfo, nil)
+	ts.Nil(err)
+}
+
+func (ts *IntegrationTestSuite) TestInspectLocalActivityInfo() {
+	err := ts.executeWorkflow("test-local-activity-info", ts.workflows.InspectLocalActivityInfo, nil)
+	ts.Nil(err)
+}
+
 func (ts *IntegrationTestSuite) registerDomain() {
 	client := client.NewDomainClient(ts.rpcClient.Interface, &client.Options{})
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -494,6 +494,26 @@ func (w *Workflows) sleep(ctx workflow.Context, d time.Duration) error {
 	return workflow.ExecuteActivity(ctx, "sleep", d).Get(ctx, nil)
 }
 
+func (w *Workflows) InspectActivityInfo(ctx workflow.Context) error {
+	info := workflow.GetInfo(ctx)
+	domain := info.Domain
+	wfType := info.WorkflowType.Name
+	taskList := info.TaskListName
+	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
+	return workflow.ExecuteActivity(ctx, "inspectActivityInfo", domain, taskList, wfType).Get(ctx, nil)
+}
+
+func (w *Workflows) InspectLocalActivityInfo(ctx workflow.Context) error {
+	info := workflow.GetInfo(ctx)
+	domain := info.Domain
+	wfType := info.WorkflowType.Name
+	taskList := info.TaskListName
+	ctx = workflow.WithLocalActivityOptions(ctx, w.defaultLocalActivityOptions())
+	activites := Activities{}
+	return workflow.ExecuteLocalActivity(
+		ctx, activites.InspectActivityInfo, domain, taskList, wfType).Get(ctx, nil)
+}
+
 func (w *Workflows) register() {
 	workflow.Register(w.Basic)
 	workflow.Register(w.ActivityRetryOnError)
@@ -508,6 +528,8 @@ func (w *Workflows) register() {
 	workflow.Register(w.ChildWorkflowSuccess)
 	workflow.Register(w.ChildWorkflowSuccessWithParentClosePolicyTerminate)
 	workflow.Register(w.ChildWorkflowSuccessWithParentClosePolicyAbandon)
+	workflow.Register(w.InspectActivityInfo)
+	workflow.Register(w.InspectLocalActivityInfo)
 	workflow.Register(w.sleep)
 	workflow.Register(w.child)
 	workflow.Register(w.childForMemoAndSearchAttr)
@@ -525,6 +547,13 @@ func (w *Workflows) defaultActivityOptions() workflow.ActivityOptions {
 		StartToCloseTimeout:    9 * time.Second,
 	}
 }
+
+func (w *Workflows) defaultLocalActivityOptions() workflow.LocalActivityOptions {
+	return workflow.LocalActivityOptions{
+		ScheduleToCloseTimeout: 5 * time.Second,
+	}
+}
+
 func (w *Workflows) defaultActivityOptionsWithRetry() workflow.ActivityOptions {
 	return workflow.ActivityOptions{
 		ScheduleToStartTimeout: 5 * time.Second,


### PR DESCRIPTION
Removes the breaking change to test framework. Adds integration test for GetActivityInfo. Tested on localhost. Fixes #936 