### PR TITLE
Fix Jaeger Baggage Injection

### DIFF
--- a/internal/tracer.go
+++ b/internal/tracer.go
@@ -100,7 +100,7 @@ func (t *tracingContextPropagator) InjectFromWorkflow(
 	if spanContext == nil {
 		return nil
 	}
-	return t.tracer.Inject(spanContext, opentracing.HTTPHeaders, tracingWriter{hw})
+	return t.tracer.Inject(spanContext, opentracing.TextMap, tracingWriter{hw})
 }
 
 func (t *tracingContextPropagator) ExtractToWorkflow(


### PR DESCRIPTION
We've observed an issue where 

1) Workflow gets started with Jaeger Baggage that we base64 encode. Ex: `eyJzZXJ2aWNlcyI6W3sicG9vbCI6ImJpdHMtdWNpIiwic2VydmljZV9uYW1lIjoiZnVsZmlsbG1lbnQiLCJob3N0IjoiYWdlbnQzNC1waHgyLnByb2QudWJlci5pbnRlcm5hbCIsInBvcnRzIjp7Imh0dHAiOjMxMDI1LCJodHRwMiI6MzEwMTgsInRjaGFubmVsIjozMTAzMX19XX0=`
2) Subsequent activity gets scheduled with Jaeger Baggage that is url-escaped (`opentracing.HTTPHeaders` does this https://github.com/jaegertracing/jaeger-client-go/blob/ff64c7c174e5f532e57276fcfafef2d7114d26ab/propagation.go#L82)
Ex: `eyJzZXJ2aWNlcyI6W3sicG9vbCI6ImJpdHMtdWNpIiwic2VydmljZV9uYW1lIjoiZnVsZmlsbG1lbnQiLCJob3N0IjoiYWdlbnQzNC1waHgyLnByb2QudWJlci5pbnRlcm5hbCIsInBvcnRzIjp7Imh0dHAiOjMxMDI1LCJodHRwMiI6MzEwMTgsInRjaGFubmVsIjozMTAzMX19XX0%3D`

The inconsistent injection and extraction leads to issues where the baggage gets corrupted due to the mismatched encoding.