### PR TITLE
Ensure min number of scan workflow result for shadowing

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -530,6 +530,21 @@ func (env *testWorkflowEnvironmentImpl) executeActivity(
 	activityFn interface{},
 	args ...interface{},
 ) (Value, error) {
+	return env.executeActivityWithOptions(
+		activityOptions{
+			ScheduleToCloseTimeoutSeconds: 600,
+			StartToCloseTimeoutSeconds:    600,
+		},
+		activityFn,
+		args,
+	)
+}
+
+func (env *testWorkflowEnvironmentImpl) executeActivityWithOptions(
+	activityOptions activityOptions,
+	activityFn interface{},
+	args ...interface{},
+) (Value, error) {
 	activityType, err := getValidatedActivityFunction(activityFn, args, env.registry)
 	if err != nil {
 		panic(err)
@@ -541,13 +556,10 @@ func (env *testWorkflowEnvironmentImpl) executeActivity(
 	}
 
 	params := executeActivityParams{
-		activityOptions: activityOptions{
-			ScheduleToCloseTimeoutSeconds: 600,
-			StartToCloseTimeoutSeconds:    600,
-		},
-		ActivityType: *activityType,
-		Input:        input,
-		Header:       env.header,
+		activityOptions: activityOptions,
+		ActivityType:    *activityType,
+		Input:           input,
+		Header:          env.header,
 	}
 
 	task := newTestActivityTask(

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -536,7 +536,7 @@ func (env *testWorkflowEnvironmentImpl) executeActivity(
 			StartToCloseTimeoutSeconds:    600,
 		},
 		activityFn,
-		args,
+		args...,
 	)
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Ensure min number of scan workflow result for shadowing

<!-- Tell your future self why have you made these changes -->
**Why?**
If sampling rate is low is possible each scan workflow activity only return a very small number of results. We can keep scanning next page and batch the sampled workflows

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
