### PR TITLE
Add workflow already completed error to client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -134,6 +134,7 @@ type (
 		// The errors it can return:
 		//	- EntityNotExistsError
 		//	- InternalServiceError
+		//	- WorkflowExecutionAlreadyCompletedError
 		SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error
 
 		// SignalWithStartWorkflow sends a signal to a running workflow.
@@ -154,6 +155,7 @@ type (
 		//	- EntityNotExistsError
 		//	- BadRequestError
 		//	- InternalServiceError
+		//	- WorkflowExecutionAlreadyCompletedError
 		CancelWorkflow(ctx context.Context, workflowID string, runID string) error
 
 		// TerminateWorkflow terminates a workflow execution.
@@ -164,6 +166,7 @@ type (
 		//	- EntityNotExistsError
 		//	- BadRequestError
 		//	- InternalServiceError
+		//	- WorkflowExecutionAlreadyCompletedError
 		TerminateWorkflow(ctx context.Context, workflowID string, runID string, reason string, details []byte) error
 
 		// GetWorkflowHistory gets history events of a particular workflow

--- a/internal/client.go
+++ b/internal/client.go
@@ -114,6 +114,7 @@ type (
 		// The errors it can return:
 		//	- EntityNotExistsError
 		//	- InternalServiceError
+		//	- WorkflowExecutionAlreadyCompletedError
 		SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error
 
 		// SignalWithStartWorkflow sends a signal to a running workflow.
@@ -136,6 +137,7 @@ type (
 		//	- EntityNotExistsError
 		//	- BadRequestError
 		//	- InternalServiceError
+		//	- WorkflowExecutionAlreadyCompletedError
 		CancelWorkflow(ctx context.Context, workflowID string, runID string) error
 
 		// TerminateWorkflow terminates a workflow execution.
@@ -146,6 +148,7 @@ type (
 		//	- EntityNotExistsError
 		//	- BadRequestError
 		//	- InternalServiceError
+		//	- WorkflowExecutionAlreadyCompletedError
 		TerminateWorkflow(ctx context.Context, workflowID string, runID string, reason string, details []byte) error
 
 		// GetWorkflowHistory gets history events of a particular workflow

--- a/internal/common/metrics/service_wrapper.go
+++ b/internal/common/metrics/service_wrapper.go
@@ -121,6 +121,7 @@ func (s *operationScope) handleError(err error) {
 			*shared.BadRequestError,
 			*shared.DomainAlreadyExistsError,
 			*shared.WorkflowExecutionAlreadyStartedError,
+			*shared.WorkflowExecutionAlreadyCompletedError,
 			*shared.QueryFailedError:
 			s.scope.Counter(CadenceInvalidRequest).Inc(1)
 		default:

--- a/internal/internal_retry.go
+++ b/internal/internal_retry.go
@@ -67,6 +67,7 @@ func isServiceTransientError(err error) bool {
 	case *s.BadRequestError,
 		*s.EntityNotExistsError,
 		*s.WorkflowExecutionAlreadyStartedError,
+		*s.WorkflowExecutionAlreadyCompletedError,
 		*s.DomainAlreadyExistsError,
 		*s.QueryFailedError,
 		*s.DomainNotActiveError,

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2027,7 +2027,7 @@ func (env *testWorkflowEnvironmentImpl) signalWorkflowByID(workflowID, signalNam
 
 	if workflowHandle, ok := env.runningWorkflows[workflowID]; ok {
 		if workflowHandle.handled {
-			return &shared.EntityNotExistsError{Message: fmt.Sprintf("Workflow %v already completed", workflowID)}
+			return &shared.WorkflowExecutionAlreadyCompletedError{Message: fmt.Sprintf("Workflow %v already completed", workflowID)}
 		}
 		workflowHandle.env.postCallback(func() {
 			workflowHandle.env.signalHandler(signalName, data)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding the new error type WorkflowExecutionAlreadyCompletedError to the client repo


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Test is in the server side diff: https://github.com/uber/cadence/pull/4123


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
