### PR TITLE
Pass retry policy when completing with continue as new

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -629,6 +629,7 @@ func (wth *workflowTaskHandlerImpl) createWorkflowContext(task *s.PollForDecisio
 		ParentWorkflowExecution:             parentWorkflowExecution,
 		Memo:                                attributes.Memo,
 		SearchAttributes:                    attributes.SearchAttributes,
+		RetryPolicy:                         attributes.RetryPolicy,
 	}
 
 	wfStartTime := time.Unix(0, h.Events[0].GetTimestamp())
@@ -1497,6 +1498,7 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 			Header:                              contErr.params.header,
 			Memo:                                workflowContext.workflowInfo.Memo,
 			SearchAttributes:                    workflowContext.workflowInfo.SearchAttributes,
+			RetryPolicy:                         workflowContext.workflowInfo.RetryPolicy,
 		}
 	} else if workflowContext.err != nil {
 		// Workflow failures

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -858,6 +858,12 @@ func (t *TaskHandlersTestSuite) TestGetWorkflowInfo() {
 	workflowType := "GetWorkflowInfoWorkflow"
 	lastCompletionResult, err := getDefaultDataConverter().ToData("lastCompletionData")
 	t.NoError(err)
+	retryPolicy := &s.RetryPolicy{
+		InitialIntervalInSeconds: common.Int32Ptr(1),
+		BackoffCoefficient:       common.Float64Ptr(1.0),
+		MaximumIntervalInSeconds: common.Int32Ptr(1),
+		MaximumAttempts:          common.Int32Ptr(3),
+	}
 	startedEventAttributes := &s.WorkflowExecutionStartedEventAttributes{
 		Input:                               lastCompletionResult,
 		TaskList:                            &s.TaskList{Name: &taskList},
@@ -869,6 +875,7 @@ func (t *TaskHandlersTestSuite) TestGetWorkflowInfo() {
 		ExecutionStartToCloseTimeoutSeconds: &executionTimeout,
 		TaskStartToCloseTimeoutSeconds:      &taskTimeout,
 		LastCompletionResult:                lastCompletionResult,
+		RetryPolicy:                         retryPolicy,
 	}
 	testEvents := []*s.HistoryEvent{
 		createTestEventWorkflowExecutionStarted(1, startedEventAttributes),
@@ -904,6 +911,7 @@ func (t *TaskHandlersTestSuite) TestGetWorkflowInfo() {
 	t.EqualValues(taskTimeout, result.TaskStartToCloseTimeoutSeconds)
 	t.EqualValues(workflowType, result.WorkflowType.Name)
 	t.EqualValues(testDomain, result.Domain)
+	t.EqualValues(retryPolicy, result.RetryPolicy)
 }
 
 func (t *TaskHandlersTestSuite) TestConsistentQuery_InvalidQueryTask() {

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -738,6 +738,7 @@ type WorkflowInfo struct {
 	Memo                                *s.Memo             // Value can be decoded using data converter (DefaultDataConverter, or custom one if set).
 	SearchAttributes                    *s.SearchAttributes // Value can be decoded using DefaultDataConverter.
 	BinaryChecksum                      *string
+	RetryPolicy                         *s.RetryPolicy
 }
 
 func (wInfo *WorkflowInfo) GetBinaryChecksum() string {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Save `RetryPolicy` into `WorkflowInfo` from `WorkflowExecutionStartedEventAttributes` and them pass it to `ContinueAsNewWorkflowExecutionDecisionAttributes` when completing the workflow.

<!-- Tell your future self why have you made these changes -->
**Why?**
Retry policy was not propagated when completing workflow with ContinueAsNew. 
https://github.com/uber/cadence/issues/3329

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added unit test.
Tested with local cadence server.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A