### PR TITLE
Fixed Windows compilation failure

### DIFF
--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"syscall"
 	"time"
@@ -265,7 +266,8 @@ func (bw *baseWorker) pollTask() {
 		if err != nil {
 			if isNonRetriableError(err) {
 				bw.logger.Error("Worker received non-retriable error. Shutting down.", zap.Error(err))
-				syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+				p, _ := os.FindProcess(os.Getpid())
+				p.Signal(syscall.SIGINT)
 				return
 			}
 			bw.retrier.Failed()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Replaced syscall usage


<!-- Tell your future self why have you made these changes -->
**Why?**
Compilation failure of the cadence worker on Windows
vendor\go.uber.org\cadence\internal\internal_worker_base.go:268:5: undefined syscall.Kill


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Successfully built on Windows machine

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

None
