### PR TITLE
Cherry-pick f6cb456afa7b90936e51338736d8de32af4e194e from temporal-go-sdk

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -57,7 +57,8 @@ type (
 
 	// RegisterActivityOptions consists of options for registering an activity
 	RegisterActivityOptions struct {
-		Name string
+		Name                          string
+		DisableAlreadyRegisteredCheck bool
 	}
 
 	// ActivityOptions stores all activity-specific parameters that will be stored inside of a context.
@@ -119,8 +120,14 @@ type (
 	}
 )
 
-// RegisterActivity - register a activity function with the framework.
-// A activity takes a context and input and returns a (result, error) or just error.
+// RegisterActivity - register an activity function or a pointer to a structure with the framework.
+// The public form is: activity.Register(...)
+// An activity function takes a context and input and returns a (result, error) or just error.
+//
+// And activity struct is a structure with all its exported methods treated as activities. The default
+// name of each activity is the <structure name>_<method name>. Use RegisterActivityWithOptions to override the
+// "<structure name>_" prefix.
+//
 // Examples:
 //	func sampleActivity(ctx context.Context, input []byte) (result []byte, err error)
 //	func sampleActivity(ctx context.Context, arg1 int, arg2 string) (result *customerStruct, err error)
@@ -128,33 +135,44 @@ type (
 //	func sampleActivity() (result string, err error)
 //	func sampleActivity(arg1 bool) (result int, err error)
 //	func sampleActivity(arg1 bool) (err error)
+//
+//  type Activities struct {
+//     // fields
+//  }
+//  func (a *Activities) SampleActivity1(ctx context.Context, arg1 int, arg2 string) (result *customerStruct, err error) {
+//    ...
+//  }
+//
+//  func (a *Activities) SampleActivity2(ctx context.Context, arg1 int, arg2 *customerStruct) (result string, err error) {
+//    ...
+//  }
+//
 // Serialization of all primitive types, structures is supported ... except channels, functions, variadic, unsafe pointer.
 // This method calls panic if activityFunc doesn't comply with the expected format.
 func RegisterActivity(activityFunc interface{}) {
 	RegisterActivityWithOptions(activityFunc, RegisterActivityOptions{})
 }
 
-// RegisterActivityWithOptions registers the activity function with options
+// RegisterActivityWithOptions registers the activity function or struct pointer with options.
+// The public form is: activity.RegisterWithOptions(...)
 // The user can use options to provide an external name for the activity or leave it empty if no
 // external name is required. This can be used as
-//  client.RegisterActivity(barActivity, RegisterActivityOptions{})
-//  client.RegisterActivity(barActivity, RegisterActivityOptions{Name: "barExternal"})
-// An activity takes a context and input and returns a (result, error) or just error.
-// Examples:
-//	func sampleActivity(ctx context.Context, input []byte) (result []byte, err error)
-//	func sampleActivity(ctx context.Context, arg1 int, arg2 string) (result *customerStruct, err error)
-//	func sampleActivity(ctx context.Context) (err error)
-//	func sampleActivity() (result string, err error)
-//	func sampleActivity(arg1 bool) (result int, err error)
-//	func sampleActivity(arg1 bool) (err error)
-// Serialization of all primitive types, structures is supported ... except channels, functions, variadic, unsafe pointer.
-// This method calls panic if activityFunc doesn't comply with the expected format.
+//  activity.RegisterWithOptions(barActivity, RegisterActivityOptions{})
+//  activity.RegisterWithOptions(barActivity, RegisterActivityOptions{Name: "barExternal"})
+// When registering the structure that implements activities the name is used as a prefix that is
+// prepended to the activity method name.
+//  activity.RegisterWithOptions(&Activities{ ... }, RegisterActivityOptions{Name: "MyActivities_"})
+// To override each name of activities defined through a structure register the methods one by one:
+// activities := &Activities{ ... }
+// activity.RegisterWithOptions(activities.SampleActivity1, RegisterActivityOptions{Name: "Sample1"})
+// activity.RegisterWithOptions(activities.SampleActivity2, RegisterActivityOptions{Name: "Sample2"})
+// See RegisterActivity function for more info.
+// The other use of options is to disable duplicated activity registration check
+// which might be useful for integration tests.
+// activity.RegisterWithOptions(barActivity, RegisterActivityOptions{DisableAlreadyRegisteredCheck: true})
 func RegisterActivityWithOptions(activityFunc interface{}, opts RegisterActivityOptions) {
-	thImpl := getHostEnvironment()
-	err := thImpl.RegisterActivityWithOptions(activityFunc, opts)
-	if err != nil {
-		panic(err)
-	}
+	registry := getGlobalRegistry()
+	registry.RegisterActivityWithOptions(activityFunc, opts)
 }
 
 // GetActivityInfo returns information about currently executing activity.

--- a/internal/client.go
+++ b/internal/client.go
@@ -514,6 +514,7 @@ func NewClient(service workflowserviceclient.Interface, domain string, options *
 	return &workflowClient{
 		workflowService:    metrics.NewWorkflowServiceWrapper(service, metricScope),
 		domain:             domain,
+		registry:           newRegistry(getGlobalRegistry()),
 		metricsScope:       metrics.NewTaggedScope(metricScope),
 		identity:           identity,
 		dataConverter:      dataConverter,

--- a/internal/error.go
+++ b/internal/error.go
@@ -219,7 +219,8 @@ func NewContinueAsNewError(ctx Context, wfn interface{}, args ...interface{}) *C
 	if options == nil {
 		panic("context is missing required options for continue as new")
 	}
-	workflowType, input, err := getValidatedWorkflowFunction(wfn, args, options.dataConverter)
+	env := getWorkflowEnvironment(ctx)
+	workflowType, input, err := getValidatedWorkflowFunction(wfn, args, options.dataConverter, env.GetRegistry())
 	if err != nil {
 		panic(err)
 	}

--- a/internal/internal_activity.go
+++ b/internal/internal_activity.go
@@ -282,7 +282,7 @@ func validateFunctionArgs(f interface{}, args []interface{}, isWorkflow bool) er
 	return nil
 }
 
-func getValidatedActivityFunction(f interface{}, args []interface{}, dataConverter DataConverter) (*ActivityType, []byte, error) {
+func getValidatedActivityFunction(f interface{}, args []interface{}, dataConverter DataConverter, registry *registry) (*ActivityType, []byte, error) {
 	fnName := ""
 	fType := reflect.TypeOf(f)
 	switch getKind(fType) {
@@ -294,13 +294,13 @@ func getValidatedActivityFunction(f interface{}, args []interface{}, dataConvert
 			return nil, nil, err
 		}
 		fnName = getFunctionName(f)
-		if alias, ok := getHostEnvironment().getActivityAlias(fnName); ok {
+		if alias, ok := registry.getActivityAlias(fnName); ok {
 			fnName = alias
 		}
 
 	default:
 		return nil, nil, fmt.Errorf(
-			"Invalid type 'f' parameter provided, it can be either activity function or name of the activity: %v", f)
+			"invalid type 'f' parameter provided, it can be either activity function or name of the activity: %v", f)
 	}
 
 	input, err := encodeArgs(dataConverter, args)
@@ -328,7 +328,7 @@ func validateFunctionAndGetResults(f interface{}, values []reflect.Value, dataCo
 
 	if resultSize < 1 || resultSize > 2 {
 		return nil, fmt.Errorf(
-			"The function: %v signature returns %d results, it is expecting to return either error or (result, error)",
+			"the function: %v signature returns %d results, it is expecting to return either error or (result, error)",
 			fnName, resultSize)
 	}
 
@@ -380,7 +380,7 @@ func deSerializeFnResultFromFnType(fnType reflect.Type, result []byte, to interf
 	return nil
 }
 
-func deSerializeFunctionResult(f interface{}, result []byte, to interface{}, dataConverter DataConverter) error {
+func deSerializeFunctionResult(f interface{}, result []byte, to interface{}, dataConverter DataConverter, registry *registry) error {
 	fType := reflect.TypeOf(f)
 	if dataConverter == nil {
 		dataConverter = getDefaultDataConverter()
@@ -394,7 +394,7 @@ func deSerializeFunctionResult(f interface{}, result []byte, to interface{}, dat
 	case reflect.String:
 		// If we know about this function through registration then we will try to return corresponding result type.
 		fnName := reflect.ValueOf(f).String()
-		if fnRegistered, ok := getHostEnvironment().getActivityFn(fnName); ok {
+		if fnRegistered, ok := registry.getActivityFn(fnName); ok {
 			return deSerializeFnResultFromFnType(reflect.TypeOf(fnRegistered), result, to, dataConverter)
 		}
 	}

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -112,7 +112,7 @@ type (
 		enableLoggingInReplay bool // flag to indicate if workflow should enable logging in replay mode
 
 		metricsScope       tally.Scope
-		hostEnv            *hostEnvImpl
+		registry           *registry
 		dataConverter      DataConverter
 		contextPropagators []ContextPropagator
 		tracer             opentracing.Tracer
@@ -175,7 +175,7 @@ func newWorkflowExecutionEventHandler(
 	logger *zap.Logger,
 	enableLoggingInReplay bool,
 	scope tally.Scope,
-	hostEnv *hostEnvImpl,
+	registry *registry,
 	dataConverter DataConverter,
 	contextPropagators []ContextPropagator,
 	tracer opentracing.Tracer,
@@ -191,7 +191,7 @@ func newWorkflowExecutionEventHandler(
 		openSessions:          make(map[string]*SessionInfo),
 		completeHandler:       completeHandler,
 		enableLoggingInReplay: enableLoggingInReplay,
-		hostEnv:               hostEnv,
+		registry:              registry,
 		dataConverter:         dataConverter,
 		contextPropagators:    contextPropagators,
 		tracer:                tracer,
@@ -734,6 +734,10 @@ func (wc *workflowEnvironmentImpl) getOpenSessions() []*SessionInfo {
 	return openSessions
 }
 
+func (wc *workflowEnvironmentImpl) GetRegistry() *registry {
+	return wc.registry
+}
+
 func (weh *workflowExecutionEventHandlerImpl) ProcessEvent(
 	event *m.HistoryEvent,
 	isReplay bool,
@@ -944,7 +948,7 @@ func (weh *workflowExecutionEventHandlerImpl) Close() {
 
 func (weh *workflowExecutionEventHandlerImpl) handleWorkflowExecutionStarted(
 	attributes *m.WorkflowExecutionStartedEventAttributes) (err error) {
-	weh.workflowDefinition, err = weh.hostEnv.getWorkflowDefinition(
+	weh.workflowDefinition, err = weh.registry.getWorkflowDefinition(
 		weh.workflowInfo.WorkflowType,
 	)
 	if err != nil {

--- a/internal/internal_pressure_points.go
+++ b/internal/internal_pressure_points.go
@@ -61,14 +61,14 @@ func newWorkflowWorkerWithPressurePoints(
 	domain string,
 	params workerExecutionParameters,
 	pressurePoints map[string]map[string]string,
-	hostEnv *hostEnvImpl,
-) (worker Worker) {
+	registry *registry,
+) (worker *workflowWorker) {
 	return newWorkflowWorker(
 		service,
 		domain,
 		params,
 		&pressurePointMgrImpl{config: pressurePoints, logger: params.Logger},
-		hostEnv,
+		registry,
 	)
 }
 

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -118,7 +118,7 @@ type (
 		identity                       string
 		enableLoggingInReplay          bool
 		disableStickyExecution         bool
-		hostEnv                        *hostEnvImpl
+		registry                       *registry
 		laTunnel                       *localActivityTunnel
 		nonDeterministicWorkflowPolicy NonDeterministicWorkflowPolicy
 		dataConverter                  DataConverter
@@ -136,7 +136,7 @@ type (
 		metricsScope       *metrics.TaggedScope
 		logger             *zap.Logger
 		userContext        context.Context
-		hostEnv            *hostEnvImpl
+		registry           *registry
 		activityProvider   activityProvider
 		dataConverter      DataConverter
 		workerStopCh       <-chan struct{}
@@ -369,7 +369,7 @@ func newWorkflowTaskHandler(
 	domain string,
 	params workerExecutionParameters,
 	ppMgr pressurePointMgr,
-	hostEnv *hostEnvImpl,
+	registry *registry,
 ) WorkflowTaskHandler {
 	ensureRequiredParams(&params)
 	return &workflowTaskHandlerImpl{
@@ -380,7 +380,7 @@ func newWorkflowTaskHandler(
 		identity:                       params.Identity,
 		enableLoggingInReplay:          params.EnableLoggingInReplay,
 		disableStickyExecution:         params.DisableStickyExecution,
-		hostEnv:                        hostEnv,
+		registry:                       registry,
 		nonDeterministicWorkflowPolicy: params.NonDeterministicWorkflowPolicy,
 		dataConverter:                  params.DataConverter,
 		contextPropagators:             params.ContextPropagators,
@@ -567,7 +567,7 @@ func (w *workflowExecutionContextImpl) createEventHandler() {
 		w.wth.logger,
 		w.wth.enableLoggingInReplay,
 		w.wth.metricsScope,
-		w.wth.hostEnv,
+		w.wth.registry,
 		w.wth.dataConverter,
 		w.wth.contextPropagators,
 		w.wth.tracer,
@@ -1580,15 +1580,15 @@ func (wth *workflowTaskHandlerImpl) executeAnyPressurePoints(event *s.HistoryEve
 func newActivityTaskHandler(
 	service workflowserviceclient.Interface,
 	params workerExecutionParameters,
-	env *hostEnvImpl,
+	registry *registry,
 ) ActivityTaskHandler {
-	return newActivityTaskHandlerWithCustomProvider(service, params, env, nil)
+	return newActivityTaskHandlerWithCustomProvider(service, params, registry, nil)
 }
 
 func newActivityTaskHandlerWithCustomProvider(
 	service workflowserviceclient.Interface,
 	params workerExecutionParameters,
-	env *hostEnvImpl,
+	registry *registry,
 	activityProvider activityProvider,
 ) ActivityTaskHandler {
 	return &activityTaskHandlerImpl{
@@ -1598,7 +1598,7 @@ func newActivityTaskHandlerWithCustomProvider(
 		logger:             params.Logger,
 		metricsScope:       metrics.NewTaggedScope(params.MetricsScope),
 		userContext:        params.UserContext,
-		hostEnv:            env,
+		registry:           registry,
 		activityProvider:   activityProvider,
 		dataConverter:      params.DataConverter,
 		workerStopCh:       params.WorkerStopChannel,
@@ -1828,7 +1828,7 @@ func (ath *activityTaskHandlerImpl) getActivity(name string) activity {
 		return ath.activityProvider(name)
 	}
 
-	if a, ok := ath.hostEnv.getActivity(name); ok {
+	if a, ok := ath.registry.getActivity(name); ok {
 		return a
 	}
 
@@ -1836,7 +1836,7 @@ func (ath *activityTaskHandlerImpl) getActivity(name string) activity {
 }
 
 func (ath *activityTaskHandlerImpl) getRegisteredActivityNames() (activityNames []string) {
-	for _, a := range ath.hostEnv.getRegisteredActivities() {
+	for _, a := range ath.registry.getRegisteredActivities() {
 		activityNames = append(activityNames, a.ActivityType().Name)
 	}
 	return

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -289,7 +289,7 @@ func (t *TaskHandlersTestSuite) testWorkflowTaskWorkflowExecutionStartedHelper(p
 		createTestEventWorkflowExecutionStarted(1, &s.WorkflowExecutionStartedEventAttributes{TaskList: &s.TaskList{Name: &testWorkflowTaskTasklist}}),
 	}
 	task := createWorkflowTask(testEvents, 0, "HelloWorld_Workflow")
-	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
@@ -345,7 +345,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_BinaryChecksum() {
 		Identity: "test-id-1",
 		Logger:   t.logger,
 	}
-	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 
@@ -385,7 +385,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_ActivityTaskScheduled() {
 		Identity: "test-id-1",
 		Logger:   t.logger,
 	}
-	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 
@@ -431,7 +431,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_Sticky() {
 		Identity: "test-id-1",
 		Logger:   t.logger,
 	}
-	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 
 	// first make progress on the workflow
 	task := createWorkflowTask(testEvents[0:1], 0, "HelloWorld_Workflow")
@@ -479,30 +479,30 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_NonSticky() {
 
 	// query after first decision task (notice the previousStartEventID is always the last eventID for query task)
 	task := createQueryTask(testEvents[0:3], 3, "HelloWorld_Workflow", queryType)
-	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	response, _ := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.verifyQueryResult(response, "waiting-activity-result")
 
 	// query after activity task complete but before second decision task started
 	task = createQueryTask(testEvents[0:7], 7, "HelloWorld_Workflow", queryType)
-	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	response, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.verifyQueryResult(response, "waiting-activity-result")
 
 	// query after second decision task
 	task = createQueryTask(testEvents[0:8], 8, "HelloWorld_Workflow", queryType)
-	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	response, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.verifyQueryResult(response, "done")
 
 	// query after second decision task with extra events
 	task = createQueryTask(testEvents[0:9], 9, "HelloWorld_Workflow", queryType)
-	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	response, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.verifyQueryResult(response, "done")
 
 	task = createQueryTask(testEvents[0:9], 9, "HelloWorld_Workflow", "invalid-query-type")
-	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler = newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	response, _ = taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.NotNil(response)
 	queryResp, ok := response.(*s.RespondQueryTaskCompletedRequest)
@@ -544,7 +544,7 @@ func (t *TaskHandlersTestSuite) TestCacheEvictionWhenErrorOccurs() {
 		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
 	}
 
-	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	// now change the history event so it does not match to decision produced via replay
 	testEvents[4].ActivityTaskScheduledEventAttributes.ActivityType.Name = common.StringPtr("some-other-activity")
 	task := createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
@@ -579,7 +579,7 @@ func (t *TaskHandlersTestSuite) TestWithMissingHistoryEvents() {
 	}
 
 	for _, startEventID := range []int64{0, 3} {
-		taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+		taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 		task := createWorkflowTask(testEvents, startEventID, "HelloWorld_Workflow")
 		// newWorkflowTaskWorkerInternal will set the laTunnel in taskHandler, without it, ProcessWorkflowTask()
 		// will fail as it can't find laTunnel in getWorkflowCache().
@@ -630,7 +630,7 @@ func (t *TaskHandlersTestSuite) TestWithTruncatedHistory() {
 	}
 
 	for i, tc := range testCases {
-		taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+		taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 		task := createWorkflowTask(testEvents, tc.previousStartedEventID, "HelloWorld_Workflow")
 		task.StartedEventId = common.Int64Ptr(tc.startedEventID)
 		// newWorkflowTaskWorkerInternal will set the laTunnel in taskHandler, without it, ProcessWorkflowTask()
@@ -694,7 +694,7 @@ func (t *TaskHandlersTestSuite) testSideEffectDeferHelper(disableSticky bool) {
 		DisableStickyExecution: disableSticky,
 	}
 
-	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	task := createWorkflowTask(testEvents, 0, workflowName)
 	_, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.Nil(err)
@@ -737,7 +737,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 		WorkerStopChannel:              stopC,
 	}
 
-	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	// there should be no error as the history events matched the decisions.
@@ -758,7 +758,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	// now, create a new task handler with fail nondeterministic workflow policy
 	// and verify that it handles the mismatching history correctly.
 	params.NonDeterministicWorkflowPolicy = NonDeterministicWorkflowPolicyFailWorkflow
-	failOnNondeterminismTaskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	failOnNondeterminismTaskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	task = createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
 	request, err = failOnNondeterminismTaskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	// When FailWorkflow policy is set, task handler does not return an error,
@@ -798,7 +798,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowReturnsPanicError() {
 		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
 	}
 
-	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.NoError(err)
 	t.NotNil(request)
@@ -826,7 +826,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowPanics() {
 		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
 	}
 
-	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.NoError(err)
 	t.NotNil(request)
@@ -878,7 +878,7 @@ func (t *TaskHandlersTestSuite) TestGetWorkflowInfo() {
 		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
 	}
 
-	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	t.NoError(err)
 	t.NotNil(request)
@@ -910,7 +910,7 @@ func (t *TaskHandlersTestSuite) TestConsistentQuery_InvalidQueryTask() {
 		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
 	}
 
-	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	task := createWorkflowTask(nil, 3, "HelloWorld_Workflow")
 	task.Query = &s.WorkflowQuery{}
 	task.Queries = map[string]*s.WorkflowQuery{"query_id": {}}
@@ -959,7 +959,7 @@ func (t *TaskHandlersTestSuite) TestConsistentQuery_Success() {
 		Logger:   t.logger,
 	}
 
-	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
@@ -1023,7 +1023,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_CancelActivityBeforeSent() {
 		Identity: "test-id-1",
 		Logger:   t.logger,
 	}
-	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
@@ -1058,7 +1058,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_PageToken() {
 			return &s.History{nextEvents}, nil, nil
 		},
 	}
-	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task, historyIterator: historyIterator}, nil)
 	response := request.(*s.RespondDecisionTaskCompletedRequest)
 	t.NoError(err)
@@ -1116,7 +1116,7 @@ func (t *TaskHandlersTestSuite) TestLocalActivityRetry_DecisionHeartbeatFail() {
 	}
 	defer close(stopCh)
 
-	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	laTunnel := newLocalActivityTunnel(params.WorkerStopChannel)
 	taskHandlerImpl, ok := taskHandler.(*workflowTaskHandlerImpl)
 	t.True(ok)
@@ -1268,8 +1268,8 @@ func (t *TaskHandlersTestSuite) TestActivityExecutionDeadline() {
 		{time.Duration(1 * time.Second), time.Now(), 1, time.Now(), 2, context.DeadlineExceeded},
 	}
 	a := &testActivityDeadline{logger: t.logger}
-	hostEnv := getHostEnvironment()
-	hostEnv.addActivity(a.ActivityType().Name, a)
+	registry := getGlobalRegistry()
+	registry.addActivity(a.ActivityType().Name, a)
 
 	mockCtrl := gomock.NewController(t.T())
 	mockService := workflowservicetest.NewMockClient(mockCtrl)
@@ -1281,7 +1281,7 @@ func (t *TaskHandlersTestSuite) TestActivityExecutionDeadline() {
 			DataConverter: getDefaultDataConverter(),
 			Tracer:        opentracing.NoopTracer{},
 		}
-		activityHandler := newActivityTaskHandler(mockService, wep, hostEnv)
+		activityHandler := newActivityTaskHandler(mockService, wep, registry)
 		pats := &s.PollForActivityTaskResponse{
 			TaskToken: []byte("token"),
 			WorkflowExecution: &s.WorkflowExecution{
@@ -1322,8 +1322,8 @@ func activityWithWorkerStop(ctx context.Context) error {
 
 func (t *TaskHandlersTestSuite) TestActivityExecutionWorkerStop() {
 	a := &testActivityDeadline{logger: t.logger}
-	hostEnv := getHostEnvironment()
-	hostEnv.addActivityFn(a.ActivityType().Name, activityWithWorkerStop)
+	registry := getGlobalRegistry()
+	registry.addActivityFn(a.ActivityType().Name, activityWithWorkerStop)
 
 	mockCtrl := gomock.NewController(t.T())
 	mockService := workflowservicetest.NewMockClient(mockCtrl)
@@ -1336,7 +1336,7 @@ func (t *TaskHandlersTestSuite) TestActivityExecutionWorkerStop() {
 		UserContextCancel: cancel,
 		WorkerStopChannel: workerStopCh,
 	}
-	activityHandler := newActivityTaskHandler(mockService, wep, hostEnv)
+	activityHandler := newActivityTaskHandler(mockService, wep, registry)
 	pats := &s.PollForActivityTaskResponse{
 		TaskToken: []byte("token"),
 		WorkflowExecution: &s.WorkflowExecution{

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -75,9 +75,6 @@ const (
 	testTagsContextKey = "cadence-testTags"
 )
 
-// Assert that structs do indeed implement the interfaces
-var _ Worker = (*aggregatedWorker)(nil)
-
 type (
 	// WorkflowWorker wraps the code for hosting workflow types.
 	// And worker is mapped 1:1 with task list. If the user want's to poll multiple
@@ -109,8 +106,8 @@ type (
 	// activities within a session. The creationWorker polls from a global tasklist,
 	// while the activityWorker polls from a resource specific tasklist.
 	sessionWorker struct {
-		creationWorker Worker
-		activityWorker Worker
+		creationWorker *activityWorker
+		activityWorker *activityWorker
 	}
 
 	// Worker overrides.
@@ -200,9 +197,9 @@ func newWorkflowWorker(
 	domain string,
 	params workerExecutionParameters,
 	ppMgr pressurePointMgr,
-	hostEnv *hostEnvImpl,
-) Worker {
-	return newWorkflowWorkerInternal(service, domain, params, ppMgr, nil, hostEnv)
+	registry *registry,
+) *workflowWorker {
+	return newWorkflowWorkerInternal(service, domain, params, ppMgr, nil, registry)
 }
 
 func ensureRequiredParams(params *workerExecutionParameters) {
@@ -267,8 +264,8 @@ func newWorkflowWorkerInternal(
 	params workerExecutionParameters,
 	ppMgr pressurePointMgr,
 	overrides *workerOverrides,
-	hostEnv *hostEnvImpl,
-) Worker {
+	registry *registry,
+) *workflowWorker {
 	workerStopChannel := make(chan struct{})
 	params.WorkerStopChannel = getReadOnlyChannel(workerStopChannel)
 	// Get a workflow task handler.
@@ -277,7 +274,7 @@ func newWorkflowWorkerInternal(
 	if overrides != nil && overrides.workflowTaskHandler != nil {
 		taskHandler = overrides.workflowTaskHandler
 	} else {
-		taskHandler = newWorkflowTaskHandler(domain, params, ppMgr, hostEnv)
+		taskHandler = newWorkflowTaskHandler(domain, params, ppMgr, registry)
 	}
 	return newWorkflowTaskWorkerInternal(taskHandler, service, domain, params, workerStopChannel)
 }
@@ -288,7 +285,7 @@ func newWorkflowTaskWorkerInternal(
 	domain string,
 	params workerExecutionParameters,
 	stopC chan struct{},
-) Worker {
+) *workflowWorker {
 	ensureRequiredParams(&params)
 	poller := newWorkflowTaskPoller(
 		taskHandler,
@@ -381,9 +378,9 @@ func newSessionWorker(service workflowserviceclient.Interface,
 	domain string,
 	params workerExecutionParameters,
 	overrides *workerOverrides,
-	env *hostEnvImpl,
+	env *registry,
 	maxConcurrentSessionExecutionSize int,
-) Worker {
+) *sessionWorker {
 	if params.Identity == "" {
 		params.Identity = getWorkerIdentity(params.TaskList)
 	}
@@ -440,9 +437,9 @@ func newActivityWorker(
 	domain string,
 	params workerExecutionParameters,
 	overrides *workerOverrides,
-	env *hostEnvImpl,
+	env *registry,
 	sessionTokenBucket *sessionTokenBucket,
-) Worker {
+) *activityWorker {
 	workerStopChannel := make(chan struct{}, 1)
 	params.WorkerStopChannel = getReadOnlyChannel(workerStopChannel)
 	ensureRequiredParams(&params)
@@ -464,7 +461,7 @@ func newActivityTaskWorker(
 	workerParams workerExecutionParameters,
 	sessionTokenBucket *sessionTokenBucket,
 	stopC chan struct{},
-) (worker Worker) {
+) (worker *activityWorker) {
 	ensureRequiredParams(&workerParams)
 
 	poller := newActivityTaskPoller(
@@ -527,27 +524,27 @@ func (aw *activityWorker) Stop() {
 	aw.worker.Stop()
 }
 
-// hostEnvImpl is the implementation of hostEnv
-type hostEnvImpl struct {
+type registry struct {
 	sync.Mutex
 	workflowFuncMap  map[string]interface{}
 	workflowAliasMap map[string]string
 	activityFuncMap  map[string]activity
 	activityAliasMap map[string]string
+	next             *registry // Allows to chain registries
 }
 
-func (th *hostEnvImpl) RegisterWorkflow(af interface{}) error {
-	return th.RegisterWorkflowWithOptions(af, RegisterWorkflowOptions{})
+func (r *registry) RegisterWorkflow(af interface{}) {
+	r.RegisterWorkflowWithOptions(af, RegisterWorkflowOptions{})
 }
 
-func (th *hostEnvImpl) RegisterWorkflowWithOptions(
+func (r *registry) RegisterWorkflowWithOptions(
 	af interface{},
 	options RegisterWorkflowOptions,
-) error {
+) {
 	// Validate that it is a function
 	fnType := reflect.TypeOf(af)
 	if err := validateFnFormat(fnType, true); err != nil {
-		return err
+		panic(err)
 	}
 	fnName := getFunctionName(af)
 	alias := options.Name
@@ -555,29 +552,33 @@ func (th *hostEnvImpl) RegisterWorkflowWithOptions(
 	if len(alias) > 0 {
 		registerName = alias
 	}
-	// Check if already registered
-	if _, ok := th.getWorkflowFn(registerName); ok {
-		return fmt.Errorf("workflow name \"%v\" is already registered", registerName)
+	if !options.DisableAlreadyRegisteredCheck {
+		if _, ok := r.workflowFuncMap[registerName]; ok {
+			panic(fmt.Sprintf("workflow name \"%v\" is already registered", registerName))
+		}
 	}
-	th.addWorkflowFn(registerName, af)
+	r.addWorkflowFn(registerName, af)
 	if len(alias) > 0 {
-		th.addWorkflowAlias(fnName, alias)
+		r.addWorkflowAlias(fnName, alias)
 	}
-	return nil
 }
 
-func (th *hostEnvImpl) RegisterActivity(af interface{}) error {
-	return th.RegisterActivityWithOptions(af, RegisterActivityOptions{})
+func (r *registry) RegisterActivity(af interface{}) {
+	r.RegisterActivityWithOptions(af, RegisterActivityOptions{})
 }
 
-func (th *hostEnvImpl) RegisterActivityWithOptions(
+func (r *registry) RegisterActivityWithOptions(
 	af interface{},
 	options RegisterActivityOptions,
-) error {
+) {
 	// Validate that it is a function
 	fnType := reflect.TypeOf(af)
+	if fnType.Kind() == reflect.Ptr && fnType.Elem().Kind() == reflect.Struct {
+		r.registerActivityStructWithOptions(af, options)
+		return
+	}
 	if err := validateFnFormat(fnType, false); err != nil {
-		return err
+		panic(err)
 	}
 	fnName := getFunctionName(af)
 	alias := options.Name
@@ -585,96 +586,155 @@ func (th *hostEnvImpl) RegisterActivityWithOptions(
 	if len(alias) > 0 {
 		registerName = alias
 	}
-	// Check if already registered
-	if _, ok := th.getActivityFn(registerName); ok {
-		return fmt.Errorf("activity type \"%v\" is already registered", registerName)
+	if !options.DisableAlreadyRegisteredCheck {
+		if _, ok := r.activityFuncMap[registerName]; ok {
+			panic(fmt.Sprintf("activity type \"%v\" is already registered", registerName))
+		}
 	}
-	th.addActivityFn(registerName, af)
+	r.addActivityFn(registerName, af)
 	if len(alias) > 0 {
-		th.addActivityAlias(fnName, alias)
+		r.addActivityAlias(fnName, alias)
+	}
+}
+
+func (r *registry) registerActivityStructWithOptions(aStruct interface{}, options RegisterActivityOptions) error {
+	structValue := reflect.ValueOf(aStruct)
+	structType := structValue.Type()
+	count := 0
+	for i := 0; i < structValue.NumMethod(); i++ {
+		methodValue := structValue.Method(i)
+		method := structType.Method(i)
+		// skip private method
+		if method.PkgPath != "" {
+			continue
+		}
+		name := method.Name
+		if err := validateFnFormat(method.Type, false); err != nil {
+			return fmt.Errorf("method %v of %v: %e", name, structType.Name(), err)
+		}
+		prefix := options.Name
+		registerName := name
+		if len(prefix) == 0 {
+			prefix = structType.Elem().Name() + "_"
+		}
+		registerName = prefix + name
+		if !options.DisableAlreadyRegisteredCheck {
+			if _, ok := r.getActivityFn(registerName); ok {
+				return fmt.Errorf("activity type \"%v\" is already registered", registerName)
+			}
+		}
+		r.addActivityFn(registerName, methodValue.Interface())
+		count++
+	}
+	if count == 0 {
+		return fmt.Errorf("no activities (public methods) found at %v structure", structType.Name())
 	}
 	return nil
 }
 
-func (th *hostEnvImpl) addWorkflowAlias(fnName string, alias string) {
-	th.Lock()
-	defer th.Unlock()
-	th.workflowAliasMap[fnName] = alias
+func (r *registry) addWorkflowAlias(fnName string, alias string) {
+	r.Lock()
+	defer r.Unlock()
+	r.workflowAliasMap[fnName] = alias
 }
 
-func (th *hostEnvImpl) getWorkflowAlias(fnName string) (string, bool) {
-	th.Lock()
-	defer th.Unlock()
-	alias, ok := th.workflowAliasMap[fnName]
+func (r *registry) getWorkflowAlias(fnName string) (string, bool) {
+	r.Lock() // do not defer for Unlock to call next.getWorkflowAlias without lock
+	alias, ok := r.workflowAliasMap[fnName]
+	if !ok && r.next != nil {
+		r.Unlock()
+		return r.next.getWorkflowAlias(fnName)
+	}
+	r.Unlock()
 	return alias, ok
 }
 
-func (th *hostEnvImpl) addWorkflowFn(fnName string, wf interface{}) {
-	th.Lock()
-	defer th.Unlock()
-	th.workflowFuncMap[fnName] = wf
+func (r *registry) addWorkflowFn(fnName string, wf interface{}) {
+	r.Lock()
+	defer r.Unlock()
+	r.workflowFuncMap[fnName] = wf
 }
 
-func (th *hostEnvImpl) getWorkflowFn(fnName string) (interface{}, bool) {
-	th.Lock()
-	defer th.Unlock()
-	fn, ok := th.workflowFuncMap[fnName]
+func (r *registry) getWorkflowFn(fnName string) (interface{}, bool) {
+	r.Lock() // do not defer for Unlock to call next.getWorkflowFn without lock
+	fn, ok := r.workflowFuncMap[fnName]
+	if !ok && r.next != nil {
+		r.Unlock()
+		return r.next.getWorkflowFn(fnName)
+	}
+	r.Unlock()
 	return fn, ok
 }
 
-func (th *hostEnvImpl) getRegisteredWorkflowTypes() []string {
-	th.Lock()
-	defer th.Unlock()
-	var r []string
-	for t := range th.workflowFuncMap {
-		r = append(r, t)
+func (r *registry) getRegisteredWorkflowTypes() []string {
+	r.Lock() // do not defer for Unlock to call next.getRegisteredWorkflowTypes without lock
+	var result []string
+	for t := range r.workflowFuncMap {
+		result = append(result, t)
 	}
-	return r
+	r.Unlock()
+	if r.next != nil {
+		nextTypes := r.next.getRegisteredWorkflowTypes()
+		result = append(result, nextTypes...)
+	}
+	return result
 }
 
-func (th *hostEnvImpl) addActivityAlias(fnName string, alias string) {
-	th.Lock()
-	defer th.Unlock()
-	th.activityAliasMap[fnName] = alias
+func (r *registry) addActivityAlias(fnName string, alias string) {
+	r.Lock()
+	defer r.Unlock()
+	r.activityAliasMap[fnName] = alias
 }
 
-func (th *hostEnvImpl) getActivityAlias(fnName string) (string, bool) {
-	th.Lock()
-	defer th.Unlock()
-	alias, ok := th.activityAliasMap[fnName]
+func (r *registry) getActivityAlias(fnName string) (string, bool) {
+	r.Lock() // do not defer for Unlock to call next.getActivityAlias without lock
+	alias, ok := r.activityAliasMap[fnName]
+	if !ok && r.next != nil {
+		r.Unlock()
+		return r.next.getActivityAlias(fnName)
+	}
+	r.Unlock()
 	return alias, ok
 }
 
-func (th *hostEnvImpl) addActivity(fnName string, a activity) {
-	th.Lock()
-	defer th.Unlock()
-	th.activityFuncMap[fnName] = a
+func (r *registry) addActivity(fnName string, a activity) {
+	r.Lock()
+	defer r.Unlock()
+	r.activityFuncMap[fnName] = a
 }
 
-func (th *hostEnvImpl) addActivityFn(fnName string, af interface{}) {
-	th.addActivity(fnName, &activityExecutor{fnName, af})
+func (r *registry) addActivityFn(fnName string, af interface{}) {
+	r.addActivity(fnName, &activityExecutor{fnName, af})
 }
 
-func (th *hostEnvImpl) getActivity(fnName string) (activity, bool) {
-	th.Lock()
-	defer th.Unlock()
-	a, ok := th.activityFuncMap[fnName]
+func (r *registry) getActivity(fnName string) (activity, bool) {
+	r.Lock() // do not defer for Unlock to call next.getActivity without lock
+	a, ok := r.activityFuncMap[fnName]
+	if !ok && r.next != nil {
+		r.Unlock()
+		return r.next.getActivity(fnName)
+	}
+	r.Unlock()
 	return a, ok
 }
 
-func (th *hostEnvImpl) getActivityFn(fnName string) (interface{}, bool) {
-	if a, ok := th.getActivity(fnName); ok {
+func (r *registry) getActivityFn(fnName string) (interface{}, bool) {
+	if a, ok := r.getActivity(fnName); ok {
 		return a.GetFunction(), ok
 	}
 	return nil, false
 }
 
-func (th *hostEnvImpl) getRegisteredActivities() []activity {
-	th.Lock()
-	defer th.Unlock()
-	activities := make([]activity, 0, len(th.activityFuncMap))
-	for _, a := range th.activityFuncMap {
+func (r *registry) getRegisteredActivities() []activity {
+	r.Lock() // do not defer for Unlock to call next.getRegisteredActivities without lock
+	activities := make([]activity, 0, len(r.activityFuncMap))
+	for _, a := range r.activityFuncMap {
 		activities = append(activities, a)
+	}
+	r.Unlock()
+	if r.next != nil {
+		nextActivities := r.next.getRegisteredActivities()
+		activities = append(activities, nextActivities...)
 	}
 	return activities
 }
@@ -712,18 +772,18 @@ func isUseThriftDecoding(objs []interface{}) bool {
 	return true
 }
 
-func (th *hostEnvImpl) getWorkflowDefinition(wt WorkflowType) (workflowDefinition, error) {
+func (r *registry) getWorkflowDefinition(wt WorkflowType) (workflowDefinition, error) {
 	lookup := wt.Name
-	if alias, ok := th.getWorkflowAlias(lookup); ok {
+	if alias, ok := r.getWorkflowAlias(lookup); ok {
 		lookup = alias
 	}
-	wf, ok := th.getWorkflowFn(lookup)
+	wf, ok := r.getWorkflowFn(lookup)
 	if !ok {
-		supported := strings.Join(th.getRegisteredWorkflowTypes(), ", ")
+		supported := strings.Join(r.getRegisteredWorkflowTypes(), ", ")
 		return nil, fmt.Errorf("unable to find workflow type: %v. Supported types: [%v]", lookup, supported)
 	}
 	wd := &workflowExecutor{name: lookup, fn: wf}
-	return newWorkflowDefinition(wd), nil
+	return newSyncWorkflowDefinition(wd), nil
 }
 
 // Validate function parameters.
@@ -846,20 +906,21 @@ func isTypeByteSlice(inType reflect.Type) bool {
 var once sync.Once
 
 // Singleton to hold the host registration details.
-var thImpl *hostEnvImpl
+var thImpl *registry
 
-func newHostEnvironment() *hostEnvImpl {
-	return &hostEnvImpl{
+func newRegistry(next *registry) *registry {
+	return &registry{
 		workflowFuncMap:  make(map[string]interface{}),
 		workflowAliasMap: make(map[string]string),
 		activityFuncMap:  make(map[string]activity),
 		activityAliasMap: make(map[string]string),
+		next:             next,
 	}
 }
 
-func getHostEnvironment() *hostEnvImpl {
+func getGlobalRegistry() *registry {
 	once.Do(func() {
-		thImpl = newHostEnvironment()
+		thImpl = newRegistry(nil)
 	})
 	return thImpl
 }
@@ -981,11 +1042,27 @@ func getDataConverterFromActivityCtx(ctx context.Context) DataConverter {
 
 // aggregatedWorker combines management of both workflowWorker and activityWorker worker lifecycle.
 type aggregatedWorker struct {
-	workflowWorker Worker
-	activityWorker Worker
-	sessionWorker  Worker
+	workflowWorker *workflowWorker
+	activityWorker *activityWorker
+	sessionWorker  *sessionWorker
 	logger         *zap.Logger
-	hostEnv        *hostEnvImpl
+	registry       *registry
+}
+
+func (aw *aggregatedWorker) RegisterWorkflow(w interface{}) {
+	aw.registry.RegisterWorkflow(w)
+}
+
+func (aw *aggregatedWorker) RegisterWorkflowWithOptions(w interface{}, options RegisterWorkflowOptions) {
+	aw.registry.RegisterWorkflowWithOptions(w, options)
+}
+
+func (aw *aggregatedWorker) RegisterActivity(a interface{}) {
+	aw.registry.RegisterActivity(a)
+}
+
+func (aw *aggregatedWorker) RegisterActivityWithOptions(a interface{}, options RegisterActivityOptions) {
+	aw.registry.RegisterActivityWithOptions(a, options)
 }
 
 func (aw *aggregatedWorker) Start() error {
@@ -994,7 +1071,7 @@ func (aw *aggregatedWorker) Start() error {
 	}
 
 	if !isInterfaceNil(aw.workflowWorker) {
-		if len(aw.hostEnv.getRegisteredWorkflowTypes()) == 0 {
+		if len(aw.registry.getRegisteredWorkflowTypes()) == 0 {
 			aw.logger.Warn(
 				"Starting worker without any workflows. Workflows must be registered before start.",
 			)
@@ -1004,7 +1081,7 @@ func (aw *aggregatedWorker) Start() error {
 		}
 	}
 	if !isInterfaceNil(aw.activityWorker) {
-		if len(aw.hostEnv.getRegisteredActivities()) == 0 {
+		if len(aw.registry.getRegisteredActivities()) == 0 {
 			aw.logger.Warn(
 				"Starting worker without any activities. Activities must be registered before start.",
 			)
@@ -1126,7 +1203,7 @@ func newAggregatedWorker(
 	domain string,
 	taskList string,
 	options WorkerOptions,
-) (worker Worker) {
+) (worker *aggregatedWorker) {
 	wOptions := augmentWorkerOptions(options)
 	ctx := wOptions.BackgroundActivityContext
 	if ctx == nil {
@@ -1172,9 +1249,10 @@ func newAggregatedWorker(
 
 	processTestTags(&wOptions, &workerParams)
 
-	hostEnv := getHostEnvironment()
+	// worker specific registry
+	registry := newRegistry(getGlobalRegistry())
 	// workflow factory.
-	var workflowWorker Worker
+	var workflowWorker *workflowWorker
 	if !wOptions.DisableWorkflowWorker {
 		testTags := getTestTags(wOptions.BackgroundActivityContext)
 		if testTags != nil && len(testTags) > 0 {
@@ -1183,7 +1261,7 @@ func newAggregatedWorker(
 				domain,
 				workerParams,
 				testTags,
-				hostEnv,
+				registry,
 			)
 		} else {
 			workflowWorker = newWorkflowWorker(
@@ -1191,13 +1269,13 @@ func newAggregatedWorker(
 				domain,
 				workerParams,
 				nil,
-				hostEnv,
+				registry,
 			)
 		}
 	}
 
 	// activity types.
-	var activityWorker Worker
+	var activityWorker *activityWorker
 
 	if !wOptions.DisableActivityWorker {
 		activityWorker = newActivityWorker(
@@ -1205,19 +1283,19 @@ func newAggregatedWorker(
 			domain,
 			workerParams,
 			nil,
-			hostEnv,
+			registry,
 			nil,
 		)
 	}
 
-	var sessionWorker Worker
+	var sessionWorker *sessionWorker
 	if wOptions.EnableSessionWorker {
 		sessionWorker = newSessionWorker(
 			service,
 			domain,
 			workerParams,
 			nil,
-			hostEnv,
+			registry,
 			wOptions.MaxConcurrentSessionExecutionSize,
 		)
 	}
@@ -1227,7 +1305,7 @@ func newAggregatedWorker(
 		activityWorker: activityWorker,
 		sessionWorker:  sessionWorker,
 		logger:         logger,
-		hostEnv:        hostEnv,
+		registry:       registry,
 	}
 }
 

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -87,6 +87,7 @@ type (
 		RemoveSession(sessionID string)
 		GetContextPropagators() []ContextPropagator
 		UpsertSearchAttributes(attributes map[string]interface{}) error
+		GetRegistry() *registry
 	}
 
 	// WorkflowDefinition wraps the code that can execute a workflow.

--- a/internal/internal_worker_interfaces_test.go
+++ b/internal/internal_worker_interfaces_test.go
@@ -197,9 +197,9 @@ func (s *InterfacesTestSuite) TestInterface() {
 	s.service.EXPECT().RespondDecisionTaskCompleted(gomock.Any(), gomock.Any(), callOptions...).Return(nil, nil).AnyTimes()
 	s.service.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any(), callOptions...).Return(&m.StartWorkflowExecutionResponse{}, nil).AnyTimes()
 
-	env := getHostEnvironment()
+	registry := getGlobalRegistry()
 	// Launch worker.
-	workflowWorker := newWorkflowWorker(s.service, domain, workflowExecutionParameters, nil, env)
+	workflowWorker := newWorkflowWorker(s.service, domain, workflowExecutionParameters, nil, registry)
 	defer workflowWorker.Stop()
 	workflowWorker.Start()
 
@@ -213,7 +213,7 @@ func (s *InterfacesTestSuite) TestInterface() {
 	}
 
 	// Register activity instances and launch the worker.
-	activityWorker := newActivityWorker(s.service, domain, activityExecutionParameters, nil, env, nil)
+	activityWorker := newActivityWorker(s.service, domain, activityExecutionParameters, nil, registry, nil)
 	defer activityWorker.Stop()
 	activityWorker.Start()
 

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -341,7 +341,7 @@ func (s *internalWorkerTestSuite) testDecisionTaskHandlerHelper(params workerExe
 		PreviousStartedEventId: common.Int64Ptr(0),
 	}
 
-	r := newWorkflowTaskHandler(testDomain, params, nil, getHostEnvironment())
+	r := newWorkflowTaskHandler(testDomain, params, nil, getGlobalRegistry())
 	_, err := r.ProcessWorkflowTask(&workflowTask{task: task}, nil)
 	s.NoError(err)
 }
@@ -420,11 +420,10 @@ func (s *internalWorkerTestSuite) TestCreateWorkerRun() {
 func (s *internalWorkerTestSuite) TestNoActivitiesOrWorkflows() {
 	t := s.T()
 	w := createWorker(s.service)
-	aw := w.(*aggregatedWorker)
-	aw.hostEnv = newHostEnvironment()
-	assert.Empty(t, aw.hostEnv.getRegisteredActivities())
-	assert.Empty(t, aw.hostEnv.getRegisteredWorkflowTypes())
-	assert.NoError(t, aw.Start())
+	w.registry = newRegistry(nil)
+	assert.Empty(t, w.registry.getRegisteredActivities())
+	assert.Empty(t, w.registry.getRegisteredWorkflowTypes())
+	assert.NoError(t, w.Start())
 }
 
 func (s *internalWorkerTestSuite) TestWorkerStartFailsWithInvalidDomain() {
@@ -488,13 +487,13 @@ func (m *mockPollForActivityTaskRequest) String() string {
 	return "PollForActivityTaskRequest"
 }
 
-func createWorker(service *workflowservicetest.MockClient) Worker {
+func createWorker(service *workflowservicetest.MockClient) *aggregatedWorker {
 	return createWorkerWithThrottle(service, float64(0.0), nil)
 }
 
 func createWorkerWithThrottle(
 	service *workflowservicetest.MockClient, activitiesPerSecond float64, dc DataConverter,
-) Worker {
+) *aggregatedWorker {
 	domain := "testDomain"
 	domainStatus := shared.DomainStatusRegistered
 	domainDesc := &shared.DescribeDomainResponse{
@@ -541,7 +540,7 @@ func createWorkerWithThrottle(
 	return worker
 }
 
-func createWorkerWithDataConverter(service *workflowservicetest.MockClient) Worker {
+func createWorkerWithDataConverter(service *workflowservicetest.MockClient) *aggregatedWorker {
 	return createWorkerWithThrottle(service, float64(0.0), newTestDataConverter())
 }
 
@@ -920,9 +919,9 @@ func testActivityErrorWithDetailsHelper(ctx context.Context, t *testing.T, dataC
 		fn: func(arg1 int) (err error) {
 			return NewCustomError("testReason", "testStringDetails")
 		}}
-
+	registry := getGlobalRegistry()
 	encResult, e := a1.Execute(ctx, testEncodeFunctionArgs(dataConverter, a1.fn, 1))
-	err := deSerializeFunctionResult(a1.fn, encResult, nil, dataConverter)
+	err := deSerializeFunctionResult(a1.fn, encResult, nil, dataConverter, registry)
 	require.NoError(t, err)
 	require.Error(t, e)
 	errWD := e.(*CustomError)
@@ -937,7 +936,7 @@ func testActivityErrorWithDetailsHelper(ctx context.Context, t *testing.T, dataC
 			return NewCustomError("testReason", testErrorDetails{T: "testErrorStack"})
 		}}
 	encResult, e = a2.Execute(ctx, testEncodeFunctionArgs(dataConverter, a2.fn, 1))
-	err = deSerializeFunctionResult(a2.fn, encResult, nil, dataConverter)
+	err = deSerializeFunctionResult(a2.fn, encResult, nil, dataConverter, registry)
 	require.NoError(t, err)
 	require.Error(t, e)
 	errWD = e.(*CustomError)
@@ -953,7 +952,7 @@ func testActivityErrorWithDetailsHelper(ctx context.Context, t *testing.T, dataC
 		}}
 	encResult, e = a3.Execute(ctx, testEncodeFunctionArgs(dataConverter, a3.fn, 1))
 	var result string
-	err = deSerializeFunctionResult(a3.fn, encResult, &result, dataConverter)
+	err = deSerializeFunctionResult(a3.fn, encResult, &result, dataConverter, registry)
 	require.NoError(t, err)
 	require.Equal(t, "testResult", result)
 	require.Error(t, e)
@@ -968,7 +967,7 @@ func testActivityErrorWithDetailsHelper(ctx context.Context, t *testing.T, dataC
 			return "testResult4", NewCustomError("testReason", "testMultipleString", testErrorDetails{T: "testErrorStack4"})
 		}}
 	encResult, e = a4.Execute(ctx, testEncodeFunctionArgs(dataConverter, a4.fn, 1))
-	err = deSerializeFunctionResult(a3.fn, encResult, &result, dataConverter)
+	err = deSerializeFunctionResult(a3.fn, encResult, &result, dataConverter, registry)
 	require.NoError(t, err)
 	require.Equal(t, "testResult4", result)
 	require.Error(t, e)
@@ -991,13 +990,14 @@ func TestActivityErrorWithDetails_WithDataConverter(t *testing.T) {
 }
 
 func testActivityCancelledErrorHelper(ctx context.Context, t *testing.T, dataConverter DataConverter) {
+	registry := getGlobalRegistry()
 	a1 := activityExecutor{
 		name: "test",
 		fn: func(arg1 int) (err error) {
 			return NewCanceledError("testCancelStringDetails")
 		}}
 	encResult, e := a1.Execute(ctx, testEncodeFunctionArgs(dataConverter, a1.fn, 1))
-	err := deSerializeFunctionResult(a1.fn, encResult, nil, dataConverter)
+	err := deSerializeFunctionResult(a1.fn, encResult, nil, dataConverter, registry)
 	require.NoError(t, err)
 	require.Error(t, e)
 	errWD := e.(*CanceledError)
@@ -1011,7 +1011,7 @@ func testActivityCancelledErrorHelper(ctx context.Context, t *testing.T, dataCon
 			return NewCanceledError(testErrorDetails{T: "testCancelErrorStack"})
 		}}
 	encResult, e = a2.Execute(ctx, testEncodeFunctionArgs(dataConverter, a2.fn, 1))
-	err = deSerializeFunctionResult(a2.fn, encResult, nil, dataConverter)
+	err = deSerializeFunctionResult(a2.fn, encResult, nil, dataConverter, registry)
 	require.NoError(t, err)
 	require.Error(t, e)
 	errWD = e.(*CanceledError)
@@ -1026,7 +1026,7 @@ func testActivityCancelledErrorHelper(ctx context.Context, t *testing.T, dataCon
 		}}
 	encResult, e = a3.Execute(ctx, testEncodeFunctionArgs(dataConverter, a2.fn, 1))
 	var r string
-	err = deSerializeFunctionResult(a3.fn, encResult, &r, dataConverter)
+	err = deSerializeFunctionResult(a3.fn, encResult, &r, dataConverter, registry)
 	require.NoError(t, err)
 	require.Equal(t, "testResult", r)
 	require.Error(t, e)
@@ -1040,7 +1040,7 @@ func testActivityCancelledErrorHelper(ctx context.Context, t *testing.T, dataCon
 			return "testResult4", NewCanceledError("testMultipleString", testErrorDetails{T: "testErrorStack4"})
 		}}
 	encResult, e = a4.Execute(ctx, testEncodeFunctionArgs(dataConverter, a2.fn, 1))
-	err = deSerializeFunctionResult(a3.fn, encResult, &r, dataConverter)
+	err = deSerializeFunctionResult(a3.fn, encResult, &r, dataConverter, registry)
 	require.NoError(t, err)
 	require.Equal(t, "testResult4", r)
 	require.Error(t, e)
@@ -1062,6 +1062,7 @@ func TestActivityCancelledError_WithDataConverter(t *testing.T) {
 }
 
 func testActivityExecutionVariousTypesHelper(ctx context.Context, t *testing.T, dataConverter DataConverter) {
+	registry := getGlobalRegistry()
 	a1 := activityExecutor{
 		fn: func(ctx context.Context, arg1 string) (*testWorkflowResult, error) {
 			return &testWorkflowResult{V: 1}, nil
@@ -1069,7 +1070,7 @@ func testActivityExecutionVariousTypesHelper(ctx context.Context, t *testing.T, 
 	encResult, e := a1.Execute(ctx, testEncodeFunctionArgs(dataConverter, a1.fn, "test"))
 	require.NoError(t, e)
 	var r *testWorkflowResult
-	err := deSerializeFunctionResult(a1.fn, encResult, &r, dataConverter)
+	err := deSerializeFunctionResult(a1.fn, encResult, &r, dataConverter, registry)
 	require.NoError(t, err)
 	require.Equal(t, 1, r.V)
 
@@ -1079,7 +1080,7 @@ func testActivityExecutionVariousTypesHelper(ctx context.Context, t *testing.T, 
 		}}
 	encResult, e = a2.Execute(ctx, testEncodeFunctionArgs(dataConverter, a2.fn, r))
 	require.NoError(t, e)
-	err = deSerializeFunctionResult(a2.fn, encResult, &r, dataConverter)
+	err = deSerializeFunctionResult(a2.fn, encResult, &r, dataConverter, registry)
 	require.NoError(t, err)
 	require.Equal(t, 2, r.V)
 }
@@ -1111,7 +1112,7 @@ func TestActivityNilArgs(t *testing.T) {
 	}
 
 	args := []interface{}{nil, nil, nil}
-	_, input, err := getValidatedActivityFunction(activityFn, args, nil)
+	_, input, err := getValidatedActivityFunction(activityFn, args, nil, getGlobalRegistry())
 	require.NoError(t, err)
 
 	reflectArgs, err := decodeArgs(nil, reflect.TypeOf(activityFn), input)
@@ -1131,19 +1132,15 @@ func TestActivityNilArgs_WithDataConverter(t *testing.T) {
 	}
 
 	args := []interface{}{nil, nil, nil}
-	_, _, err := getValidatedActivityFunction(activityFn, args, newTestDataConverter())
+	_, _, err := getValidatedActivityFunction(activityFn, args, newTestDataConverter(), getGlobalRegistry())
 	require.Error(t, err) // testDataConverter cannot encode nil value
 }
 
 func TestWorkerOptionDefaults(t *testing.T) {
 	domain := "worker-options-test"
 	taskList := "worker-options-tl"
-	worker := newAggregatedWorker(nil, domain, taskList, WorkerOptions{})
-	aggWorker, ok := worker.(*aggregatedWorker)
-	require.True(t, ok)
-
-	decisionWorker, ok := aggWorker.workflowWorker.(*workflowWorker)
-	require.True(t, ok)
+	aggWorker := newAggregatedWorker(nil, domain, taskList, WorkerOptions{})
+	decisionWorker := aggWorker.workflowWorker
 	require.True(t, decisionWorker.executionParameters.Identity != "")
 	require.NotNil(t, decisionWorker.executionParameters.Logger)
 	require.NotNil(t, decisionWorker.executionParameters.MetricsScope)
@@ -1171,8 +1168,7 @@ func TestWorkerOptionDefaults(t *testing.T) {
 
 	assertWorkerExecutionParamsEqual(t, expected, decisionWorker.executionParameters)
 
-	activityWorker, ok := aggWorker.activityWorker.(*activityWorker)
-	require.True(t, ok)
+	activityWorker := aggWorker.activityWorker
 	require.True(t, activityWorker.executionParameters.Identity != "")
 	require.NotNil(t, activityWorker.executionParameters.Logger)
 	require.NotNil(t, activityWorker.executionParameters.MetricsScope)
@@ -1204,13 +1200,9 @@ func TestWorkerOptionNonDefaults(t *testing.T) {
 		Tracer:                                  opentracing.NoopTracer{},
 	}
 
-	worker := newAggregatedWorker(nil, domain, taskList, options)
-	aggWorker, ok := worker.(*aggregatedWorker)
-	require.True(t, ok)
-
-	decisionWorker, ok := aggWorker.workflowWorker.(*workflowWorker)
+	aggWorker := newAggregatedWorker(nil, domain, taskList, options)
+	decisionWorker := aggWorker.workflowWorker
 	require.True(t, len(decisionWorker.executionParameters.ContextPropagators) > 0)
-	require.True(t, ok)
 
 	expected := workerExecutionParameters{
 		TaskList:                             taskList,
@@ -1233,8 +1225,7 @@ func TestWorkerOptionNonDefaults(t *testing.T) {
 
 	assertWorkerExecutionParamsEqual(t, expected, decisionWorker.executionParameters)
 
-	activityWorker, ok := aggWorker.activityWorker.(*activityWorker)
-	require.True(t, ok)
+	activityWorker := aggWorker.activityWorker
 	require.True(t, len(activityWorker.executionParameters.ContextPropagators) > 0)
 	assertWorkerExecutionParamsEqual(t, expected, activityWorker.executionParameters)
 }

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -102,7 +102,7 @@ func (s *WorkersTestSuite) TestWorkflowWorker() {
 	}
 	overrides := &workerOverrides{workflowTaskHandler: newSampleWorkflowTaskHandler()}
 	workflowWorker := newWorkflowWorkerInternal(
-		s.service, domain, executionParameters, nil, overrides, getHostEnvironment(),
+		s.service, domain, executionParameters, nil, overrides, getGlobalRegistry(),
 	)
 	workflowWorker.Start()
 	workflowWorker.Stop()
@@ -125,10 +125,10 @@ func (s *WorkersTestSuite) TestActivityWorker() {
 	}
 	overrides := &workerOverrides{activityTaskHandler: newSampleActivityTaskHandler()}
 	a := &greeterActivity{}
-	hostEnv := getHostEnvironment()
-	hostEnv.addActivity(a.ActivityType().Name, a)
+	registry := getGlobalRegistry()
+	registry.addActivity(a.ActivityType().Name, a)
 	activityWorker := newActivityWorker(
-		s.service, domain, executionParameters, overrides, hostEnv, nil,
+		s.service, domain, executionParameters, overrides, registry, nil,
 	)
 	activityWorker.Start()
 	activityWorker.Stop()
@@ -174,19 +174,16 @@ func (s *WorkersTestSuite) TestActivityWorkerStop() {
 	activityTaskHandler := newNoResponseActivityTaskHandler()
 	overrides := &workerOverrides{activityTaskHandler: activityTaskHandler}
 	a := &greeterActivity{}
-	hostEnv := getHostEnvironment()
-	hostEnv.addActivity(a.ActivityType().Name, a)
+	registry := getGlobalRegistry()
+	registry.addActivity(a.ActivityType().Name, a)
 	worker := newActivityWorker(
-		s.service, domain, executionParameters, overrides, hostEnv, nil,
+		s.service, domain, executionParameters, overrides, registry, nil,
 	)
 	worker.Start()
 	activityTaskHandler.BlockedOnExecuteCalled()
 	go worker.Stop()
 
-	activityWorker, ok := worker.(*activityWorker)
-	s.Equal(true, ok)
-
-	<-activityWorker.worker.shutdownCh
+	<-worker.worker.shutdownCh
 	err := ctx.Err()
 	s.NoError(err)
 
@@ -208,7 +205,7 @@ func (s *WorkersTestSuite) TestPollForDecisionTask_InternalServiceError() {
 	}
 	overrides := &workerOverrides{workflowTaskHandler: newSampleWorkflowTaskHandler()}
 	workflowWorker := newWorkflowWorkerInternal(
-		s.service, domain, executionParameters, nil, overrides, getHostEnvironment(),
+		s.service, domain, executionParameters, nil, overrides, getGlobalRegistry(),
 	)
 	workflowWorker.Start()
 	workflowWorker.Stop()

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -33,7 +33,6 @@ import (
 	"unicode"
 
 	"github.com/robfig/cron"
-	"github.com/uber-go/tally"
 	"go.uber.org/atomic"
 	"go.uber.org/cadence/.gen/go/shared"
 	s "go.uber.org/cadence/.gen/go/shared"
@@ -116,8 +115,7 @@ type (
 		closed          bool               // true if channel is closed.
 		recValue        *interface{}       // Used only while receiving value, this is used as pre-fetch buffer value from the channel.
 		dataConverter   DataConverter      // for decode data
-		scope           tally.Scope        // Used to send metrics
-		logger          *zap.Logger
+		env             workflowEnvironment
 	}
 
 	// Single case statement of the Select
@@ -728,8 +726,8 @@ func (c *channelImpl) assignValue(from interface{}, to interface{}) error {
 	err := decodeAndAssignValue(c.dataConverter, from, to)
 	//add to metrics
 	if err != nil {
-		c.logger.Error(fmt.Sprintf("Corrupt signal received on channel %s. Error deserializing", c.name), zap.Error(err))
-		c.scope.Counter(metrics.CorruptedSignalsCounter).Inc(1)
+		c.env.GetLogger().Error(fmt.Sprintf("Corrupt signal received on channel %s. Error deserializing", c.name), zap.Error(err))
+		c.env.GetMetricsScope().Counter(metrics.CorruptedSignalsCounter).Inc(1)
 	}
 	return err
 }
@@ -1077,11 +1075,11 @@ func (s *selectorImpl) Select(ctx Context) {
 }
 
 // NewWorkflowDefinition creates a WorkflowDefinition from a Workflow
-func newWorkflowDefinition(workflow workflow) workflowDefinition {
+func newSyncWorkflowDefinition(workflow workflow) *syncWorkflowDefinition {
 	return &syncWorkflowDefinition{workflow: workflow}
 }
 
-func getValidatedWorkflowFunction(workflowFunc interface{}, args []interface{}, dataConverter DataConverter) (*WorkflowType, []byte, error) {
+func getValidatedWorkflowFunction(workflowFunc interface{}, args []interface{}, dataConverter DataConverter, registry *registry) (*WorkflowType, []byte, error) {
 	fnName := ""
 	fType := reflect.TypeOf(workflowFunc)
 	switch getKind(fType) {
@@ -1093,7 +1091,7 @@ func getValidatedWorkflowFunction(workflowFunc interface{}, args []interface{}, 
 			return nil, nil, err
 		}
 		fnName = getFunctionName(workflowFunc)
-		if alias, ok := getHostEnvironment().getWorkflowAlias(fnName); ok {
+		if alias, ok := registry.getWorkflowAlias(fnName); ok {
 			fnName = alias
 		}
 
@@ -1187,6 +1185,11 @@ func getDataConverterFromWorkflowContext(ctx Context) DataConverter {
 	return options.dataConverter
 }
 
+func getRegistryFromWorkflowContext(ctx Context) *registry {
+	env := getWorkflowEnvironment(ctx)
+	return env.GetRegistry()
+}
+
 func getContextPropagatorsFromWorkflowContext(ctx Context) []ContextPropagator {
 	options := getWorkflowEnvOptions(ctx)
 	return options.contextPropagators
@@ -1243,7 +1246,7 @@ func (d *decodeFutureImpl) Get(ctx Context, value interface{}) error {
 		return errors.New("value parameter is not a pointer")
 	}
 
-	err := deSerializeFunctionResult(d.fn, d.futureImpl.value.([]byte), value, getDataConverterFromWorkflowContext(ctx))
+	err := deSerializeFunctionResult(d.fn, d.futureImpl.value.([]byte), value, getDataConverterFromWorkflowContext(ctx), d.channel.env.GetRegistry())
 	if err != nil {
 		return err
 	}

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -158,6 +158,7 @@ type (
 	testWorkflowEnvironmentImpl struct {
 		*testWorkflowEnvironmentShared
 		parentEnv *testWorkflowEnvironmentImpl
+		registry  *registry
 
 		workflowInfo   *WorkflowInfo
 		workflowDef    workflowDefinition
@@ -220,6 +221,7 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite) *testWorkflowEnvironme
 			ExecutionStartToCloseTimeoutSeconds: 1,
 			TaskStartToCloseTimeoutSeconds:      1,
 		},
+		registry: newRegistry(getGlobalRegistry()),
 
 		changeVersions: make(map[string]Version),
 		openSessions:   make(map[string]*SessionInfo),
@@ -320,6 +322,7 @@ func (env *testWorkflowEnvironmentImpl) newTestWorkflowEnvironmentForChild(param
 	childEnv.testWorkflowEnvironmentShared = env.testWorkflowEnvironmentShared
 	childEnv.workerOptions = env.workerOptions
 	childEnv.workerOptions.DataConverter = params.dataConverter
+	childEnv.registry = env.registry
 
 	if params.workflowID == "" {
 		params.workflowID = env.workflowInfo.WorkflowExecution.RunID + "_" + getStringID(env.nextID())
@@ -407,7 +410,11 @@ func (env *testWorkflowEnvironmentImpl) setActivityTaskList(tasklist string, act
 }
 
 func (env *testWorkflowEnvironmentImpl) executeWorkflow(workflowFn interface{}, args ...interface{}) {
-	workflowType, input, err := getValidatedWorkflowFunction(workflowFn, args, env.GetDataConverter())
+	fType := reflect.TypeOf(workflowFn)
+	if getKind(fType) == reflect.Func {
+		env.RegisterWorkflowWithOptions(workflowFn, RegisterWorkflowOptions{DisableAlreadyRegisteredCheck: true})
+	}
+	workflowType, input, err := getValidatedWorkflowFunction(workflowFn, args, env.GetDataConverter(), env.GetRegistry())
 	if err != nil {
 		panic(err)
 	}
@@ -418,7 +425,8 @@ func (env *testWorkflowEnvironmentImpl) executeWorkflowInternal(delayStart time.
 	env.locker.Lock()
 	if env.workflowInfo.WorkflowType.Name != workflowTypeNotSpecified {
 		// Current TestWorkflowEnvironment only support to run one workflow.
-		// Created task to support testing multiple workflows with one env instancehttps://github.com/uber-go/cadence-client/issues/616
+		// Created task to support testing multiple workflows with one env instance
+		// https://github.com/uber-go/cadence-client/issues/616
 		panic(fmt.Sprintf("Current TestWorkflowEnvironment is used to execute %v. Please create a new TestWorkflowEnvironment for %v.", env.workflowInfo.WorkflowType.Name, workflowType))
 	}
 	env.workflowInfo.WorkflowType.Name = workflowType
@@ -460,24 +468,23 @@ func (env *testWorkflowEnvironmentImpl) executeWorkflowInternal(delayStart time.
 }
 
 func (env *testWorkflowEnvironmentImpl) getWorkflowDefinition(wt WorkflowType) (workflowDefinition, error) {
-	hostEnv := getHostEnvironment()
-	wf, ok := hostEnv.getWorkflowFn(wt.Name)
+	wf, ok := env.registry.getWorkflowFn(wt.Name)
 	if !ok {
-		supported := strings.Join(hostEnv.getRegisteredWorkflowTypes(), ", ")
-		return nil, fmt.Errorf("Unable to find workflow type: %v. Supported types: [%v]", wt.Name, supported)
+		supported := strings.Join(env.registry.getRegisteredWorkflowTypes(), ", ")
+		return nil, fmt.Errorf("unable to find workflow type: %v. Supported types: [%v]", wt.Name, supported)
 	}
 	wd := &workflowExecutorWrapper{
 		workflowExecutor: &workflowExecutor{name: wt.Name, fn: wf},
 		env:              env,
 	}
-	return newWorkflowDefinition(wd), nil
+	return newSyncWorkflowDefinition(wd), nil
 }
 
 func (env *testWorkflowEnvironmentImpl) executeActivity(
 	activityFn interface{},
 	args ...interface{},
 ) (Value, error) {
-	activityType, input, err := getValidatedActivityFunction(activityFn, args, env.GetDataConverter())
+	activityType, input, err := getValidatedActivityFunction(activityFn, args, env.GetDataConverter(), env.registry)
 	if err != nil {
 		panic(err)
 	}
@@ -1045,7 +1052,7 @@ func (env *testWorkflowEnvironmentImpl) ExecuteLocalActivity(params executeLocal
 	activityID := getStringID(env.nextID())
 	wOptions := augmentWorkerOptions(env.workerOptions)
 	ae := &activityExecutor{name: getFunctionName(params.ActivityFn), fn: params.ActivityFn}
-	if at, _, _ := getValidatedActivityFunction(params.ActivityFn, params.InputArgs, wOptions.DataConverter); at != nil {
+	if at, _, _ := getValidatedActivityFunction(params.ActivityFn, params.InputArgs, wOptions.DataConverter, env.registry); at != nil {
 		// local activity could be registered, if so use the registered name. This name is only used to find a mock.
 		ae.name = at.Name
 	}
@@ -1494,8 +1501,8 @@ func (env *testWorkflowEnvironmentImpl) newTestActivityTaskHandler(taskList stri
 		env.sessionEnvironment = newTestSessionEnvironment(env, &params, wOptions.MaxConcurrentSessionExecutionSize)
 	}
 	params.UserContext = context.WithValue(params.UserContext, sessionEnvironmentContextKey, env.sessionEnvironment)
-
-	if len(getHostEnvironment().getRegisteredActivities()) == 0 {
+	registry := env.registry
+	if len(registry.getRegisteredActivities()) == 0 {
 		panic(fmt.Sprintf("no activity is registered for tasklist '%v'", taskList))
 	}
 
@@ -1509,7 +1516,7 @@ func (env *testWorkflowEnvironmentImpl) newTestActivityTaskHandler(taskList stri
 			}
 		}
 
-		activity, ok := getHostEnvironment().getActivity(name)
+		activity, ok := registry.getActivity(name)
 		if !ok {
 			return nil
 		}
@@ -1527,7 +1534,7 @@ func (env *testWorkflowEnvironmentImpl) newTestActivityTaskHandler(taskList stri
 		return &activityExecutorWrapper{activityExecutor: ae, env: env}
 	}
 
-	taskHandler := newActivityTaskHandlerWithCustomProvider(env.service, params, getHostEnvironment(), getActivity)
+	taskHandler := newActivityTaskHandlerWithCustomProvider(env.service, params, registry, getActivity)
 	return taskHandler
 }
 
@@ -1592,6 +1599,22 @@ func (env *testWorkflowEnvironmentImpl) Now() time.Time {
 
 func (env *testWorkflowEnvironmentImpl) WorkflowInfo() *WorkflowInfo {
 	return env.workflowInfo
+}
+
+func (env *testWorkflowEnvironmentImpl) RegisterWorkflow(w interface{}) {
+	env.registry.RegisterWorkflow(w)
+}
+
+func (env *testWorkflowEnvironmentImpl) RegisterWorkflowWithOptions(w interface{}, options RegisterWorkflowOptions) {
+	env.registry.RegisterWorkflowWithOptions(w, options)
+}
+
+func (env *testWorkflowEnvironmentImpl) RegisterActivity(a interface{}) {
+	env.registry.RegisterActivity(a)
+}
+
+func (env *testWorkflowEnvironmentImpl) RegisterActivityWithOptions(a interface{}, options RegisterActivityOptions) {
+	env.registry.RegisterActivityWithOptions(a, options)
 }
 
 func (env *testWorkflowEnvironmentImpl) RegisterCancelHandler(handler func()) {
@@ -1927,6 +1950,10 @@ func (env *testWorkflowEnvironmentImpl) setHeartbeatDetails(details interface{})
 		panic(err)
 	}
 	env.heartbeatDetails = data
+}
+
+func (wc *testWorkflowEnvironmentImpl) GetRegistry() *registry {
+	return wc.registry
 }
 
 func newTestSessionEnvironment(testWorkflowEnvironment *testWorkflowEnvironmentImpl,

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -172,7 +172,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_OnActivityStartedListener() {
 		s.NoError(args.Get(&input))
 		activityCalls = append(activityCalls, fmt.Sprintf("%s:%s", activityInfo.ActivityType.Name, input))
 	})
-	expectedCalls := []string{}
+	var expectedCalls []string
 	for i := 1; i <= runCount; i++ {
 		expectedCalls = append(expectedCalls, fmt.Sprintf("testActivityHello:msg%v", i))
 	}
@@ -478,19 +478,19 @@ func testWorkflowHello(ctx Context) (string, error) {
 func testWorkflowContext(ctx Context) (string, error) {
 	value := ctx.Value(contextKey(testHeader))
 	if val, ok := value.(string); ok {
-		return string(val), nil
+		return val, nil
 	}
 	return "", fmt.Errorf("context did not propagate to workflow")
 }
 
-func testActivityHello(ctx context.Context, msg string) (string, error) {
+func testActivityHello(_ context.Context, msg string) (string, error) {
 	return "hello" + "_" + msg, nil
 }
 
 func testActivityContext(ctx context.Context) (string, error) {
 	value := ctx.Value(contextKey(testHeader))
 	if val, ok := value.(string); ok {
-		return string(val), nil
+		return val, nil
 	}
 	return "", fmt.Errorf("context did not propagate to workflow")
 }
@@ -1154,6 +1154,9 @@ func (s *WorkflowTestSuiteUnitTest) Test_GetVersion() {
 			f = ExecuteActivity(ctx, newActivity, "new_msg")
 		}
 		err := f.Get(ctx, nil) // wait for result
+		if err != nil {
+			return err
+		}
 
 		// test searchable change version
 		wfInfo := GetWorkflowInfo(ctx)
@@ -1199,6 +1202,9 @@ func (s *WorkflowTestSuiteUnitTest) Test_MockGetVersion() {
 		}
 		var ret1 string
 		err := f.Get(ctx, &ret1) // wait for result
+		if err != nil {
+			return "", err
+		}
 
 		v2 := GetVersion(ctx, "change_2", DefaultVersion, 2)
 		if v2 == DefaultVersion {
@@ -1208,6 +1214,9 @@ func (s *WorkflowTestSuiteUnitTest) Test_MockGetVersion() {
 		}
 		var ret2 string
 		err = f.Get(ctx, &ret2) // wait for result
+		if err != nil {
+			return "", err
+		}
 
 		// test searchable change version
 		wfInfo := GetWorkflowInfo(ctx)
@@ -1525,7 +1534,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityFullyQualifiedName() {
 func (s *WorkflowTestSuiteUnitTest) Test_WorkflowFullyQualifiedName() {
 	defer func() {
 		if r := recover(); r != nil {
-			s.Contains(r.(error).Error(), "Unable to find workflow type")
+			s.Contains(r.(error).Error(), "unable to find workflow type")
 		}
 	}()
 	env := s.NewTestWorkflowEnvironment()

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -43,17 +43,6 @@ import (
 )
 
 type (
-	// Worker represents objects that can be started and stopped.
-	Worker interface {
-		// Start starts the worker in a non-blocking fashion
-		Start() error
-		// Run is a blocking start and cleans up resources when killed
-		// returns error only if it fails to start the worker
-		Run() error
-		// Stop cleans up any resources opened by worker
-		Stop()
-	}
-
 	// WorkerOptions is used to configure a worker instance.
 	// The current timeout resolution implementation is in seconds and uses math.Ceil(d.Seconds()) as the duration. But is
 	// subjected to change in the future.
@@ -263,7 +252,7 @@ func NewWorker(
 	domain string,
 	taskList string,
 	options WorkerOptions,
-) Worker {
+) *aggregatedWorker {
 	return newAggregatedWorker(service, domain, taskList, options)
 }
 
@@ -397,7 +386,7 @@ func replayWorkflowHistory(logger *zap.Logger, service workflowserviceclient.Int
 		Identity: "replayID",
 		Logger:   logger,
 	}
-	taskHandler := newWorkflowTaskHandler(domain, params, nil, getHostEnvironment())
+	taskHandler := newWorkflowTaskHandler(domain, params, nil, getGlobalRegistry())
 	resp, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task, historyIterator: iterator}, nil)
 	if err != nil {
 		return err

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -223,10 +223,12 @@ type (
 
 // RegisterWorkflowOptions consists of options for registering a workflow
 type RegisterWorkflowOptions struct {
-	Name string
+	Name                          string
+	DisableAlreadyRegisteredCheck bool
 }
 
 // RegisterWorkflow - registers a workflow function with the framework.
+// The public form is: workflow.Register(...)
 // A workflow takes a cadence context and input and returns a (result, error) or just error.
 // Examples:
 //	func sampleWorkflow(ctx workflow.Context, input []byte) (result []byte, err error)
@@ -239,11 +241,12 @@ func RegisterWorkflow(workflowFunc interface{}) {
 	RegisterWorkflowWithOptions(workflowFunc, RegisterWorkflowOptions{})
 }
 
-// RegisterWorkflowWithOptions registers the workflow function with options
+// RegisterWorkflowWithOptions registers the workflow function with options.
+// The public form is: workflow.RegisterWithOptions(...)
 // The user can use options to provide an external name for the workflow or leave it empty if no
 // external name is required. This can be used as
-//  client.RegisterWorkflow(sampleWorkflow, RegisterWorkflowOptions{})
-//  client.RegisterWorkflow(sampleWorkflow, RegisterWorkflowOptions{Name: "foo"})
+//  workflow.RegisterWithOptions(sampleWorkflow, RegisterWorkflowOptions{})
+//  workflow.RegisterWithOptions(sampleWorkflow, RegisterWorkflowOptions{Name: "foo"})
 // A workflow takes a cadence context and input and returns a (result, error) or just error.
 // Examples:
 //	func sampleWorkflow(ctx workflow.Context, input []byte) (result []byte, err error)
@@ -251,13 +254,11 @@ func RegisterWorkflow(workflowFunc interface{}) {
 //	func sampleWorkflow(ctx workflow.Context) (result []byte, err error)
 //	func sampleWorkflow(ctx workflow.Context, arg1 int) (result string, err error)
 // Serialization of all primitive types, structures is supported ... except channels, functions, variadic, unsafe pointer.
-// This method calls panic if workflowFunc doesn't comply with the expected format.
+// This method calls panic if workflowFunc doesn't comply with the expected format or tries to register the same workflow
+// type name twice. Use workflow.RegisterOptions.DisableAlreadyRegisteredCheck to allow multiple registrations.
 func RegisterWorkflowWithOptions(workflowFunc interface{}, opts RegisterWorkflowOptions) {
-	thImpl := getHostEnvironment()
-	err := thImpl.RegisterWorkflowWithOptions(workflowFunc, opts)
-	if err != nil {
-		panic(err)
-	}
+	registry := getGlobalRegistry()
+	registry.RegisterWorkflowWithOptions(workflowFunc, opts)
 }
 
 // NewChannel create new Channel instance
@@ -271,20 +272,20 @@ func NewChannel(ctx Context) Channel {
 // Name appears in stack traces that are blocked on this channel.
 func NewNamedChannel(ctx Context, name string) Channel {
 	env := getWorkflowEnvironment(ctx)
-	return &channelImpl{name: name, dataConverter: getDataConverterFromWorkflowContext(ctx), scope: env.GetMetricsScope(), logger: env.GetLogger()}
+	return &channelImpl{name: name, dataConverter: getDataConverterFromWorkflowContext(ctx), env: env}
 }
 
 // NewBufferedChannel create new buffered Channel instance
 func NewBufferedChannel(ctx Context, size int) Channel {
 	env := getWorkflowEnvironment(ctx)
-	return &channelImpl{size: size, dataConverter: getDataConverterFromWorkflowContext(ctx), scope: env.GetMetricsScope(), logger: env.GetLogger()}
+	return &channelImpl{size: size, dataConverter: getDataConverterFromWorkflowContext(ctx), env: env}
 }
 
 // NewNamedBufferedChannel create new BufferedChannel instance with a given human readable name.
 // Name appears in stack traces that are blocked on this Channel.
 func NewNamedBufferedChannel(ctx Context, name string, size int) Channel {
 	env := getWorkflowEnvironment(ctx)
-	return &channelImpl{name: name, size: size, dataConverter: getDataConverterFromWorkflowContext(ctx), scope: env.GetMetricsScope(), logger: env.GetLogger()}
+	return &channelImpl{name: name, size: size, dataConverter: getDataConverterFromWorkflowContext(ctx), env: env}
 }
 
 // NewSelector creates a new Selector instance.
@@ -352,8 +353,9 @@ func NewFuture(ctx Context) (Future, Settable) {
 func ExecuteActivity(ctx Context, activity interface{}, args ...interface{}) Future {
 	// Validate type and its arguments.
 	dataConverter := getDataConverterFromWorkflowContext(ctx)
+	registry := getRegistryFromWorkflowContext(ctx)
 	future, settable := newDecodeFuture(ctx, activity)
-	activityType, input, err := getValidatedActivityFunction(activity, args, dataConverter)
+	activityType, input, err := getValidatedActivityFunction(activity, args, dataConverter, registry)
 	if err != nil {
 		settable.Set(nil, err)
 		return future
@@ -565,7 +567,8 @@ func ExecuteChildWorkflow(ctx Context, childWorkflow interface{}, args ...interf
 	}
 	workflowOptionsFromCtx := getWorkflowEnvOptions(ctx)
 	dc := workflowOptionsFromCtx.dataConverter
-	wfType, input, err := getValidatedWorkflowFunction(childWorkflow, args, dc)
+	env := getWorkflowEnvironment(ctx)
+	wfType, input, err := getValidatedWorkflowFunction(childWorkflow, args, dc, env.GetRegistry())
 	if err != nil {
 		executionSettable.Set(nil, err)
 		mainSettable.Set(nil, err)
@@ -655,7 +658,7 @@ type WorkflowInfo struct {
 	ContinuedExecutionRunID             *string
 	ParentWorkflowDomain                *string
 	ParentWorkflowExecution             *WorkflowExecution
-	Memo                                *s.Memo // Value can be decoded using data converter (DefaultDataConverter, or custom one if set).
+	Memo                                *s.Memo             // Value can be decoded using data converter (DefaultDataConverter, or custom one if set).
 	SearchAttributes                    *s.SearchAttributes // Value can be decoded using DefaultDataConverter.
 	BinaryChecksum                      *string
 }

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -190,6 +190,22 @@ func (t *TestActivityEnvironment) SetWorkerStopChannel(c chan struct{}) {
 	t.impl.setWorkerStopChannel(c)
 }
 
+func (t *TestWorkflowEnvironment) RegisterWorkflow(w interface{}) {
+	t.impl.RegisterWorkflow(w)
+}
+
+func (t *TestWorkflowEnvironment) RegisterWorkflowWithOptions(w interface{}, options RegisterWorkflowOptions) {
+	t.impl.RegisterWorkflowWithOptions(w, options)
+}
+
+func (t *TestWorkflowEnvironment) RegisterActivity(a interface{}) {
+	t.impl.RegisterActivity(a)
+}
+
+func (t *TestWorkflowEnvironment) RegisterActivityWithOptions(a interface{}, options RegisterActivityOptions) {
+	t.impl.RegisterActivityWithOptions(a, options)
+}
+
 // SetStartTime sets the start time of the workflow. This is optional, default start time will be the wall clock time when
 // workflow starts. Start time is the workflow.Now(ctx) time at the beginning of the workflow.
 func (t *TestWorkflowEnvironment) SetStartTime(startTime time.Time) {
@@ -219,7 +235,7 @@ func (t *TestWorkflowEnvironment) OnActivity(activity interface{}, args ...inter
 			panic(err)
 		}
 		fnName := getFunctionName(activity)
-		if alias, ok := getHostEnvironment().getActivityAlias(fnName); ok {
+		if alias, ok := t.impl.registry.getActivityAlias(fnName); ok {
 			fnName = alias
 		}
 		call = t.Mock.On(fnName, args...)
@@ -262,7 +278,7 @@ func (t *TestWorkflowEnvironment) OnWorkflow(workflow interface{}, args ...inter
 			panic(err)
 		}
 		fnName := getFunctionName(workflow)
-		if alias, ok := getHostEnvironment().getWorkflowAlias(fnName); ok {
+		if alias, ok := t.impl.registry.getWorkflowAlias(fnName); ok {
 			fnName = alias
 		}
 		call = t.Mock.On(fnName, args...)

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -29,27 +29,40 @@ import (
 
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/worker"
 )
 
 type Activities struct {
-	sync.Mutex
+	mu          sync.Mutex
 	invocations []string
+	activities2 *Activities2
+}
+
+type Activities2 struct {
+	impl *Activities
 }
 
 var errFailOnPurpose = cadence.NewCustomError("failing-on-purpose")
 
-func (a *Activities) RetryTimeoutStableErrorActivity(ctx context.Context) error {
+func newActivities() *Activities {
+	activities2 := &Activities2{}
+	result := &Activities{activities2: activities2}
+	activities2.impl = result
+	return result
+}
+
+func (a *Activities) RetryTimeoutStableErrorActivity() error {
 	time.Sleep(time.Second * 3)
 	return errFailOnPurpose
 }
 
-func (a *Activities) Sleep(ctx context.Context, delay time.Duration) error {
+func (a *Activities) Sleep(_ context.Context, delay time.Duration) error {
 	a.append("sleep")
 	time.Sleep(delay)
 	return nil
 }
 
-func LocalSleep(ctx context.Context, delay time.Duration) error {
+func LocalSleep(_ context.Context, delay time.Duration) error {
 	time.Sleep(delay)
 	return nil
 }
@@ -68,23 +81,7 @@ func (a *Activities) HeartbeatAndSleep(ctx context.Context, seq int, delay time.
 	return seq, nil
 }
 
-func (a *Activities) ToUpper(ctx context.Context, arg string) (string, error) {
-	a.append("toUpper")
-	return strings.ToUpper(arg), nil
-}
-
-func (a *Activities) ToUpperWithDelay(ctx context.Context, arg string, delay time.Duration) (string, error) {
-	a.append("toUpperWithDelay")
-	time.Sleep(delay)
-	return strings.ToUpper(arg), nil
-}
-
-func (a *Activities) GetMemoAndSearchAttr(ctx context.Context, memo, searchAttr string) (string, error) {
-	a.append("getMemoAndSearchAttr")
-	return memo + ", " + searchAttr, nil
-}
-
-func (a *Activities) Fail(ctx context.Context) error {
+func (a *Activities) fail(_ context.Context) error {
 	a.append("fail")
 	return errFailOnPurpose
 }
@@ -105,14 +102,14 @@ func (a *Activities) InspectActivityInfo(ctx context.Context, domain, taskList, 
 }
 
 func (a *Activities) append(name string) {
-	a.Lock()
-	defer a.Unlock()
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.invocations = append(a.invocations, name)
 }
 
 func (a *Activities) invoked() []string {
-	a.Lock()
-	defer a.Unlock()
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	result := make([]string, len(a.invocations))
 	for i := range a.invocations {
 		result[i] = a.invocations[i]
@@ -121,18 +118,32 @@ func (a *Activities) invoked() []string {
 }
 
 func (a *Activities) clearInvoked() {
-	a.Lock()
-	defer a.Unlock()
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.invocations = []string{}
 }
 
-func (a *Activities) register() {
-	activity.RegisterWithOptions(a.Fail, activity.RegisterOptions{Name: "fail"})
-	activity.RegisterWithOptions(a.Sleep, activity.RegisterOptions{Name: "sleep"})
-	activity.RegisterWithOptions(a.ToUpper, activity.RegisterOptions{Name: "toUpper"})
-	activity.RegisterWithOptions(a.ToUpperWithDelay, activity.RegisterOptions{Name: "toUpperWithDelay"})
-	activity.RegisterWithOptions(a.HeartbeatAndSleep, activity.RegisterOptions{Name: "heartbeatAndSleep"})
-	activity.RegisterWithOptions(a.GetMemoAndSearchAttr, activity.RegisterOptions{Name: "getMemoAndSearchAttr"})
-	activity.RegisterWithOptions(a.RetryTimeoutStableErrorActivity, activity.RegisterOptions{Name: "retryTimeoutStableErrorActivity"})
-	activity.RegisterWithOptions(a.InspectActivityInfo, activity.RegisterOptions{Name: "inspectActivityInfo"})
+func (a *Activities2) ToUpper(_ context.Context, arg string) (string, error) {
+	a.impl.append("toUpper")
+	return strings.ToUpper(arg), nil
+}
+
+func (a *Activities2) ToUpperWithDelay(_ context.Context, arg string, delay time.Duration) (string, error) {
+	a.impl.append("toUpperWithDelay")
+	time.Sleep(delay)
+	return strings.ToUpper(arg), nil
+}
+
+func (a *Activities) GetMemoAndSearchAttr(_ context.Context, memo, searchAttr string) (string, error) {
+	a.append("getMemoAndSearchAttr")
+	return memo + ", " + searchAttr, nil
+}
+
+func (a *Activities) register(worker worker.Worker) {
+	worker.RegisterActivity(a)
+	// Check reregistration
+	worker.RegisterActivityWithOptions(a.fail, activity.RegisterOptions{Name: "Fail", DisableAlreadyRegisteredCheck: true})
+	// Check prefix
+	worker.RegisterActivityWithOptions(a.activities2, activity.RegisterOptions{Name: "Prefix_", DisableAlreadyRegisteredCheck: true})
+	worker.RegisterActivityWithOptions(a.InspectActivityInfo, activity.RegisterOptions{Name: "inspectActivityInfo"})
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -87,12 +87,11 @@ func waitForTCP(timeout time.Duration, addr string) error {
 func (ts *IntegrationTestSuite) SetupSuite() {
 	ts.Assertions = require.New(ts.T())
 	ts.config = newConfig()
-	ts.activities = &Activities{}
+	ts.activities = newActivities()
 	ts.workflows = &Workflows{}
-	ts.registerWorkflowsAndActivities()
 	ts.Nil(waitForTCP(time.Minute, ts.config.ServiceAddr))
 	rpcClient, err := newRPCClient(ts.config.ServiceName, ts.config.ServiceAddr)
-	ts.Nil(err)
+	ts.NoError(err)
 	ts.rpcClient = rpcClient
 	ts.libClient = client.NewClient(ts.rpcClient.Interface, domainName, &client.Options{})
 	ts.registerDomain()
@@ -131,11 +130,12 @@ func (ts *IntegrationTestSuite) SetupTest() {
 	ts.activities.clearInvoked()
 	ts.taskListName = fmt.Sprintf("tl-%v", ts.seq)
 	logger, err := zap.NewDevelopment()
-	ts.Nil(err)
+	ts.NoError(err)
 	ts.worker = worker.New(ts.rpcClient.Interface, domainName, ts.taskListName, worker.Options{
 		DisableStickyExecution: ts.config.IsStickyOff,
 		Logger:                 logger,
 	})
+	ts.registerWorkflowsAndActivities(ts.worker)
 	ts.Nil(ts.worker.Start())
 }
 
@@ -146,14 +146,14 @@ func (ts *IntegrationTestSuite) TearDownTest() {
 func (ts *IntegrationTestSuite) TestBasic() {
 	var expected []string
 	err := ts.executeWorkflow("test-basic", ts.workflows.Basic, &expected)
-	ts.Nil(err)
+	ts.NoError(err)
 	ts.EqualValues(expected, ts.activities.invoked())
 }
 
 func (ts *IntegrationTestSuite) TestActivityRetryOnError() {
 	var expected []string
 	err := ts.executeWorkflow("test-activity-retry-on-error", ts.workflows.ActivityRetryOnError, &expected)
-	ts.Nil(err)
+	ts.NoError(err)
 	ts.EqualValues(expected, ts.activities.invoked())
 }
 
@@ -166,7 +166,7 @@ func (ts *IntegrationTestSuite) TestActivityRetryOnTimeoutStableError() {
 func (ts *IntegrationTestSuite) TestActivityRetryOptionsChange() {
 	var expected []string
 	err := ts.executeWorkflow("test-activity-retry-options-change", ts.workflows.ActivityRetryOptionsChange, &expected)
-	ts.Nil(err)
+	ts.NoError(err)
 	ts.EqualValues(expected, ts.activities.invoked())
 }
 
@@ -178,21 +178,21 @@ func (ts *IntegrationTestSuite) TestActivityRetryOnStartToCloseTimeout() {
 		&expected,
 		shared.TimeoutTypeStartToClose)
 
-	ts.Nil(err)
+	ts.NoError(err)
 	ts.EqualValues(expected, ts.activities.invoked())
 }
 
 func (ts *IntegrationTestSuite) TestActivityRetryOnHBTimeout() {
 	var expected []string
 	err := ts.executeWorkflow("test-activity-retry-on-hbtimeout", ts.workflows.ActivityRetryOnHBTimeout, &expected)
-	ts.Nil(err)
+	ts.NoError(err)
 	ts.EqualValues(expected, ts.activities.invoked())
 }
 
 func (ts *IntegrationTestSuite) TestContinueAsNew() {
 	var result int
 	err := ts.executeWorkflow("test-continueasnew", ts.workflows.ContinueAsNew, &result, 4, ts.taskListName)
-	ts.Nil(err)
+	ts.NoError(err)
 	ts.Equal(999, result)
 }
 
@@ -206,7 +206,7 @@ func (ts *IntegrationTestSuite) TestContinueAsNewCarryOver() {
 		"CustomKeywordField": "searchAttr",
 	}
 	err := ts.executeWorkflowWithOption(startOptions, ts.workflows.ContinueAsNewWithOptions, &result, 4, ts.taskListName)
-	ts.Nil(err)
+	ts.NoError(err)
 	ts.Equal("memoVal,searchAttr", result)
 }
 
@@ -215,7 +215,7 @@ func (ts *IntegrationTestSuite) TestCancellation() {
 	defer cancel()
 	run, err := ts.libClient.ExecuteWorkflow(ctx,
 		ts.startWorkflowOptions("test-cancellation"), ts.workflows.Basic)
-	ts.Nil(err)
+	ts.NoError(err)
 	ts.NotNil(run)
 	ts.Nil(ts.libClient.CancelWorkflow(ctx, "test-cancellation", run.GetRunID()))
 	err = run.Get(ctx, nil)
@@ -229,9 +229,9 @@ func (ts *IntegrationTestSuite) TestStackTraceQuery() {
 	defer cancel()
 	run, err := ts.libClient.ExecuteWorkflow(ctx,
 		ts.startWorkflowOptions("test-stack-trace-query"), ts.workflows.Basic)
-	ts.Nil(err)
+	ts.NoError(err)
 	value, err := ts.libClient.QueryWorkflow(ctx, "test-stack-trace-query", run.GetRunID(), "__stack_trace")
-	ts.Nil(err)
+	ts.NoError(err)
 	ts.NotNil(value)
 	var trace string
 	ts.Nil(value.Get(&trace))
@@ -316,7 +316,7 @@ func (ts *IntegrationTestSuite) TestWorkflowIDReuseAllowDuplicateFailedOnly2() {
 		false,
 		true,
 	)
-	ts.Nil(err)
+	ts.NoError(err)
 	ts.Equal("WORLD", result)
 }
 
@@ -331,7 +331,7 @@ func (ts *IntegrationTestSuite) TestWorkflowIDReuseAllowDuplicate() {
 		false,
 		false,
 	)
-	ts.Nil(err)
+	ts.NoError(err)
 	ts.Equal("HELLOWORLD", result)
 }
 
@@ -375,14 +375,15 @@ func (ts *IntegrationTestSuite) TestChildWFWithParentClosePolicyAbandon() {
 
 func (ts *IntegrationTestSuite) TestActivityCancelUsingReplay() {
 	logger, err := zap.NewDevelopment()
+	workflow.RegisterWithOptions(ts.workflows.ActivityCancelRepro, workflow.RegisterOptions{DisableAlreadyRegisteredCheck: true})
 	err = worker.ReplayPartialWorkflowHistoryFromJSONFile(logger, "fixtures/activity.cancel.sm.repro.json", 12)
-	ts.Nil(err)
+	ts.NoError(err)
 }
 
 func (ts *IntegrationTestSuite) TestActivityCancelRepro() {
 	var expected []string
 	err := ts.executeWorkflow("test-activity-cancel-sm", ts.workflows.ActivityCancelRepro, &expected)
-	ts.Nil(err)
+	ts.NoError(err)
 	ts.EqualValues(expected, ts.activities.invoked())
 }
 
@@ -426,7 +427,7 @@ func (ts *IntegrationTestSuite) registerDomain() {
 			return
 		}
 	}
-	ts.Nil(err)
+	ts.NoError(err)
 	time.Sleep(domainCacheRefreshInterval) // wait for domain cache refresh on cadence-server
 	// bellow is used to guarantee domain is ready
 	var dummyReturn string
@@ -482,7 +483,7 @@ func (ts *IntegrationTestSuite) startWorkflowOptions(wfID string) client.StartWo
 	}
 }
 
-func (ts *IntegrationTestSuite) registerWorkflowsAndActivities() {
-	ts.workflows.register()
-	ts.activities.register()
+func (ts *IntegrationTestSuite) registerWorkflowsAndActivities(w worker.Worker) {
+	ts.workflows.register(w)
+	ts.activities.register(w)
 }

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -43,12 +43,12 @@ func (w *Workflows) Basic(ctx workflow.Context) ([]string, error) {
 	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
 	var ans1 string
 	workflow.GetLogger(ctx).Info("calling ExecuteActivity")
-	err := workflow.ExecuteActivity(ctx, "toUpperWithDelay", "hello", time.Second).Get(ctx, &ans1)
+	err := workflow.ExecuteActivity(ctx, "Prefix_ToUpperWithDelay", "hello", time.Second).Get(ctx, &ans1)
 	if err != nil {
 		return nil, err
 	}
 	var ans2 string
-	if err := workflow.ExecuteActivity(ctx, "toUpper", ans1).Get(ctx, &ans2); err != nil {
+	if err := workflow.ExecuteActivity(ctx, "Prefix_ToUpper", ans1).Get(ctx, &ans2); err != nil {
 		return nil, err
 	}
 	if ans2 != "HELLO" {
@@ -60,7 +60,7 @@ func (w *Workflows) Basic(ctx workflow.Context) ([]string, error) {
 func (w *Workflows) ActivityRetryOnError(ctx workflow.Context) ([]string, error) {
 	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptionsWithRetry())
 	startTime := workflow.Now(ctx)
-	err := workflow.ExecuteActivity(ctx, "fail").Get(ctx, nil)
+	err := workflow.ExecuteActivity(ctx, "Fail").Get(ctx, nil)
 	if err == nil {
 		return nil, fmt.Errorf("expected activity to fail but succeeded")
 	}
@@ -88,7 +88,7 @@ func (w *Workflows) ActivityRetryOptionsChange(ctx workflow.Context) ([]string, 
 		opts.RetryPolicy.MaximumAttempts = 3
 	}
 	ctx = workflow.WithActivityOptions(ctx, opts)
-	err := workflow.ExecuteActivity(ctx, "fail").Get(ctx, nil)
+	err := workflow.ExecuteActivity(ctx, "Fail").Get(ctx, nil)
 	if err == nil {
 		return nil, fmt.Errorf("expected activity to fail but succeeded")
 	}
@@ -107,7 +107,7 @@ func (w *Workflows) ActivityRetryOnTimeout(ctx workflow.Context, timeoutType sha
 	ctx = workflow.WithActivityOptions(ctx, opts)
 
 	startTime := workflow.Now(ctx)
-	err := workflow.ExecuteActivity(ctx, "sleep", 2*time.Second).Get(ctx, nil)
+	err := workflow.ExecuteActivity(ctx, "Activities_Sleep", 2*time.Second).Get(ctx, nil)
 	if err == nil {
 		return nil, fmt.Errorf("expected activity to fail but succeeded")
 	}
@@ -136,7 +136,7 @@ func (w *Workflows) ActivityRetryOnHBTimeout(ctx workflow.Context) ([]string, er
 
 	var result int
 	startTime := workflow.Now(ctx)
-	err := workflow.ExecuteActivity(ctx, "heartbeatAndSleep", 0, 2*time.Second).Get(ctx, &result)
+	err := workflow.ExecuteActivity(ctx, "Activities_HeartbeatAndSleep", 0, 2*time.Second).Get(ctx, &result)
 	if err == nil {
 		return nil, fmt.Errorf("expected activity to fail but succeeded")
 	}
@@ -343,7 +343,7 @@ func (w *Workflows) ActivityCancelRepro(ctx workflow.Context) ([]string, error) 
 			StartToCloseTimeout:    9 * time.Second,
 		})
 
-		activityF := workflow.ExecuteActivity(activityCtx, "toUpperWithDelay", "hello", 1*time.Second)
+		activityF := workflow.ExecuteActivity(activityCtx, "Prefix_ToUpperWithDelay", "hello", 1*time.Second)
 		var ans string
 		err := activityF.Get(activityCtx, &ans)
 		if err != nil {
@@ -364,7 +364,7 @@ func (w *Workflows) ActivityCancelRepro(ctx workflow.Context) ([]string, error) 
 			TaskList:               "bad_tl",
 		})
 
-		activityF := workflow.ExecuteActivity(activityCtx, "toUpper", "hello")
+		activityF := workflow.ExecuteActivity(activityCtx, "Prefix_ToUpper", "hello")
 		var ans string
 		err := activityF.Get(activityCtx, &ans)
 		if err != nil {
@@ -381,7 +381,7 @@ func (w *Workflows) ActivityCancelRepro(ctx workflow.Context) ([]string, error) 
 			TaskList:               "bad_tl",
 		})
 
-		activityF := workflow.ExecuteActivity(activityCtx, "toUpper", "hello")
+		activityF := workflow.ExecuteActivity(activityCtx, "Prefix_ToUpper", "hello")
 		var ans string
 		err := activityF.Get(activityCtx, &ans)
 		if err != nil {
@@ -466,7 +466,7 @@ func (w *Workflows) RetryTimeoutStableErrorWorkflow(ctx workflow.Context) ([]str
 func (w *Workflows) child(ctx workflow.Context, arg string, mustFail bool) (string, error) {
 	var result string
 	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
-	err := workflow.ExecuteActivity(ctx, "toUpper", arg).Get(ctx, &result)
+	err := workflow.ExecuteActivity(ctx, "Prefix_ToUpper", arg).Get(ctx, &result)
 	if mustFail {
 		return "", fmt.Errorf("failing-on-purpose")
 	}
@@ -485,13 +485,13 @@ func (w *Workflows) childForMemoAndSearchAttr(ctx workflow.Context) (result stri
 		return
 	}
 	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
-	err = workflow.ExecuteActivity(ctx, "getMemoAndSearchAttr", memo, searchAttr).Get(ctx, &result)
+	err = workflow.ExecuteActivity(ctx, "Activities_GetMemoAndSearchAttr", memo, searchAttr).Get(ctx, &result)
 	return
 }
 
 func (w *Workflows) sleep(ctx workflow.Context, d time.Duration) error {
 	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
-	return workflow.ExecuteActivity(ctx, "sleep", d).Get(ctx, nil)
+	return workflow.ExecuteActivity(ctx, "Activities_Sleep", d).Get(ctx, nil)
 }
 
 func (w *Workflows) InspectActivityInfo(ctx workflow.Context) error {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -26,14 +26,94 @@ import (
 
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	"go.uber.org/cadence/.gen/go/shared"
+	"go.uber.org/cadence/activity"
 	"go.uber.org/cadence/internal"
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/zap"
 )
 
 type (
-	// Worker represents objects that can be started and stopped.
-	Worker = internal.Worker
+	// Worker hosts workflow and activity implementations.
+	// Use worker.New(...) to create an instance.
+	Worker interface {
+		// RegisterWorkflow - registers a workflow function with the worker.
+		// A workflow takes a workflow.Context and input and returns a (result, error) or just error.
+		// Examples:
+		//	func sampleWorkflow(ctx workflow.Context, input []byte) (result []byte, err error)
+		//	func sampleWorkflow(ctx workflow.Context, arg1 int, arg2 string) (result []byte, err error)
+		//	func sampleWorkflow(ctx workflow.Context) (result []byte, err error)
+		//	func sampleWorkflow(ctx workflow.Context, arg1 int) (result string, err error)
+		// Serialization of all primitive types, structures is supported ... except channels, functions, variadic, unsafe pointer.
+		// For global registration consider workflow.Register
+		// This method panics if workflowFunc doesn't comply with the expected format or tries to register the same workflow
+		RegisterWorkflow(w interface{})
+
+		// RegisterWorkflowWithOptions registers the workflow function with options.
+		// The user can use options to provide an external name for the workflow or leave it empty if no
+		// external name is required. This can be used as
+		//  worker.RegisterWorkflowWithOptions(sampleWorkflow, RegisterWorkflowOptions{})
+		//  worker.RegisterWorkflowWithOptions(sampleWorkflow, RegisterWorkflowOptions{Name: "foo"})
+		// This method panics if workflowFunc doesn't comply with the expected format or tries to register the same workflow
+		// type name twice. Use workflow.RegisterOptions.DisableAlreadyRegisteredCheck to allow multiple registrations.
+		RegisterWorkflowWithOptions(w interface{}, options workflow.RegisterOptions)
+
+		// RegisterActivity - register an activity function or a pointer to a structure with the worker.
+		// An activity function takes a context and input and returns a (result, error) or just error.
+		//
+		// And activity struct is a structure with all its exported methods treated as activities. The default
+		// name of each activity is the method name.
+		//
+		// Examples:
+		//	func sampleActivity(ctx context.Context, input []byte) (result []byte, err error)
+		//	func sampleActivity(ctx context.Context, arg1 int, arg2 string) (result *customerStruct, err error)
+		//	func sampleActivity(ctx context.Context) (err error)
+		//	func sampleActivity() (result string, err error)
+		//	func sampleActivity(arg1 bool) (result int, err error)
+		//	func sampleActivity(arg1 bool) (err error)
+		//
+		//  type Activities struct {
+		//     // fields
+		//  }
+		//  func (a *Activities) SampleActivity1(ctx context.Context, arg1 int, arg2 string) (result *customerStruct, err error) {
+		//    ...
+		//  }
+		//
+		//  func (a *Activities) SampleActivity2(ctx context.Context, arg1 int, arg2 *customerStruct) (result string, err error) {
+		//    ...
+		//  }
+		//
+		// Serialization of all primitive types, structures is supported ... except channels, functions, variadic, unsafe pointer.
+		// This method panics if activityFunc doesn't comply with the expected format or an activity with the same
+		// type name is registered more than once.
+		// For global registration consider activity.Register
+		RegisterActivity(a interface{})
+
+		// RegisterActivityWithOptions registers the activity function or struct pointer with options.
+		// The user can use options to provide an external name for the activity or leave it empty if no
+		// external name is required. This can be used as
+		//  worker.RegisterActivityWithOptions(barActivity, RegisterActivityOptions{})
+		//  worker.RegisterActivityWithOptions(barActivity, RegisterActivityOptions{Name: "barExternal"})
+		// When registering the structure that implements activities the name is used as a prefix that is
+		// prepended to the activity method name.
+		//  worker.RegisterActivityWithOptions(&Activities{ ... }, RegisterActivityOptions{Name: "MyActivities_"})
+		// To override each name of activities defined through a structure register the methods one by one:
+		// activities := &Activities{ ... }
+		// worker.RegisterActivityWithOptions(activities.SampleActivity1, RegisterActivityOptions{Name: "Sample1"})
+		// worker.RegisterActivityWithOptions(activities.SampleActivity2, RegisterActivityOptions{Name: "Sample2"})
+		// See RegisterActivity function for more info.
+		// The other use of options is to disable duplicated activity registration check
+		// which might be useful for integration tests.
+		// worker.RegisterActivityWithOptions(barActivity, RegisterActivityOptions{DisableAlreadyRegisteredCheck: true})
+		RegisterActivityWithOptions(a interface{}, options activity.RegisterOptions)
+
+		// Start starts the worker in a non-blocking fashion
+		Start() error
+		// Run is a blocking start and cleans up resources when killed
+		// returns error only if it fails to start the worker
+		Run() error
+		// Stop cleans up any resources opened by worker
+		Stop()
+	}
 
 	// Options is used to configure a worker instance.
 	Options = internal.WorkerOptions


### PR DESCRIPTION
Activity and workflow registration refactoring (#4)

The change is backwards compatible. The following new features were added:

1) Ability to register structure instance for activity implementations:

```
type MyStruct struct {
...
}

func (m *MyStruct) Foo() {
}

func (m *MyStruct) Bar() {
}

activity.Register(&MyStruct{})
```

Is going to register two activities: MyStruct_Foo and My_Struct_Bar.

2) Added registration calls for both activities and workflows to the Worker.

```
w := worker.New(...)
w.RegisterActivity(&MyStruct{})
w.RegisterWorkflow(MyWorkflow)
```

3) Added registration calls to TestWorfklowEnvironment.

```
wfEnv := s.NewTestWorkflowEnvironment()
wfEnv.RegisterActivity(MyActivity)
wfEnv.ExecuteWorkflow(continueAsNewWorkflowFn, 101, "another random string")
```

Also note that a workflow function passed to ExecuteWorkflow is registered automatically.

4) Added support for duplicated registration. Set `RegisterActivityOptions.DisableAlreadyRegisteredCheck` and `RegisterWorkflowOptions.DisableAlreadyRegisteredCheck` to `true` when calling activity.RegisterWithOptions and workflow.RegisterWithOptions to disable duplicated registration check.