### PR TITLE
Fix workflow and activity registration race

### DIFF
--- a/internal/internal_activity.go
+++ b/internal/internal_activity.go
@@ -395,8 +395,8 @@ func deSerializeFunctionResult(f interface{}, result []byte, to interface{}, dat
 	case reflect.String:
 		// If we know about this function through registration then we will try to return corresponding result type.
 		fnName := reflect.ValueOf(f).String()
-		if fnRegistered, ok := registry.getActivityFn(fnName); ok {
-			return deSerializeFnResultFromFnType(reflect.TypeOf(fnRegistered), result, to, dataConverter)
+		if activity, ok := registry.GetActivity(fnName); ok {
+			return deSerializeFnResultFromFnType(reflect.TypeOf(activity.GetFunction()), result, to, dataConverter)
 		}
 	}
 

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1833,7 +1833,7 @@ func (ath *activityTaskHandlerImpl) getActivity(name string) activity {
 		return ath.activityProvider(name)
 	}
 
-	if a, ok := ath.registry.getActivity(name); ok {
+	if a, ok := ath.registry.GetActivity(name); ok {
 		return a
 	}
 

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -1270,7 +1270,7 @@ func (t *TaskHandlersTestSuite) TestActivityExecutionDeadline() {
 	}
 	a := &testActivityDeadline{logger: t.logger}
 	registry := getGlobalRegistry()
-	registry.addActivity(a.ActivityType().Name, a)
+	registry.addActivityWithLock(a.ActivityType().Name, a)
 
 	mockCtrl := gomock.NewController(t.T())
 	mockService := workflowservicetest.NewMockClient(mockCtrl)
@@ -1324,7 +1324,10 @@ func activityWithWorkerStop(ctx context.Context) error {
 func (t *TaskHandlersTestSuite) TestActivityExecutionWorkerStop() {
 	a := &testActivityDeadline{logger: t.logger}
 	registry := getGlobalRegistry()
-	registry.addActivityFn(a.ActivityType().Name, activityWithWorkerStop)
+	registry.RegisterActivityWithOptions(
+		activityWithWorkerStop,
+		RegisterActivityOptions{Name: a.ActivityType().Name, DisableAlreadyRegisteredCheck: true},
+	)
 
 	mockCtrl := gomock.NewController(t.T())
 	mockService := workflowservicetest.NewMockClient(mockCtrl)

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -127,7 +127,7 @@ func (s *WorkersTestSuite) TestActivityWorker() {
 	overrides := &workerOverrides{activityTaskHandler: newSampleActivityTaskHandler()}
 	a := &greeterActivity{}
 	registry := getGlobalRegistry()
-	registry.addActivity(a.ActivityType().Name, a)
+	registry.addActivityWithLock(a.ActivityType().Name, a)
 	activityWorker := newActivityWorker(
 		s.service, domain, executionParameters, overrides, registry, nil,
 	)
@@ -176,7 +176,7 @@ func (s *WorkersTestSuite) TestActivityWorkerStop() {
 	overrides := &workerOverrides{activityTaskHandler: activityTaskHandler}
 	a := &greeterActivity{}
 	registry := getGlobalRegistry()
-	registry.addActivity(a.ActivityType().Name, a)
+	registry.addActivityWithLock(a.ActivityType().Name, a)
 	worker := newActivityWorker(
 		s.service, domain, executionParameters, overrides, registry, nil,
 	)

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -934,7 +934,7 @@ func getGetWorkflowExecutionHistoryRequest(filterType shared.HistoryEventFilterT
 		},
 		WaitForNewEvent:        common.BoolPtr(isLongPoll),
 		HistoryEventFilterType: &filterType,
-		SkipArchival: common.BoolPtr(true),
+		SkipArchival:           common.BoolPtr(true),
 	}
 
 	return request

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1517,7 +1517,7 @@ func (env *testWorkflowEnvironmentImpl) newTestActivityTaskHandler(taskList stri
 			}
 		}
 
-		activity, ok := registry.getActivity(name)
+		activity, ok := registry.GetActivity(name)
 		if !ok {
 			return nil
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Fix workflow and activity registration race

<!-- Tell your future self why have you made these changes -->
Workflow and activity registration methods are not protected by the lock correctly.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Local testing


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Should not cause runtime errors as long as registration works.
