### PR TITLE
Minor test enhancement for local activity retries

### DIFF
--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -2438,8 +2438,6 @@ func (s *WorkflowTestSuiteUnitTest) Test_LocalActivityRetry() {
 		if err != nil {
 			return "", err
 		}
-
-		Sleep(ctx, time.Hour)
 		return result, nil
 	}
 


### PR DESCRIPTION
While looking into a user's issue with local activities retrying and not seeming to honor NonRetriableErrorReasons, I noticed that we had no tests for non-retriable local activity errors.
    
So this test now mimics `Test_ActivityRetry`, but with local activities and maybe better names.  No problems found.