### PR TITLE
Fix decoded panic when testing CustomError

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -60,7 +60,7 @@ type (
 		// When an activity is a function the name is an actual activity type name.
 		// When an activity is part of a structure then each member of the structure becomes an activity with
 		// this Name as a prefix + activity function name.
-		Name                          string
+		Name string
 		// Activity type name is equal to function name instead of fully qualified
 		// name including function package (and struct type if used).
 		// This option has no effect when explicit Name is provided.

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -404,6 +404,13 @@ func TestErrorDetailsValues(t *testing.T) {
 	require.Equal(t, ErrTooManyArg, e.Get(&a1, &a2, &a3, &a3))
 }
 
+func TestErrorDetailsValues_WrongDecodedType(t *testing.T) {
+	e := ErrorDetailsValues{testErrorDetails1}
+	var d1 int // will cause error since it should be of type string
+	err := e.Get(&d1)
+	require.Error(t, err)
+}
+
 func Test_SignalExternalWorkflowExecutionFailedError(t *testing.T) {
 	context := &workflowEnvironmentImpl{
 		decisionsHelper: newDecisionsHelper(),

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -285,6 +285,19 @@ func Test_CustomError_Pointer(t *testing.T) {
 	require.Equal(t, &testErrorDetails4, b2)
 }
 
+func Test_CustomError_WrongDecodedType(t *testing.T) {
+	err := NewCustomError("reason", testErrorDetails1, testErrorDetails2)
+	var d1 string
+	var d2 string // will cause error since it should be of type int
+	err1 := err.Details(&d1, &d2)
+	require.Error(t, err1)
+
+	err = NewCustomError("reason", testErrorDetails3)
+	var d3 testStruct2 // will cause error since it should be of type testStruct
+	err2 := err.Details(&d3)
+	require.Error(t, err2)
+}
+
 func Test_CanceledError(t *testing.T) {
 	// test ErrorDetailValues as Details
 	var a1 string

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -101,7 +101,13 @@ func (b ErrorDetailsValues) Get(valuePtr ...interface{}) error {
 		return ErrTooManyArg
 	}
 	for i, item := range valuePtr {
-		reflect.ValueOf(item).Elem().Set(reflect.ValueOf(b[i]))
+		target := reflect.ValueOf(item).Elem()
+		val := reflect.ValueOf(b[i])
+		if target.Type() != val.Type() {
+			return fmt.Errorf(
+				"unable to decode argument: cannot set %v value to %v field", val.Type(), target.Type())
+		}
+		target.Set(val)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix decoded panic when testing CustomError

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently when execute code like:
```
func TestCustomError(t *testing.T) {
	err := cadence.NewCustomError("reason", "string detail")
	var d struct{}
	e := err.Details(&d)
	assert.Error(t, e)
}
``` 
it will panic because of mismatch of types. 
This is inconsistent with runtime behavior (which will return error when get details), and causing issue for users unit tests. 

The fix is return error when type mis-match. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test; local test with sample.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
barely.