### PR TITLE
Support Cron Schedule as part of the TestWorkflowEnvironment

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -264,8 +264,8 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite, parentRegistry *regist
 
 	// put current workflow as a running workflow so child can send signal to parent
 	testWorkflowHandle := &testWorkflowHandle{env: env, callback: func(result []byte, err error) {}}
-	if len(env.cronSchedule) > 0 {
-		testWorkflowHandle.params.cronSchedule = env.cronSchedule
+	if env.workflowInfo.CronSchedule != nil && len(*env.workflowInfo.CronSchedule) > 0 {
+		testWorkflowHandle.params.cronSchedule = *env.workflowInfo.CronSchedule
 	}
 	env.runningWorkflows[env.workflowInfo.WorkflowExecution.ID] = testWorkflowHandle
 
@@ -348,7 +348,6 @@ func (env *testWorkflowEnvironmentImpl) setStartTime(startTime time.Time) {
 
 func (env *testWorkflowEnvironmentImpl) setCronSchedule(cronSchedule string) {
 	env.workflowInfo.CronSchedule = &cronSchedule
-	env.cronSchedule = cronSchedule
 }
 
 func (env *testWorkflowEnvironmentImpl) setCronMaxIterationas(cronMaxIterations int) {
@@ -831,7 +830,7 @@ func (env *testWorkflowEnvironmentImpl) Complete(result []byte, err error) {
 	// Only close on:
 	// 1. Child-Workflows
 	// 2. non-cron Workflows
-	if !env.isChildWorkflow() && !env.IsCron() {
+	if env.isChildWorkflow() && !env.IsCron() {
 	  close(env.doneChannel)
 	}
 
@@ -998,7 +997,7 @@ func (env *testWorkflowEnvironmentImpl) GetLogger() *zap.Logger {
 	return env.logger
 }
 
- func (env *testWorkflowEnvironmentImpl) GetMetricsScope() tally.Scope {
+func (env *testWorkflowEnvironmentImpl) GetMetricsScope() tally.Scope {
 	return env.workerOptions.MetricsScope
 }
 

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -447,6 +447,23 @@ func (t *TestWorkflowEnvironment) SetWorkflowTimeout(executionTimeout time.Durat
 	return t
 }
 
+// SetWorkflowCronSchedule sets the Cron schedule for this tested workflow.
+// The first execution of the workflow will not adhere to the Cron schedule and will start executing immediately.
+// Consecutive iterations will follow the specified schedule.
+// Use SetWorkflowCronMaxIterations() to enforce a limit on the number of consecutive iterations after the initial
+// execution.
+func (t *TestWorkflowEnvironment) SetWorkflowCronSchedule(cron string) *TestWorkflowEnvironment {
+	t.impl.setCronSchedule(cron)
+	return t
+}
+
+// SetWorkflowCronMaxIterations sets the a limit on the number of Cron iterations, not including the first one
+// of the tested workflow.
+func (t *TestWorkflowEnvironment) SetWorkflowCronMaxIterations(maxIterations int) *TestWorkflowEnvironment {
+	t.impl.setCronMaxIterationas(maxIterations )
+	return t
+}
+
 // SetOnActivityStartedListener sets a listener that will be called before activity starts execution.
 // Note: ActivityInfo is defined in internal package, use public type activity.Info instead.
 func (t *TestWorkflowEnvironment) SetOnActivityStartedListener(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Allows setting a Cron schedule for non-child Workflows in the Test environment using
`SetWorkflowCronSchedule` and `SetWorkflowCronMaxIterations`.

<!-- Tell your future self why have you made these changes -->
**Why?**
I wanted to be able to run Cron Workflows and not have to wrap them inside the test Workflow.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Yes, local testing via unit tests + made sure my code can use the functionality

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Nothing, this is related only to the Workflow testing environment
