### PR TITLE
Backwards compatible activity type names

### DIFF
--- a/evictiontest/workflow_cache_eviction_test.go
+++ b/evictiontest/workflow_cache_eviction_test.go
@@ -130,7 +130,7 @@ func (s *CacheEvictionSuite) TestResetStickyOnEviction() {
 		ret := &m.PollForDecisionTaskResponse{
 			TaskToken:              make([]byte, 5),
 			WorkflowExecution:      &m.WorkflowExecution{WorkflowId: workflowID, RunId: runID},
-			WorkflowType:           &m.WorkflowType{Name: common.StringPtr("testReplayWorkflow")},
+			WorkflowType:           &m.WorkflowType{Name: common.StringPtr("go.uber.org/cadence/evictiontest.testReplayWorkflow")},
 			History:                &m.History{Events: testEvents},
 			PreviousStartedEventId: common.Int64Ptr(5)}
 		return ret, nil

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -61,6 +61,10 @@ type (
 		// When an activity is part of a structure then each member of the structure becomes an activity with
 		// this Name as a prefix + activity function name.
 		Name                          string
+		// Activity type name is equal to function name instead of fully qualified
+		// name including function package (and struct type if used).
+		// This option has no effect when explicit Name is provided.
+		EnableShortName               bool
 		DisableAlreadyRegisteredCheck bool
 	}
 

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1091,8 +1091,6 @@ func getFunctionName(i interface{}) string {
 		return fullName
 	}
 	fullName := runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
-	elements := strings.Split(fullName, ".")
-	shortName := elements[len(elements)-1]
 	// This allows to call activities by method pointer
 	// Compiler adds -fm suffix to a function name which has a receiver
 	// Note that this works even if struct pointer used to get the function is nil
@@ -1101,7 +1099,7 @@ func getFunctionName(i interface{}) string {
 	// var a *Activities
 	// ExecuteActivity(ctx, a.Foo)
 	// will call this function which is going to return "Foo"
-	return strings.TrimSuffix(shortName, "-fm")
+	return strings.TrimSuffix(fullName, "-fm")
 }
 
 func getActivityFunctionName(r *registry, i interface{}) string {

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -219,7 +219,7 @@ func (s *internalWorkerTestSuite) TestReplayWorkflowHistory() {
 	taskList := "taskList1"
 	testEvents := []*shared.HistoryEvent{
 		createTestEventWorkflowExecutionStarted(1, &shared.WorkflowExecutionStartedEventAttributes{
-			WorkflowType: &shared.WorkflowType{Name: common.StringPtr("testReplayWorkflow")},
+			WorkflowType: &shared.WorkflowType{Name: common.StringPtr("go.uber.org/cadence/internal.testReplayWorkflow")},
 			TaskList:     &shared.TaskList{Name: common.StringPtr(taskList)},
 			Input:        testEncodeFunctionArgs(getDefaultDataConverter()),
 		}),
@@ -261,7 +261,7 @@ func (s *internalWorkerTestSuite) TestReplayWorkflowHistory_LocalActivity() {
 	taskList := "taskList1"
 	testEvents := []*shared.HistoryEvent{
 		createTestEventWorkflowExecutionStarted(1, &shared.WorkflowExecutionStartedEventAttributes{
-			WorkflowType: &shared.WorkflowType{Name: common.StringPtr("testReplayWorkflowLocalActivity")},
+			WorkflowType: &shared.WorkflowType{Name: common.StringPtr("go.uber.org/cadence/internal.testReplayWorkflowLocalActivity")},
 			TaskList:     &shared.TaskList{Name: common.StringPtr(taskList)},
 			Input:        testEncodeFunctionArgs(getDefaultDataConverter()),
 		}),
@@ -379,7 +379,7 @@ func (s *internalWorkerTestSuite) testDecisionTaskHandlerHelper(params workerExe
 		createTestEventDecisionTaskStarted(3),
 	}
 
-	workflowType := "testReplayWorkflow"
+	workflowType := "go.uber.org/cadence/internal.testReplayWorkflow"
 	workflowID := "testID"
 	runID := "testRunID"
 
@@ -799,30 +799,30 @@ func (w activitiesCallingOptionsWorkflow) Execute(ctx Context, input []byte) (re
 	require.True(w.t, **rStruct2Ptr == testActivityResult{Index: 10})
 
 	// By names.
-	err = ExecuteActivity(ctx, "testActivityByteArgs", input).Get(ctx, nil)
+	err = ExecuteActivity(ctx, "go.uber.org/cadence/internal.testActivityByteArgs", input).Get(ctx, nil)
 	require.NoError(w.t, err, err)
 
 	err = ExecuteActivity(ctx, "testActivityMultipleArgs", 2, []string{"test"}, true).Get(ctx, nil)
 	require.NoError(w.t, err, err)
 
-	err = ExecuteActivity(ctx, "testActivityNoResult", 2, "test").Get(ctx, nil)
+	err = ExecuteActivity(ctx, "go.uber.org/cadence/internal.testActivityNoResult", 2, "test").Get(ctx, nil)
 	require.NoError(w.t, err, err)
 
-	err = ExecuteActivity(ctx, "testActivityNoContextArg", 2, "test").Get(ctx, nil)
+	err = ExecuteActivity(ctx, "go.uber.org/cadence/internal.testActivityNoContextArg", 2, "test").Get(ctx, nil)
 	require.NoError(w.t, err, err)
 
-	f = ExecuteActivity(ctx, "testActivityReturnString")
+	f = ExecuteActivity(ctx, "go.uber.org/cadence/internal.testActivityReturnString")
 	err = f.Get(ctx, &rString)
 	require.NoError(w.t, err, err)
 	require.Equal(w.t, "testActivity", rString, rString)
 
-	f = ExecuteActivity(ctx, "testActivityReturnEmptyString")
+	f = ExecuteActivity(ctx, "go.uber.org/cadence/internal.testActivityReturnEmptyString")
 	var r2sString string
 	err = f.Get(ctx, &r2String)
 	require.NoError(w.t, err, err)
 	require.Equal(w.t, "", r2sString)
 
-	f = ExecuteActivity(ctx, "testActivityReturnEmptyStruct")
+	f = ExecuteActivity(ctx, "go.uber.org/cadence/internal.testActivityReturnEmptyStruct")
 	err = f.Get(ctx, &r2Struct)
 	require.NoError(w.t, err, err)
 	require.Equal(w.t, testActivityResult{}, r2Struct)

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -166,6 +166,7 @@ func returnPanicWorkflow(ctx Context) (err error) {
 
 func (s *WorkflowUnitTest) Test_SplitJoinActivityWorkflow() {
 	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflowWithOptions(splitJoinActivityWorkflow, RegisterWorkflowOptions{Name: "splitJoinActivityWorkflow"})
 	env.RegisterActivityWithOptions(testAct, RegisterActivityOptions{Name: "testActivityWithOptions"})
 	env.OnActivity(testAct, mock.Anything).Return(func(ctx context.Context) (string, error) {
 		activityID := GetActivityInfo(ctx).ActivityID

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -163,7 +163,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_OnActivityStartedListener() {
 
 	env := s.NewTestWorkflowEnvironment()
 	env.RegisterWorkflow(workflowFn)
-	env.RegisterActivity(testActivityHello)
+	env.RegisterActivityWithOptions(testActivityHello, RegisterActivityOptions{Name: "testActivityHello"})
 
 	var activityCalls []string
 	env.SetOnActivityStartedListener(func(activityInfo *ActivityInfo, ctx context.Context, args Values) {
@@ -745,7 +745,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflow_Mock_Panic_GetChildWorkfl
 	}
 
 	env := s.NewTestWorkflowEnvironment()
-	env.RegisterWorkflow(testWorkflowHello)
+	env.RegisterWorkflowWithOptions(testWorkflowHello, RegisterWorkflowOptions{Name: "testWorkflowHello"})
 	env.RegisterWorkflow(workflowFn)
 	env.OnWorkflow(testWorkflowHello, mock.Anything, mock.Anything, mock.Anything).
 		Return("mock_result", nil, "extra_argument") // extra arg causes panic
@@ -803,7 +803,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflow_Listener() {
 
 	env := s.NewTestWorkflowEnvironment()
 	env.RegisterWorkflow(workflowFn)
-	env.RegisterWorkflow(testWorkflowHello)
+	env.RegisterWorkflowWithOptions(testWorkflowHello, RegisterWorkflowOptions{Name: "testWorkflowHello"})
 	env.RegisterActivity(testActivityHello)
 
 	var childWorkflowName, childWorkflowResult string
@@ -1524,7 +1524,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowFriendlyName() {
 
 	env := s.NewTestWorkflowEnvironment()
 	env.RegisterWorkflow(workflowFn)
-	env.RegisterWorkflow(testWorkflowHello)
+	env.RegisterWorkflowWithOptions(testWorkflowHello, RegisterWorkflowOptions{Name: "testWorkflowHello"})
 	env.RegisterActivity(testActivityHello)
 	var called []string
 	env.SetOnChildWorkflowStartedListener(func(workflowInfo *WorkflowInfo, ctx Context, args Values) {

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -80,6 +80,10 @@ func (r *registry) RegisterWorkflowWithOptions(
 	fnName := getFunctionName(wf)
 	alias := options.Name
 	registerName := fnName
+
+	if options.EnableShortName {
+		registerName = getShortFunctionName(fnName)
+	}
 	if len(alias) > 0 {
 		registerName = alias
 	}
@@ -93,8 +97,8 @@ func (r *registry) RegisterWorkflowWithOptions(
 		}
 	}
 	r.workflowFuncMap[registerName] = wf
-	if len(alias) > 0 {
-		r.workflowAliasMap[fnName] = alias
+	if len(alias) > 0 || options.EnableShortName {
+		r.workflowAliasMap[fnName] = registerName
 	}
 }
 

--- a/internal/registry_test.go
+++ b/internal/registry_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkflowRegistration(t *testing.T) {
+	tests := []struct{
+		msg string
+		register func(r *registry)
+		workflowType string
+		resolveByFunction interface{}
+		resolveByAlias string
+	}{
+		{
+			msg: "register workflow function",
+			register: func(r *registry) { r.RegisterWorkflow(testWorkflowFunction) },
+			workflowType: "go.uber.org/cadence/internal.testWorkflowFunction",
+			resolveByFunction: testWorkflowFunction,
+		},
+		{
+			msg: "register workflow function with alias",
+			register: func(r *registry) { r.RegisterWorkflowWithOptions(testWorkflowFunction, RegisterWorkflowOptions{Name:"workflow.alias"}) },
+			workflowType: "workflow.alias",
+			resolveByFunction: testWorkflowFunction,
+			resolveByAlias: "workflow.alias",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			r := newRegistry()
+			tt.register(r)
+
+			// Verify registered workflow type
+			workflowType := r.getRegisteredWorkflowTypes()[0]
+			require.Equal(t, tt.workflowType, workflowType)
+
+			// Verify workflow is resolved from workflow type
+			_, ok := r.getWorkflowFn(tt.workflowType)
+			require.True(t, ok)
+
+			// Verify resolving by function reference
+			workflowType = getWorkflowFunctionName(r, tt.resolveByFunction)
+			require.Equal(t, tt.workflowType, workflowType)
+
+			// Verify resolving by alias
+			if tt.resolveByAlias != "" {
+				workflowType = getWorkflowFunctionName(r, tt.resolveByAlias)
+				require.Equal(t, tt.workflowType, workflowType)
+			}
+		})
+	}
+}
+
+func TestActivityRegistration(t *testing.T) {
+	tests := []struct{
+		msg string
+		register func(r *registry)
+		activityType string
+		resolveByFunction interface{}
+		resolveByAlias string
+	}{
+		{
+			msg: "register activity function",
+			register: func(r *registry) { r.RegisterActivity(testActivityFunction) },
+			activityType: "go.uber.org/cadence/internal.testActivityFunction",
+			resolveByFunction: testActivityFunction,
+		},
+		{
+			msg: "register activity function with short name",
+			register: func(r *registry) { r.RegisterActivityWithOptions(testActivityFunction, RegisterActivityOptions{EnableShortName:true}) },
+			activityType: "testActivityFunction",
+			resolveByFunction: testActivityFunction,
+		},
+		{
+			msg: "register activity function with an alias",
+			register: func(r *registry) { r.RegisterActivityWithOptions(testActivityFunction, RegisterActivityOptions{Name:"activity.alias"}) },
+			activityType: "activity.alias",
+			resolveByFunction: testActivityFunction,
+			resolveByAlias: "activity.alias",
+		},
+		{
+			msg: "register activity struct",
+			register: func(r *registry) { r.RegisterActivity(&testActivityStruct{}) },
+			activityType: "go.uber.org/cadence/internal.(*testActivityStruct).Method",
+			resolveByFunction: (&testActivityStruct{}).Method,
+		},
+		{
+			msg: "register activity struct with short name",
+			register: func(r *registry) { r.RegisterActivityWithOptions(&testActivityStruct{}, RegisterActivityOptions{EnableShortName:true})},
+			activityType: "Method",
+			resolveByFunction: (&testActivityStruct{}).Method,
+		},
+		{
+			msg: "register activity struct with a prefix",
+			register: func(r *registry) { r.RegisterActivityWithOptions(&testActivityStruct{}, RegisterActivityOptions{Name:"prefix."}) },
+			activityType: "prefix.Method",
+			resolveByFunction: (&testActivityStruct{}).Method,
+			resolveByAlias: "prefix.Method",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			r := newRegistry()
+			tt.register(r)
+
+			// Verify registered activity type
+			activityType := r.getRegisteredActivities()[0].ActivityType().Name
+			require.Equal(t, tt.activityType, activityType, "activity type")
+
+			// Verify activity is resolved from activity type
+			_, ok := r.GetActivity(tt.activityType)
+			require.True(t, ok)
+
+			// Verify resolving by function reference
+			activityType = getActivityFunctionName(r, tt.resolveByFunction)
+			require.Equal(t, tt.activityType, activityType, "resolve by function reference")
+
+			// Verify resolving by alias
+			if tt.resolveByAlias != "" {
+				activityType = getActivityFunctionName(r, tt.resolveByAlias)
+				require.Equal(t, tt.activityType, activityType, "resolve by alias")
+			}
+		})
+	}
+}
+
+type testActivityStruct struct {}
+func (ts *testActivityStruct) Method() error { return nil }
+
+func testActivityFunction() error { return nil }
+func testWorkflowFunction(ctx Context) error { return nil }

--- a/internal/registry_test.go
+++ b/internal/registry_test.go
@@ -22,29 +22,40 @@ package internal
 
 import (
 	"testing"
+
 	"github.com/stretchr/testify/require"
 )
 
 func TestWorkflowRegistration(t *testing.T) {
-	tests := []struct{
-		msg string
-		register func(r *registry)
-		workflowType string
+	tests := []struct {
+		msg               string
+		register          func(r *registry)
+		workflowType      string
 		resolveByFunction interface{}
-		resolveByAlias string
+		resolveByAlias    string
 	}{
 		{
-			msg: "register workflow function",
-			register: func(r *registry) { r.RegisterWorkflow(testWorkflowFunction) },
-			workflowType: "go.uber.org/cadence/internal.testWorkflowFunction",
+			msg:               "register workflow function",
+			register:          func(r *registry) { r.RegisterWorkflow(testWorkflowFunction) },
+			workflowType:      "go.uber.org/cadence/internal.testWorkflowFunction",
+			resolveByFunction: testWorkflowFunction,
+		},
+		{
+			msg: "register workflow function with short name",
+			register: func(r *registry) {
+				r.RegisterWorkflowWithOptions(testWorkflowFunction, RegisterWorkflowOptions{EnableShortName: true})
+			},
+			workflowType:      "testWorkflowFunction",
 			resolveByFunction: testWorkflowFunction,
 		},
 		{
 			msg: "register workflow function with alias",
-			register: func(r *registry) { r.RegisterWorkflowWithOptions(testWorkflowFunction, RegisterWorkflowOptions{Name:"workflow.alias"}) },
-			workflowType: "workflow.alias",
+			register: func(r *registry) {
+				r.RegisterWorkflowWithOptions(testWorkflowFunction, RegisterWorkflowOptions{Name: "workflow.alias"})
+			},
+			workflowType:      "workflow.alias",
 			resolveByFunction: testWorkflowFunction,
-			resolveByAlias: "workflow.alias",
+			resolveByAlias:    "workflow.alias",
 		},
 	}
 
@@ -75,50 +86,58 @@ func TestWorkflowRegistration(t *testing.T) {
 }
 
 func TestActivityRegistration(t *testing.T) {
-	tests := []struct{
-		msg string
-		register func(r *registry)
-		activityType string
+	tests := []struct {
+		msg               string
+		register          func(r *registry)
+		activityType      string
 		resolveByFunction interface{}
-		resolveByAlias string
+		resolveByAlias    string
 	}{
 		{
-			msg: "register activity function",
-			register: func(r *registry) { r.RegisterActivity(testActivityFunction) },
-			activityType: "go.uber.org/cadence/internal.testActivityFunction",
+			msg:               "register activity function",
+			register:          func(r *registry) { r.RegisterActivity(testActivityFunction) },
+			activityType:      "go.uber.org/cadence/internal.testActivityFunction",
 			resolveByFunction: testActivityFunction,
 		},
 		{
 			msg: "register activity function with short name",
-			register: func(r *registry) { r.RegisterActivityWithOptions(testActivityFunction, RegisterActivityOptions{EnableShortName:true}) },
-			activityType: "testActivityFunction",
+			register: func(r *registry) {
+				r.RegisterActivityWithOptions(testActivityFunction, RegisterActivityOptions{EnableShortName: true})
+			},
+			activityType:      "testActivityFunction",
 			resolveByFunction: testActivityFunction,
 		},
 		{
 			msg: "register activity function with an alias",
-			register: func(r *registry) { r.RegisterActivityWithOptions(testActivityFunction, RegisterActivityOptions{Name:"activity.alias"}) },
-			activityType: "activity.alias",
+			register: func(r *registry) {
+				r.RegisterActivityWithOptions(testActivityFunction, RegisterActivityOptions{Name: "activity.alias"})
+			},
+			activityType:      "activity.alias",
 			resolveByFunction: testActivityFunction,
-			resolveByAlias: "activity.alias",
+			resolveByAlias:    "activity.alias",
 		},
 		{
-			msg: "register activity struct",
-			register: func(r *registry) { r.RegisterActivity(&testActivityStruct{}) },
-			activityType: "go.uber.org/cadence/internal.(*testActivityStruct).Method",
+			msg:               "register activity struct",
+			register:          func(r *registry) { r.RegisterActivity(&testActivityStruct{}) },
+			activityType:      "go.uber.org/cadence/internal.(*testActivityStruct).Method",
 			resolveByFunction: (&testActivityStruct{}).Method,
 		},
 		{
 			msg: "register activity struct with short name",
-			register: func(r *registry) { r.RegisterActivityWithOptions(&testActivityStruct{}, RegisterActivityOptions{EnableShortName:true})},
-			activityType: "Method",
+			register: func(r *registry) {
+				r.RegisterActivityWithOptions(&testActivityStruct{}, RegisterActivityOptions{EnableShortName: true})
+			},
+			activityType:      "Method",
 			resolveByFunction: (&testActivityStruct{}).Method,
 		},
 		{
 			msg: "register activity struct with a prefix",
-			register: func(r *registry) { r.RegisterActivityWithOptions(&testActivityStruct{}, RegisterActivityOptions{Name:"prefix."}) },
-			activityType: "prefix.Method",
+			register: func(r *registry) {
+				r.RegisterActivityWithOptions(&testActivityStruct{}, RegisterActivityOptions{Name: "prefix."})
+			},
+			activityType:      "prefix.Method",
 			resolveByFunction: (&testActivityStruct{}).Method,
-			resolveByAlias: "prefix.Method",
+			resolveByAlias:    "prefix.Method",
 		},
 	}
 	for _, tt := range tests {
@@ -147,8 +166,9 @@ func TestActivityRegistration(t *testing.T) {
 	}
 }
 
-type testActivityStruct struct {}
+type testActivityStruct struct{}
+
 func (ts *testActivityStruct) Method() error { return nil }
 
-func testActivityFunction() error { return nil }
+func testActivityFunction() error            { return nil }
 func testWorkflowFunction(ctx Context) error { return nil }

--- a/internal/testdata/parentWF.json
+++ b/internal/testdata/parentWF.json
@@ -6,7 +6,7 @@
   "taskId": 50331648,
   "workflowExecutionStartedEventAttributes": {
     "workflowType": {
-      "name": "testReplayWorkflowFromFileParent"
+      "name": "go.uber.org/cadence/internal.testReplayWorkflowFromFileParent"
     },
     "taskList": {
       "name": "childWorkflowGroup"

--- a/internal/testdata/sampleHistory.json
+++ b/internal/testdata/sampleHistory.json
@@ -5,7 +5,7 @@
     "eventType": "WorkflowExecutionStarted",
     "workflowExecutionStartedEventAttributes": {
       "workflowType": {
-        "name": "testReplayWorkflowFromFile"
+        "name": "go.uber.org/cadence/internal.testReplayWorkflowFromFile"
       },
       "taskList": {
         "name": "taskList1"

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -226,7 +226,10 @@ type (
 
 // RegisterWorkflowOptions consists of options for registering a workflow
 type RegisterWorkflowOptions struct {
-	Name                          string
+	Name string
+	// Workflow type name is equal to function name instead of fully qualified name including function package.
+	// This option has no effect when explicit Name is provided.
+	EnableShortName               bool
 	DisableAlreadyRegisteredCheck bool
 }
 

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -150,7 +150,7 @@ func (a *Activities) InspectActivityInfo(ctx context.Context, domain, taskList, 
 
 func (a *Activities) register(worker worker.Worker) {
 	// Kept to verify backward compatibility of activity registration.
-	activity.RegisterWithOptions(a, activity.RegisterOptions{DisableAlreadyRegisteredCheck: true})
+	activity.RegisterWithOptions(a, activity.RegisterOptions{Name: "Activities_", DisableAlreadyRegisteredCheck: true})
 	// Check reregistration
 	worker.RegisterActivityWithOptions(a.fail, activity.RegisterOptions{Name: "Fail", DisableAlreadyRegisteredCheck: true})
 	// Check prefix

--- a/test/fixtures/activity.cancel.sm.repro.json
+++ b/test/fixtures/activity.cancel.sm.repro.json
@@ -6,7 +6,7 @@
     "version": -24,
     "workflowExecutionStartedEventAttributes": {
       "workflowType": {
-        "name": "ActivityCancelRepro"
+        "name": "go.uber.org/cadence/test.(*Workflows).ActivityCancelRepro"
       },
       "taskList": {
         "name": "tl-1"

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -166,7 +166,7 @@ func (ts *IntegrationTestSuite) TestBasic() {
 	ts.NoError(err)
 	ts.EqualValues(expected, ts.activities.invoked())
 	ts.Equal([]string{"ExecuteWorkflow begin", "ExecuteActivity", "ExecuteActivity", "ExecuteWorkflow end"},
-		ts.tracer.GetTrace("Basic"))
+		ts.tracer.GetTrace("go.uber.org/cadence/test.(*Workflows).Basic"))
 }
 
 func (ts *IntegrationTestSuite) TestActivityRetryOnError() {
@@ -372,7 +372,8 @@ func (ts *IntegrationTestSuite) TestChildWFWithMemoAndSearchAttributes() {
 	ts.NoError(err)
 	ts.EqualValues([]string{"getMemoAndSearchAttr"}, ts.activities.invoked())
 	ts.Equal("memoVal, searchAttrVal", result)
-	ts.Equal([]string{"ExecuteWorkflow begin", "ExecuteChildWorkflow", "ExecuteWorkflow end"}, ts.tracer.GetTrace("ChildWorkflowSuccess"))
+	ts.Equal([]string{"ExecuteWorkflow begin", "ExecuteChildWorkflow", "ExecuteWorkflow end"},
+		ts.tracer.GetTrace("go.uber.org/cadence/test.(*Workflows).ChildWorkflowSuccess"))
 }
 
 func (ts *IntegrationTestSuite) TestChildWFWithParentClosePolicyTerminate() {

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -109,7 +109,7 @@ func (w *Workflows) ActivityRetryOnTimeout(ctx workflow.Context, timeoutType sha
 	ctx = workflow.WithActivityOptions(ctx, opts)
 
 	startTime := workflow.Now(ctx)
-	err := workflow.ExecuteActivity(ctx, "Sleep", 2*time.Second).Get(ctx, nil)
+	err := workflow.ExecuteActivity(ctx, "Activities_Sleep", 2*time.Second).Get(ctx, nil)
 	if err == nil {
 		return nil, fmt.Errorf("expected activity to fail but succeeded")
 	}
@@ -138,7 +138,7 @@ func (w *Workflows) ActivityRetryOnHBTimeout(ctx workflow.Context) ([]string, er
 
 	var result int
 	startTime := workflow.Now(ctx)
-	err := workflow.ExecuteActivity(ctx, "HeartbeatAndSleep", 0, 2*time.Second).Get(ctx, &result)
+	err := workflow.ExecuteActivity(ctx, "Activities_HeartbeatAndSleep", 0, 2*time.Second).Get(ctx, &result)
 	if err == nil {
 		return nil, fmt.Errorf("expected activity to fail but succeeded")
 	}
@@ -489,13 +489,13 @@ func (w *Workflows) childForMemoAndSearchAttr(ctx workflow.Context) (result stri
 		return
 	}
 	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
-	err = workflow.ExecuteActivity(ctx, "GetMemoAndSearchAttr", memo, searchAttr).Get(ctx, &result)
+	err = workflow.ExecuteActivity(ctx, "Activities_GetMemoAndSearchAttr", memo, searchAttr).Get(ctx, &result)
 	return
 }
 
 func (w *Workflows) sleep(ctx workflow.Context, d time.Duration) error {
 	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
-	return workflow.ExecuteActivity(ctx, "Sleep", d).Get(ctx, nil)
+	return workflow.ExecuteActivity(ctx, "Activities_Sleep", d).Get(ctx, nil)
 }
 
 func (w *Workflows) InspectActivityInfo(ctx workflow.Context) error {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This change reverts shortening when no activity alias (prefix) is provided.
The use of prefix shortens the name, assuming the users responsibility to
choose proper prefix. Additionally added an option to enable shorted names.

<!-- Tell your future self why have you made these changes -->
**Why?**
Previously merged shortened activity type names of form {Method} is not
compatible with current users of this client, since multiple activities
in different packages with the same name results in naming conflicts.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
