### PR TITLE
UseNumber for the json defaultDataConverter

### DIFF
--- a/internal/encoding.go
+++ b/internal/encoding.go
@@ -60,6 +60,7 @@ func (g jsonEncoding) Marshal(objs []interface{}) ([]byte, error) {
 // Unmarshal decodes a byte array into the passed in objects
 func (g jsonEncoding) Unmarshal(data []byte, objs []interface{}) error {
 	dec := json.NewDecoder(bytes.NewBuffer(data))
+	dec.UseNumber()
 	for i, obj := range objs {
 		if err := dec.Decode(obj); err != nil {
 			return fmt.Errorf(


### PR DESCRIPTION
To keep numbers pass through the marshal-unmarshal process unchanged, set UseNumber for the json defaultDataConverter

<!-- Describe what has changed in this PR -->
**What changed?**
set UseNumber for the json defaultDataConverter 

<!-- Tell your future self why have you made these changes -->
**Why?**
To use bindings map[string]interface{} as the parameters of activity to transfer many kinds of dynamic data structures. But with the limitation of go Unmarshal to interface{}, big number may change to float64. To keep numbers pass through the marshal-unmarshal process unchanged, set UseNumber for the json defaultDataConverter.

Please refer to https://github.com/uber/cadence/issues/3322

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Test by set it as custom encoded.DataConverter

