### PR TITLE
Fixes for struct activity naming

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -57,6 +57,9 @@ type (
 
 	// RegisterActivityOptions consists of options for registering an activity
 	RegisterActivityOptions struct {
+		// When an activity is a function the name is an actual activity type name.
+		// When an activity is part of a structure then each member of the structure becomes an activity with
+		// this Name as a prefix + activity function name.
 		Name                          string
 		DisableAlreadyRegisteredCheck bool
 	}

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1087,10 +1087,10 @@ func isError(inType reflect.Type) bool {
 }
 
 func getFunctionName(i interface{}) string {
-	fullName, ok := i.(string)
-	if !ok {
-		fullName = runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
+	if fullName, ok := i.(string); ok {
+		return fullName
 	}
+	fullName := runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
 	elements := strings.Split(fullName, ".")
 	return elements[len(elements)-1]
 }

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1092,7 +1092,16 @@ func getFunctionName(i interface{}) string {
 	}
 	fullName := runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
 	elements := strings.Split(fullName, ".")
-	return elements[len(elements)-1]
+	shortName := elements[len(elements)-1]
+	// This allows to call activities by method pointer
+	// Compiler adds -fm suffix to a function name which has a receiver
+	// Note that this works even if struct pointer used to get the function is nil
+	// It is possible because nil receivers are allowed.
+	// For example:
+	// var a *Activities
+	// ExecuteActivity(ctx, a.Foo)
+	// will call this function which is going to return "Foo"
+	return strings.TrimSuffix(shortName, "-fm")
 }
 
 func getActivityFunctionName(r *registry, i interface{}) string {

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -2147,7 +2147,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_Channel() {
 				}
 
 				// continue as new
-				return NewContinueAsNewError(ctx, "this-workflow-fn")
+				return NewContinueAsNewError(ctx, "this-workflow")
 			}
 
 			for i := range fanoutChs {

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -163,12 +163,7 @@ func (r *registry) registerActivityStruct(aStruct interface{}, options RegisterA
 		if err := validateFnFormat(method.Type, false); err != nil {
 			return fmt.Errorf("failed to register activity method %v of %v: %e", name, structType.Name(), err)
 		}
-		prefix := options.Name
-		registerName := name
-		if len(prefix) == 0 {
-			prefix = structType.Elem().Name() + "_"
-		}
-		registerName = prefix + name
+		registerName := options.Name + name
 		if !options.DisableAlreadyRegisteredCheck {
 			if _, ok := r.getActivityNoLock(registerName); ok {
 				return fmt.Errorf("activity type \"%v\" is already registered", registerName)

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -159,17 +159,21 @@ func (r *registry) registerActivityStruct(aStruct interface{}, options RegisterA
 		if method.PkgPath != "" {
 			continue
 		}
-		name := method.Name
+		methodName := method.Name
+		structPrefix := options.Name
 		if err := validateFnFormat(method.Type, false); err != nil {
-			return fmt.Errorf("failed to register activity method %v of %v: %e", name, structType.Name(), err)
+			return fmt.Errorf("failed to register activity method %v of %v: %e", methodName, structType.Name(), err)
 		}
-		registerName := options.Name + name
+		registerName := structPrefix + methodName
 		if !options.DisableAlreadyRegisteredCheck {
 			if _, ok := r.getActivityNoLock(registerName); ok {
 				return fmt.Errorf("activity type \"%v\" is already registered", registerName)
 			}
 		}
 		r.activityFuncMap[registerName] = &activityExecutor{registerName, methodValue.Interface()}
+		if len(structPrefix) > 0 {
+			r.activityAliasMap[methodName] = registerName
+		}
 		count++
 	}
 

--- a/test/fixtures/activity.cancel.sm.repro.json
+++ b/test/fixtures/activity.cancel.sm.repro.json
@@ -6,7 +6,7 @@
     "version": -24,
     "workflowExecutionStartedEventAttributes": {
       "workflowType": {
-        "name": "go.uber.org/cadence/test.(*Workflows).ActivityCancelRepro-fm"
+        "name": "ActivityCancelRepro-fm"
       },
       "taskList": {
         "name": "tl-1"

--- a/test/fixtures/activity.cancel.sm.repro.json
+++ b/test/fixtures/activity.cancel.sm.repro.json
@@ -6,7 +6,7 @@
     "version": -24,
     "workflowExecutionStartedEventAttributes": {
       "workflowType": {
-        "name": "ActivityCancelRepro-fm"
+        "name": "ActivityCancelRepro"
       },
       "taskList": {
         "name": "tl-1"

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -165,10 +165,8 @@ func (ts *IntegrationTestSuite) TestBasic() {
 	err := ts.executeWorkflow("test-basic", ts.workflows.Basic, &expected)
 	ts.NoError(err)
 	ts.EqualValues(expected, ts.activities.invoked())
-	// See https://grokbase.com/p/gg/golang-nuts/153jjj8dgg/go-nuts-fm-suffix-in-function-name-what-does-it-mean
-	// for explanation of -fm postfix.
 	ts.Equal([]string{"ExecuteWorkflow begin", "ExecuteActivity", "ExecuteActivity", "ExecuteWorkflow end"},
-		ts.tracer.GetTrace("Basic-fm"))
+		ts.tracer.GetTrace("Basic"))
 }
 
 func (ts *IntegrationTestSuite) TestActivityRetryOnError() {
@@ -374,7 +372,7 @@ func (ts *IntegrationTestSuite) TestChildWFWithMemoAndSearchAttributes() {
 	ts.NoError(err)
 	ts.EqualValues([]string{"getMemoAndSearchAttr"}, ts.activities.invoked())
 	ts.Equal("memoVal, searchAttrVal", result)
-	ts.Equal([]string{"ExecuteWorkflow begin", "ExecuteChildWorkflow", "ExecuteWorkflow end"}, ts.tracer.GetTrace("ChildWorkflowSuccess-fm"))
+	ts.Equal([]string{"ExecuteWorkflow begin", "ExecuteChildWorkflow", "ExecuteWorkflow end"}, ts.tracer.GetTrace("ChildWorkflowSuccess"))
 }
 
 func (ts *IntegrationTestSuite) TestChildWFWithParentClosePolicyTerminate() {

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -452,8 +452,10 @@ func (w *Workflows) RetryTimeoutStableErrorWorkflow(ctx workflow.Context) ([]str
 		},
 	}
 	ctx = workflow.WithActivityOptions(ctx, ao)
-
-	err := workflow.ExecuteActivity(ctx, "RetryTimeoutStableErrorActivity").Get(ctx, nil)
+	// Test calling activity by method pointer
+	// As Go allows nil receiver pointers it works fine
+	var a *Activities
+	err := workflow.ExecuteActivity(ctx, a.RetryTimeoutStableErrorActivity).Get(ctx, nil)
 
 	cerr, ok := err.(*cadence.CustomError)
 	if !ok {

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -109,7 +109,7 @@ func (w *Workflows) ActivityRetryOnTimeout(ctx workflow.Context, timeoutType sha
 	ctx = workflow.WithActivityOptions(ctx, opts)
 
 	startTime := workflow.Now(ctx)
-	err := workflow.ExecuteActivity(ctx, "Activities_Sleep", 2*time.Second).Get(ctx, nil)
+	err := workflow.ExecuteActivity(ctx, "Sleep", 2*time.Second).Get(ctx, nil)
 	if err == nil {
 		return nil, fmt.Errorf("expected activity to fail but succeeded")
 	}
@@ -138,7 +138,7 @@ func (w *Workflows) ActivityRetryOnHBTimeout(ctx workflow.Context) ([]string, er
 
 	var result int
 	startTime := workflow.Now(ctx)
-	err := workflow.ExecuteActivity(ctx, "Activities_HeartbeatAndSleep", 0, 2*time.Second).Get(ctx, &result)
+	err := workflow.ExecuteActivity(ctx, "HeartbeatAndSleep", 0, 2*time.Second).Get(ctx, &result)
 	if err == nil {
 		return nil, fmt.Errorf("expected activity to fail but succeeded")
 	}
@@ -453,7 +453,7 @@ func (w *Workflows) RetryTimeoutStableErrorWorkflow(ctx workflow.Context) ([]str
 	}
 	ctx = workflow.WithActivityOptions(ctx, ao)
 
-	err := workflow.ExecuteActivity(ctx, "Activities_RetryTimeoutStableErrorActivity").Get(ctx, nil)
+	err := workflow.ExecuteActivity(ctx, "RetryTimeoutStableErrorActivity").Get(ctx, nil)
 
 	cerr, ok := err.(*cadence.CustomError)
 	if !ok {
@@ -487,13 +487,13 @@ func (w *Workflows) childForMemoAndSearchAttr(ctx workflow.Context) (result stri
 		return
 	}
 	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
-	err = workflow.ExecuteActivity(ctx, "Activities_GetMemoAndSearchAttr", memo, searchAttr).Get(ctx, &result)
+	err = workflow.ExecuteActivity(ctx, "GetMemoAndSearchAttr", memo, searchAttr).Get(ctx, &result)
 	return
 }
 
 func (w *Workflows) sleep(ctx workflow.Context, d time.Duration) error {
 	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
-	return workflow.ExecuteActivity(ctx, "Activities_Sleep", d).Get(ctx, nil)
+	return workflow.ExecuteActivity(ctx, "Sleep", d).Get(ctx, nil)
 }
 
 func (w *Workflows) InspectActivityInfo(ctx workflow.Context) error {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
These changes allow executing activities within structs by directly passing function pointer instead of manually constructing function name.

For example, given the following registration:
```
func register(w worker.Worker) {
  w.RegisterActivityWithOptions(&myActivity{}, activity.RegisterOptions{Name: "some-prefix"})
}

type myActivity struct {}
func (m *myActivity) Run() error {}
```

One can execute it with:
```
var my *myActivity
future := workflow.ExecuteActivity(ctx, my.Run)
```

Instead of manually constructing string name like:
```
future := workflow.ExecuteActivity(ctx, "some-prefix_Run")
```

<!-- Tell your future self why have you made these changes -->
**Why?**
Manual activity name string construction is not straightforward, involves internal logic how this string is formatted by cadence client and is a subject to get outdated if activity method get renamed.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests, integration tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
