### PR TITLE
Fix registry to resolve functions with -fm suffix

### DIFF
--- a/internal/registry.go
+++ b/internal/registry.go
@@ -220,6 +220,9 @@ func (r *registry) getWorkflowAlias(fnName string) (string, bool) {
 func (r *registry) getWorkflowFn(fnName string) (interface{}, bool) {
 	r.Lock() // do not defer for Unlock to call next.getWorkflowFn without lock
 	fn, ok := r.workflowFuncMap[fnName]
+	if !ok { // if exact match is not found, check for backwards compatible name without -fm suffix
+		fn, ok = r.workflowFuncMap[strings.TrimSuffix(fnName, "-fm")]
+	}
 	if !ok && r.next != nil {
 		r.Unlock()
 		return r.next.getWorkflowFn(fnName)
@@ -263,6 +266,9 @@ func (r *registry) addActivityWithLock(fnName string, a activity) {
 func (r *registry) GetActivity(fnName string) (activity, bool) {
 	r.Lock() // do not defer for Unlock to call next.GetActivity without lock
 	a, ok := r.activityFuncMap[fnName]
+	if !ok { // if exact match is not found, check for backwards compatible name without -fm suffix
+		a, ok = r.activityFuncMap[strings.TrimSuffix(fnName, "-fm")]
+	}
 	if !ok && r.next != nil {
 		r.Unlock()
 		return r.next.GetActivity(fnName)

--- a/test/fixtures/activity.cancel.sm.repro.json
+++ b/test/fixtures/activity.cancel.sm.repro.json
@@ -6,7 +6,7 @@
     "version": -24,
     "workflowExecutionStartedEventAttributes": {
       "workflowType": {
-        "name": "go.uber.org/cadence/test.(*Workflows).ActivityCancelRepro"
+        "name": "go.uber.org/cadence/test.(*Workflows).ActivityCancelRepro-fm"
       },
       "taskList": {
         "name": "tl-1"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
With this fix we check for exact match and then check for registered
function without -fm suffix for backwards compatibility.

<!-- Tell your future self why have you made these changes -->
**Why?**
With recent changes -fm suffix was dropped from function names.
This caused errors when resolving existing scheduled workflows and
activities.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Updated unit test to include cases with -fm suffix. Updated integration test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
