### PR TITLE
Fix local activity marker handler

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -1091,7 +1091,7 @@ func (weh *workflowExecutionEventHandlerImpl) handleLocalActivityMarker(markerDa
 	}
 
 	if la, ok := weh.pendingLaTasks[lamd.ActivityID]; ok {
-		if len(lamd.ActivityType) > 0 && lamd.ActivityType != la.params.ActivityType {
+		if len(lamd.ActivityType) > 0 && lastPartOfName(lamd.ActivityType) != lastPartOfName(la.params.ActivityType) {
 			// history marker mismatch to the current code.
 			panicMsg := fmt.Sprintf("code execute local activity %v, but history event found %v, markerData: %v", la.params.ActivityType, lamd.ActivityType, string(markerData))
 			panicIllegalState(panicMsg)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix local activity marker handler, to be less strict when comparing activity types.

<!-- Tell your future self why have you made these changes -->
**Why?**
After introduction of short activity names, event handler fails to
playback previously recorded markers with long names, as activity
type no longer match.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Modified existing unit test `TestReplayWorkflowHistory_LocalActivity_Activity_Type_Mismatch`. Please note that this test previously was not testing local activities at all (regular activities instead). 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
