### PR TITLE
add rpc request metrics with retry in consideration

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -521,6 +521,10 @@ func NewClient(service workflowserviceclient.Interface, domain string, options *
 		domain:             domain,
 		registry:           newRegistry(),
 		metricsScope:       metrics.NewTaggedScope(metricScope),
+		scope:              &scopeMetricsWrapper{
+			scope: metricScope,
+			childScopes: make(map[string]tally.Scope),
+		},
 		identity:           identity,
 		dataConverter:      dataConverter,
 		contextPropagators: contextPropagators,

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -500,8 +500,8 @@ func (wc *workflowClient) SignalWithStartWorkflow(ctx context.Context, workflowI
 	}
 
 	if wc.metricsScope != nil {
-		scope := wc.metricsScope.GetTaggedScope(tagTaskList, options.TaskList, tagWorkflowType, workflowType.Name)
-		scope.Counter(metrics.WorkflowSignalWithStartCounter).Inc(1)
+		taggedScope := wc.metricsScope.GetTaggedScope(tagTaskList, options.TaskList, tagWorkflowType, workflowType.Name)
+		taggedScope.Counter(metrics.WorkflowSignalWithStartCounter).Inc(1)
 	}
 
 	executionInfo := &WorkflowExecution{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
(#1015) Introduced new metrics for sync APIs that factors in retries as well.

<!-- Tell your future self why have you made these changes -->
**Why?**
Right now we have rpc metrics for single requests that does not factor in retry options. Since client does retries automatically, this does not tell the accurate story about the actual failure rate.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Not verified yet.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk.