### PR TITLE
Handle completed workflows client's heartbeat

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1738,7 +1738,7 @@ func (i *cadenceInvoker) internalHeartBeat(details []byte) (bool, error) {
 		i.cancelHandler()
 		isActivityCancelled = true
 
-	case *s.EntityNotExistsError, *s.DomainNotActiveError:
+	case *s.EntityNotExistsError, *s.WorkflowExecutionAlreadyCompletedError, *s.DomainNotActiveError:
 		// We will pass these through as cancellation for now but something we can change
 		// later when we have setter on cancel handler.
 		i.cancelHandler()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Since we are changing the server APIs to return WorkflowExecutionAlreadyCompletedError when the workflow is complete. Client needs to be able to handle those errors. 

Will be tested with this diff: https://github.com/uber/cadence/pull/4123


<!-- Tell your future self why have you made these changes -->
**Why?**
More details: https://t3.uberinternal.com/browse/CDNC-615

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
