### PR TITLE
Support returning WorkflowExecutionAlreadyStartedError in tests

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -764,7 +764,7 @@ func (env *testWorkflowEnvironmentImpl) Complete(result []byte, err error) {
 
 	if err != nil {
 		switch err := err.(type) {
-		case *CanceledError, *ContinueAsNewError, *TimeoutError:
+		case *CanceledError, *ContinueAsNewError, *TimeoutError, *shared.WorkflowExecutionAlreadyStartedError:
 			env.testError = err
 		case *workflowPanicError:
 			env.testError = newPanicError(err.value, err.stackTrace)

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -2569,6 +2569,40 @@ func (s *WorkflowTestSuiteUnitTest) Test_SameActivityIDFromDifferentChildWorkflo
 	s.Equal("hello_child_1 hello_child_2", actualResult)
 }
 
+func (s *WorkflowTestSuiteUnitTest) Test_MockChildWorkflowAlreadyRunning() {
+	childWorkflowFn := func(ctx Context) error {
+		return nil
+	}
+
+	runID := "run-id"
+	workflowFn := func(ctx Context) error {
+		cwo := ChildWorkflowOptions{
+			ExecutionStartToCloseTimeout: time.Minute,
+		}
+		ctx = WithChildWorkflowOptions(ctx, cwo)
+		err := ExecuteChildWorkflow(ctx, childWorkflowFn).Get(ctx, nil)
+		s.Error(err)
+
+		alreadySytartedErr, ok := err.(*shared.WorkflowExecutionAlreadyStartedError)
+		s.True(ok)
+		s.Equal(runID, *alreadySytartedErr.RunId)
+
+		return nil
+	}
+
+	env := s.NewTestWorkflowEnvironment()
+	RegisterWorkflow(childWorkflowFn)
+	RegisterWorkflow(workflowFn)
+
+	env.OnWorkflow(childWorkflowFn, mock.Anything).
+		Return(&shared.WorkflowExecutionAlreadyStartedError{
+			RunId: &runID,
+		})
+
+	env.ExecuteWorkflow(workflowFn)
+	s.NoError(env.GetWorkflowError())
+}
+
 func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflowAlreadyRunning() {
 	workflowFn := func(ctx Context) (string, error) {
 		ctx1 := WithChildWorkflowOptions(ctx, ChildWorkflowOptions{
@@ -2841,7 +2875,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_AwaitWithTimeout() {
 	workflowFn := func(ctx Context) (bool, error) {
 		t := NewTimer(ctx, time.Second)
 		value := false
-		err := Await(ctx, func() bool { return t.IsReady() || value})
+		err := Await(ctx, func() bool { return t.IsReady() || value })
 		return value, err
 	}
 


### PR DESCRIPTION
Without this change, it is not possible to return a `WorkflowExecutionAlreadyStartedError` in tests.

This makes the following possible:
```
s.env.OnWorkflow(Workflow, mock.Anything, mock.Anything).
		Once().
		Return(&shared.WorkflowExecutionAlreadyStartedError{
			RunId: &runID,
		})
```