### PR TITLE
Ignore workflowPanicError in query task and add warn logs

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -781,8 +781,8 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessEvent(
 			topLine := fmt.Sprintf("process event for %s [panic]:", weh.workflowInfo.TaskListName)
 			st := getStackTraceRaw(topLine, 7, 0)
 			weh.logger.Error("ProcessEvent panic.",
-				zap.String("PanicError", fmt.Sprintf("%v", p)),
-				zap.String("PanicStack", st))
+				zap.String(tagPanicError, fmt.Sprintf("%v", p)),
+				zap.String(tagPanicStack, st))
 
 			weh.Complete(nil, newWorkflowPanicError(p, st))
 		}

--- a/internal/internal_logging_tags.go
+++ b/internal/internal_logging_tags.go
@@ -38,4 +38,6 @@ const (
 	tagLocalActivityType = "LocalActivityType"
 	tagQueryType         = "QueryType"
 	tagVisibilityQuery   = "VisibilityQuery"
+	tagPanicError        = "PanicError"
+	tagPanicStack        = "PanicStack"
 )

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1474,6 +1474,8 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 			wth.logger.Warn("Encountered PanicError in workflow query task",
 				zap.String(tagWorkflowID, task.WorkflowExecution.GetWorkflowId()),
 				zap.String(tagRunID, task.WorkflowExecution.GetRunId()),
+				zap.String(tagPanicError, panicErr.Error()),
+				zap.String(tagPanicStack, panicErr.StackTrace()),
 			)
 
 			queryCompletedRequest.CompletedType = common.QueryTaskCompletedTypePtr(s.QueryTaskCompletedTypeFailed)
@@ -1487,8 +1489,8 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 			wth.logger.Warn("Ignored workflow panic error for query, query result may be partial",
 				zap.String(tagWorkflowID, task.WorkflowExecution.GetWorkflowId()),
 				zap.String(tagRunID, task.WorkflowExecution.GetRunId()),
-				zap.String("PanicError", workflowPanicErr.Error()),
-				zap.String("PanicStack", workflowPanicErr.StackTrace()),
+				zap.String(tagPanicError, workflowPanicErr.Error()),
+				zap.String(tagPanicStack, workflowPanicErr.StackTrace()),
 			)
 		}
 
@@ -1512,8 +1514,8 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 		wth.logger.Error("Workflow panic.",
 			zap.String(tagWorkflowID, task.WorkflowExecution.GetWorkflowId()),
 			zap.String(tagRunID, task.WorkflowExecution.GetRunId()),
-			zap.String("PanicError", panicErr.Error()),
-			zap.String("PanicStack", panicErr.StackTrace()))
+			zap.String(tagPanicError, panicErr.Error()),
+			zap.String(tagPanicStack, panicErr.StackTrace()))
 		return errorToFailDecisionTask(task.TaskToken, panicErr, wth.identity)
 	}
 
@@ -1871,8 +1873,8 @@ func (ath *activityTaskHandlerImpl) Execute(taskList string, t *s.PollForActivit
 				zap.String(tagWorkflowID, t.WorkflowExecution.GetWorkflowId()),
 				zap.String(tagRunID, t.WorkflowExecution.GetRunId()),
 				zap.String(tagActivityType, activityType),
-				zap.String("PanicError", fmt.Sprintf("%v", p)),
-				zap.String("PanicStack", st))
+				zap.String(tagPanicError, fmt.Sprintf("%v", p)),
+				zap.String(tagPanicStack, st))
 			metricsScope.Counter(metrics.ActivityTaskPanicCounter).Inc(1)
 			panicErr := newPanicError(p, st)
 			result, err = convertActivityResultToRespondRequest(ath.identity, t.TaskToken, nil, panicErr, ath.dataConverter), nil

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1491,6 +1491,7 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 				zap.String(tagRunID, task.WorkflowExecution.GetRunId()),
 				zap.String(tagPanicError, workflowPanicErr.Error()),
 				zap.String(tagPanicStack, workflowPanicErr.StackTrace()),
+				zap.Int64("PreviousStartedEventID", task.GetPreviousStartedEventId()),
 			)
 		}
 

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -603,8 +603,8 @@ func (lath *localActivityTaskHandler) executeLocalActivityTask(task *localActivi
 				zap.String(tagWorkflowID, task.params.WorkflowInfo.WorkflowExecution.ID),
 				zap.String(tagRunID, task.params.WorkflowInfo.WorkflowExecution.RunID),
 				zap.String(tagActivityType, activityType),
-				zap.String("PanicError", fmt.Sprintf("%v", p)),
-				zap.String("PanicStack", st))
+				zap.String(tagPanicError, fmt.Sprintf("%v", p)),
+				zap.String(tagPanicStack, st))
 			metricsScope.Counter(metrics.LocalActivityPanicCounter).Inc(1)
 			panicErr := newPanicError(p, st)
 			result = &localActivityResult{

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -313,8 +313,8 @@ func (bw *baseWorker) processTask(task interface{}) {
 			topLine := fmt.Sprintf("base worker for %s [panic]:", bw.options.workerType)
 			st := getStackTraceRaw(topLine, 7, 0)
 			bw.logger.Error("Unhandled panic.",
-				zap.String("PanicError", fmt.Sprintf("%v", p)),
-				zap.String("PanicStack", st))
+				zap.String(tagPanicError, fmt.Sprintf("%v", p)),
+				zap.String(tagPanicStack, st))
 		}
 
 		if isPolledTask {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Ignore workflowPanicError in query task and add warn logs

<!-- Tell your future self why have you made these changes -->
**Why?**
Bug fix in https://github.com/uber-go/cadence-client/pull/1082 checks workflowPanicError instead PanicError for query task, this may break existing customers that are using query feature.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
