### PR TITLE
Relax ErrorDetailsValues types matching

### DIFF
--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -47,12 +47,20 @@ type testStruct2 struct {
 	Favorites *[]string
 }
 
+type testErrorStruct struct {
+	message string
+}
+
 var (
 	testErrorDetails1 = "my details"
 	testErrorDetails2 = 123
 	testErrorDetails3 = testStruct{"a string", 321}
 	testErrorDetails4 = testStruct2{"a string", 321, &[]string{"eat", "code"}}
 )
+
+func (tes *testErrorStruct) Error() string{
+	return tes.message
+}
 
 func Test_GenericError(t *testing.T) {
 	// test activity error
@@ -409,6 +417,14 @@ func TestErrorDetailsValues_WrongDecodedType(t *testing.T) {
 	var d1 int // will cause error since it should be of type string
 	err := e.Get(&d1)
 	require.Error(t, err)
+}
+
+func TestErrorDetailsValues_AssignableType(t *testing.T) {
+	e := ErrorDetailsValues{&testErrorStruct{message: "my message"}}
+	var errorOut error
+	err := e.Get(&errorOut)
+	require.NoError(t, err)
+	require.Equal(t, "my message", errorOut.Error())
 }
 
 func Test_SignalExternalWorkflowExecutionFailedError(t *testing.T) {

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -103,7 +103,7 @@ func (b ErrorDetailsValues) Get(valuePtr ...interface{}) error {
 	for i, item := range valuePtr {
 		target := reflect.ValueOf(item).Elem()
 		val := reflect.ValueOf(b[i])
-		if target.Type() != val.Type() {
+		if !val.Type().AssignableTo(target.Type()) {
 			return fmt.Errorf(
 				"unable to decode argument: cannot set %v value to %v field", val.Type(), target.Type())
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Relaxed ErrorDetailsValues types matching.

<!-- Tell your future self why have you made these changes -->
**Why?**
Current check is too strict, because it requires types to match exactly.
Relax that, so that it can be assigned to any matching interface.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added additional unit test. 
Without relaxation, this unit test fails with:
`unable to decode argument: cannot set *internal.testErrorStruct value to error field`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
