### PR TITLE
Fix workflow replay to ignore -fm suffix

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1227,6 +1227,7 @@ matchLoop:
 }
 
 func lastPartOfName(name string) string {
+	name = strings.TrimSuffix(name, "-fm")
 	lastDotIdx := strings.LastIndex(name, ".")
 	if lastDotIdx < 0 || lastDotIdx == len(name)-1 {
 		return name


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
When existing workflow is being replayed with old activity names
it can result in non-deterministic error if activity was scheduled
with older cadence client version.

<!-- Tell your future self why have you made these changes -->
**Why?**
Ignore the suffix the same way, as the rest part of name is ignored
by extracting only the `lastPartOfName`

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added additional unit test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
