### PR TITLE
Fix GetWorkflowResult to return nil instead of ErrNoData

### DIFF
--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -584,7 +584,7 @@ func (t *TestWorkflowEnvironment) GetWorkflowResult(valuePtr interface{}) error 
 	if !t.impl.isTestCompleted {
 		panic("workflow is not completed")
 	}
-	if t.impl.testError != nil || t.impl.testResult == nil || valuePtr == nil {
+	if t.impl.testError != nil || t.impl.testResult == nil || t.impl.testResult.HasValue() == false || valuePtr == nil {
 		return t.impl.testError
 	}
 	return t.impl.testResult.Get(valuePtr)

--- a/internal/workflow_testsuite_test.go
+++ b/internal/workflow_testsuite_test.go
@@ -112,3 +112,23 @@ func TestNoExplicitRegistrationRequired(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "Hello World!", result)
 }
+
+func TestWorkflowReturnNil(t *testing.T) {
+	testSuite := &WorkflowTestSuite{}
+	env := testSuite.NewTestWorkflowEnvironment()
+
+	var isExecuted bool
+	testWF := func(ctx Context) error {
+		isExecuted = true
+		return nil
+	}
+	env.ExecuteWorkflow(testWF)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.True(t, isExecuted)
+
+	var r struct{}
+	err := env.GetWorkflowResult(&r)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix an issue for TestWokflowEnvironment `GetWorkflowResult` 

<!-- Tell your future self why have you made these changes -->
**Why?**
As a side effect of https://github.com/uber-go/cadence-client/pull/976, GetWorkflowResult will return ErrNoData instead of nil for workflow without return value. returning ErrNoData will be a breaking change and inconsistent with runtime behavior.
This PR fix it.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No