### PR TITLE
Fix the problem of ignoring the detail parameter in TerminateWorkflow function 

### DIFF
--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -473,6 +473,7 @@ func (wc *workflowClient) TerminateWorkflow(ctx context.Context, workflowID stri
 			RunId:      getRunID(runID),
 		},
 		Reason:   common.StringPtr(reason),
+		Details:  details,
 		Identity: common.StringPtr(wc.identity),
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add the **Details** field in TerminateWorkflowExecutionRequest in the terminateWorkflowExecutionRequest function

<!-- Tell your future self why have you made these changes -->
**Why?**
TerminateWorkflowExecutionRequest has the **Details** fields, but it was not included in the request and the details parameter passed to this function is unused. It should be included in the request so that detail parameter passed into this function is used.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
After making this change to my local cadence client project as I mentioned above, I replaced the go.uber.org/cadence project with my updated local cadence client project in my own workflow project. In order to validate my changes, I triggered a workflow and terminated it with detail information, and I checked the result through the cadence web UI and the detail information was clearly showed instead of showing null all the time in the past in this scenarios. 


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
I did not aware any potential risks by making this changes to this project. 


**Before making the change:**
<img width="414" alt="Screen Shot 2021-03-18 at 4 09 20 PM" src="https://user-images.githubusercontent.com/77617919/111592928-60c98b80-8804-11eb-9d57-e50101cd506e.png">

**After making the change:**
<img width="436" alt="Screen Shot 2021-03-18 at 3 36 46 PM" src="https://user-images.githubusercontent.com/77617919/111589409-c6ffdf80-87ff-11eb-883a-116bc26f0188.png">


