### PR TITLE
Fix inconsistent Jaeger baggage injection/extraction

### DIFF
--- a/internal/tracer.go
+++ b/internal/tracer.go
@@ -100,7 +100,7 @@ func (t *tracingContextPropagator) InjectFromWorkflow(
 	if spanContext == nil {
 		return nil
 	}
-	return t.tracer.Inject(spanContext, opentracing.HTTPHeaders, tracingWriter{hw})
+	return t.tracer.Inject(spanContext, opentracing.TextMap, tracingWriter{hw})
 }
 
 func (t *tracingContextPropagator) ExtractToWorkflow(

--- a/internal/tracer_test.go
+++ b/internal/tracer_test.go
@@ -116,3 +116,34 @@ func TestTracingContextPropagatorWorkflowContextNoSpan(t *testing.T) {
 	returnCtx, err = ctxProp.ExtractToWorkflow(returnCtx, NewHeaderReader(header))
 	assert.NoError(t, err)
 }
+
+func TestConsistentInjectionExtraction(t *testing.T) {
+	t.Parallel()
+	tracer, closer, err := jaeger_config.Configuration{ServiceName: "test-service"}.NewTracer()
+	require.NoError(t, err)
+	defer closer.Close()
+	ctxProp := NewTracingContextPropagator(zap.NewNop(), tracer)
+
+	span := tracer.StartSpan("test-operation")
+	// base64 encoded string '{}'
+	var baggageVal = "e30="
+	span.SetBaggageItem("request-tenancy", baggageVal)
+	assert.NotNil(t, span.Context())
+	ctx := contextWithSpan(Background(), span.Context())
+	header := &shared.Header{
+		Fields: map[string][]byte{},
+	}
+	err = ctxProp.InjectFromWorkflow(ctx, NewHeaderWriter(header))
+	require.NoError(t, err)
+
+	extractedCtx, err := ctxProp.ExtractToWorkflow(Background(), NewHeaderReader(header))
+	require.NoError(t, err)
+
+	extractedSpanContext := spanFromContext(extractedCtx)
+	extractedSpanContext.ForeachBaggageItem(func(k, v string) bool {
+		if k == "request-tenancy" {
+			assert.Equal(t, v, baggageVal)
+		}
+		return false
+	})
+}


### PR DESCRIPTION
**Context**

We've observed an issue where

1) Workflow gets started with Jaeger Baggage that we base64 encode. Ex: 
`eyJzZXJ2aWNlcyI6W3sicG9vbCI6ImJpdHMtdWNpIiwic2VydmljZV9uYW1lIjoiZnVsZmlsbG1lbnQiLCJob3N0IjoiYWdlbnQzNC1waHgyLnByb2QudWJlci5pbnRlcm5hbCIsInBvcnRzIjp7Imh0dHAiOjMxMDI1LCJodHRwMiI6MzEwMTgsInRjaGFubmVsIjozMTAzMX19XX0=`

2) Subsequent activity gets scheduled with Jaeger Baggage that is url-escaped (`opentracing.HTTPHeaders` does this https://github.com/jaegertracing/jaeger-client-go/blob/ff64c7c174e5f532e57276fcfafef2d7114d26ab/propagation.go#L82)
Ex: 
`eyJzZXJ2aWNlcyI6W3sicG9vbCI6ImJpdHMtdWNpIiwic2VydmljZV9uYW1lIjoiZnVsZmlsbG1lbnQiLCJob3N0IjoiYWdlbnQzNC1waHgyLnByb2QudWJlci5pbnRlcm5hbCIsInBvcnRzIjp7Imh0dHAiOjMxMDI1LCJodHRwMiI6MzEwMTgsInRjaGFubmVsIjozMTAzMX19XX0%3D`
The inconsistent injection and extraction leads to issues where the baggage gets corrupted due to the mismatched encoding.

**Testing Plan**

Added a unit test that fails without the change and succeeds with change to verify this bug and fix.

cc @yurishkuro