### PR TITLE
[grpc] Added sdk errors and their conversion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/apache/thrift v0.13.0
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a
+	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/mock v1.4.4
 	github.com/kisielk/errcheck v1.2.0
 	github.com/opentracing/opentracing-go v1.1.0
@@ -16,6 +17,7 @@ require (
 	github.com/uber/jaeger-client-go v2.22.1+incompatible
 	github.com/uber/tchannel-go v1.16.0
 	go.uber.org/atomic v1.7.0
+	go.uber.org/fx v1.10.0 // indirect
 	go.uber.org/goleak v1.0.0
 	go.uber.org/multierr v1.6.0
 	go.uber.org/thriftrw v1.25.0

--- a/internal/api/error.go
+++ b/internal/api/error.go
@@ -1,0 +1,276 @@
+// Copyright (c) 2017-2021 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package api
+
+import (
+	"fmt"
+	"strings"
+
+	apiv1 "go.uber.org/cadence/v1/.gen/proto/api/v1"
+	"go.uber.org/yarpc/encoding/protobuf"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+func ConvertError(err error) error {
+	status := yarpcerrors.FromError(err)
+	if status == nil || status.Code() == yarpcerrors.CodeOK {
+		return nil
+	}
+
+	switch status.Code() {
+	case yarpcerrors.CodePermissionDenied:
+		return &AccessDeniedError{
+			Message: status.Message(),
+		}
+	case yarpcerrors.CodeInternal:
+		return &InternalServiceError{
+			Message: status.Message(),
+		}
+	case yarpcerrors.CodeNotFound:
+		switch details := getErrorDetails(err).(type) {
+		case *apiv1.EntityNotExistsError:
+			return &EntityNotExistsError{
+				Message:        status.Message(),
+				CurrentCluster: details.CurrentCluster,
+				ActiveCluster:  details.ActiveCluster,
+			}
+		case *apiv1.WorkflowExecutionAlreadyCompletedError:
+			return &WorkflowExecutionAlreadyCompletedError{
+				Message: status.Message(),
+			}
+		}
+	case yarpcerrors.CodeInvalidArgument:
+		switch getErrorDetails(err).(type) {
+		case nil:
+			return &BadRequestError{
+				Message: status.Message(),
+			}
+		case *apiv1.QueryFailedError:
+			return &QueryFailedError{
+				Message: status.Message(),
+			}
+		}
+	case yarpcerrors.CodeAlreadyExists:
+		switch details := getErrorDetails(err).(type) {
+		case *apiv1.CancellationAlreadyRequestedError:
+			return &CancellationAlreadyRequestedError{
+				Message: status.Message(),
+			}
+		case *apiv1.DomainAlreadyExistsError:
+			return &DomainAlreadyExistsError{
+				Message: status.Message(),
+			}
+		case *apiv1.WorkflowExecutionAlreadyStartedError:
+			return &WorkflowExecutionAlreadyStartedError{
+				Message:        status.Message(),
+				StartRequestID: details.StartRequestId,
+				RunID:          details.RunId,
+			}
+		}
+	case yarpcerrors.CodeFailedPrecondition:
+		switch details := getErrorDetails(err).(type) {
+		case *apiv1.ClientVersionNotSupportedError:
+			return &ClientVersionNotSupportedError{
+				FeatureVersion:    details.FeatureVersion,
+				ClientImpl:        details.ClientImpl,
+				SupportedVersions: details.SupportedVersions,
+			}
+		case *apiv1.DomainNotActiveError:
+			return &DomainNotActiveError{
+				Message:        status.Message(),
+				Domain:         details.Domain,
+				CurrentCluster: details.CurrentCluster,
+				ActiveCluster:  details.ActiveCluster,
+			}
+		}
+	case yarpcerrors.CodeResourceExhausted:
+		switch getErrorDetails(err).(type) {
+		case *apiv1.LimitExceededError:
+			return &LimitExceededError{
+				Message: status.Message(),
+			}
+		case *apiv1.ServiceBusyError:
+			return &ServiceBusyError{
+				Message: status.Message(),
+			}
+		}
+	}
+
+	return err
+}
+
+type AccessDeniedError struct {
+	Message string
+}
+
+type BadRequestError struct {
+	Message string
+}
+
+type CancellationAlreadyRequestedError struct {
+	Message string
+}
+
+type ClientVersionNotSupportedError struct {
+	FeatureVersion    string
+	ClientImpl        string
+	SupportedVersions string
+}
+
+type DomainAlreadyExistsError struct {
+	Message string
+}
+
+type DomainNotActiveError struct {
+	Message        string
+	Domain         string
+	CurrentCluster string
+	ActiveCluster  string
+}
+
+type EntityNotExistsError struct {
+	Message        string
+	CurrentCluster string
+	ActiveCluster  string
+}
+
+type WorkflowExecutionAlreadyCompletedError struct {
+	Message string
+}
+
+type InternalServiceError struct {
+	Message string
+}
+
+type LimitExceededError struct {
+	Message string
+}
+
+type QueryFailedError struct {
+	Message string
+}
+
+type ServiceBusyError struct {
+	Message string
+}
+
+type WorkflowExecutionAlreadyStartedError struct {
+	Message        string
+	StartRequestID string
+	RunID          string
+}
+
+type EventAlreadyStartedError struct {
+	Message string
+}
+
+func (err AccessDeniedError) Error() string {
+	return fmt.Sprintf("AccessDeniedError{Message: %v}", err.Message)
+}
+
+func (err BadRequestError) Error() string {
+	return fmt.Sprintf("BadRequestError{Message: %v}", err.Message)
+}
+
+func (err CancellationAlreadyRequestedError) Error() string {
+	return fmt.Sprintf("CancellationAlreadyRequestedError{Message: %v}", err.Message)
+}
+
+func (err ClientVersionNotSupportedError) Error() string {
+	return fmt.Sprintf("ClientVersionNotSupportedError{FeatureVersion: %v, ClientImpl: %v, SupportedVersions: %v}",
+		err.FeatureVersion,
+		err.ClientImpl,
+		err.SupportedVersions)
+}
+
+func (err DomainAlreadyExistsError) Error() string {
+	return fmt.Sprintf("DomainAlreadyExistsError{Message: %v}", err.Message)
+}
+
+func (err DomainNotActiveError) Error() string {
+	return fmt.Sprintf("DomainNotActiveError{Message: %v, Domain: %v, CurrentCluster: %v, ActiveCluster: %v}",
+		err.Message,
+		err.Domain,
+		err.CurrentCluster,
+		err.ActiveCluster,
+	)
+}
+
+func (err EntityNotExistsError) Error() string {
+	sb := &strings.Builder{}
+	printField(sb, "Message", err.Message)
+	if err.CurrentCluster != "" {
+		printField(sb, "CurrentCluster", err.CurrentCluster)
+	}
+	if err.ActiveCluster != "" {
+		printField(sb, "ActiveCluster", err.ActiveCluster)
+	}
+	return fmt.Sprintf("EntityNotExistsError{%s}", sb.String())
+}
+
+func (err WorkflowExecutionAlreadyCompletedError) Error() string {
+	sb := &strings.Builder{}
+	printField(sb, "Message", err.Message)
+	return fmt.Sprintf("WorkflowExecutionAlreadyCompletedError{%s}", sb.String())
+}
+
+func (err InternalServiceError) Error() string {
+	return fmt.Sprintf("InternalServiceError{Message: %v}", err.Message)
+}
+
+func (err LimitExceededError) Error() string {
+	return fmt.Sprintf("LimitExceededError{Message: %v}", err.Message)
+}
+
+func (err QueryFailedError) Error() string {
+	return fmt.Sprintf("QueryFailedError{Message: %v}", err.Message)
+}
+
+func (err ServiceBusyError) Error() string {
+	return fmt.Sprintf("ServiceBusyError{Message: %v}", err.Message)
+}
+
+func (err WorkflowExecutionAlreadyStartedError) Error() string {
+	sb := &strings.Builder{}
+	printField(sb, "Message", err.Message)
+	printField(sb, "StartRequestID", err.StartRequestID)
+	printField(sb, "RunID", err.RunID)
+	return fmt.Sprintf("WorkflowExecutionAlreadyStartedError{%s}", sb.String())
+}
+
+func (err EventAlreadyStartedError) Error() string {
+	return fmt.Sprintf("EventAlreadyStartedError{Message: %v}", err.Message)
+}
+
+func printField(sb *strings.Builder, field string, value interface{}) {
+	if sb.Len() > 0 {
+		fmt.Fprintf(sb, ", ")
+	}
+	fmt.Fprintf(sb, "%s: %v", field, value)
+}
+
+func getErrorDetails(err error) interface{} {
+	details := protobuf.GetErrorDetails(err)
+	if len(details) > 0 {
+		return details[0]
+	}
+	return nil
+}

--- a/internal/api/error_test.go
+++ b/internal/api/error_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2017-2021 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "go.uber.org/cadence/v1/.gen/proto/api/v1"
+	"go.uber.org/yarpc/encoding/protobuf"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+func Test_ConvertError(t *testing.T) {
+	tests := []struct{
+		transportErr error
+		sdkError error
+	} {
+		{
+			transportErr: nil,
+			sdkError: nil,
+		},
+		{
+			transportErr: protobuf.NewError(yarpcerrors.CodeOK, ""),
+			sdkError: nil,
+		},
+		{
+			transportErr: protobuf.NewError(yarpcerrors.CodePermissionDenied, "message"),
+			sdkError: &AccessDeniedError{Message: "message"},
+		},
+		{
+			transportErr: protobuf.NewError(yarpcerrors.CodeInternal, "message"),
+			sdkError: &InternalServiceError{Message: "message"},
+		},
+		{
+			transportErr: protobuf.NewError(yarpcerrors.CodeNotFound, "message", protobuf.WithErrorDetails(
+				&apiv1.EntityNotExistsError{
+					CurrentCluster: "current",
+					ActiveCluster:  "active",
+				})),
+			sdkError: &EntityNotExistsError{
+				Message: "message",
+				CurrentCluster: "current",
+				ActiveCluster: "active",
+			},
+		},
+		{
+			transportErr: protobuf.NewError(yarpcerrors.CodeNotFound, "message", protobuf.WithErrorDetails(
+				&apiv1.WorkflowExecutionAlreadyCompletedError{})),
+			sdkError: &WorkflowExecutionAlreadyCompletedError{Message: "message"},
+		},
+		{
+			transportErr: protobuf.NewError(yarpcerrors.CodeInvalidArgument, "message"),
+			sdkError: &BadRequestError{Message: "message"},
+		},
+		{
+			transportErr: protobuf.NewError(yarpcerrors.CodeInvalidArgument, "message", protobuf.WithErrorDetails(
+				&apiv1.QueryFailedError{})),
+			sdkError: &QueryFailedError{Message: "message"},
+		},
+		{
+			transportErr: protobuf.NewError(yarpcerrors.CodeAlreadyExists, "message", protobuf.WithErrorDetails(
+				&apiv1.CancellationAlreadyRequestedError{})),
+			sdkError: &CancellationAlreadyRequestedError{Message: "message"},
+		},
+		{
+			transportErr: protobuf.NewError(yarpcerrors.CodeAlreadyExists, "message", protobuf.WithErrorDetails(
+				&apiv1.DomainAlreadyExistsError{})),
+			sdkError: &DomainAlreadyExistsError{Message: "message"},
+		},
+		{
+			transportErr: protobuf.NewError(yarpcerrors.CodeAlreadyExists, "message", protobuf.WithErrorDetails(
+				&apiv1.WorkflowExecutionAlreadyStartedError{
+					StartRequestId: "startRequestId",
+					RunId: "runId",
+				})),
+			sdkError: &WorkflowExecutionAlreadyStartedError{
+				Message: "message",
+				StartRequestID: "startRequestId",
+				RunID: "runId",
+			},
+		},
+		{
+			transportErr: protobuf.NewError(yarpcerrors.CodeFailedPrecondition, "message", protobuf.WithErrorDetails(
+				&apiv1.ClientVersionNotSupportedError{
+					FeatureVersion: "featureVersion",
+					ClientImpl: "clientImpl",
+					SupportedVersions: "supportedVersions",
+				})),
+			sdkError: &ClientVersionNotSupportedError{
+				FeatureVersion: "featureVersion",
+				ClientImpl: "clientImpl",
+				SupportedVersions: "supportedVersions",
+			},
+		},
+		{
+			transportErr: protobuf.NewError(yarpcerrors.CodeFailedPrecondition, "message", protobuf.WithErrorDetails(
+				&apiv1.DomainNotActiveError{
+					Domain: "domain",
+					CurrentCluster: "current",
+					ActiveCluster: "active",
+				})),
+			sdkError: &DomainNotActiveError{
+				Message: "message",
+				Domain: "domain",
+				CurrentCluster: "current",
+				ActiveCluster: "active",
+			},
+		},
+		{
+			transportErr: protobuf.NewError(yarpcerrors.CodeResourceExhausted, "message", protobuf.WithErrorDetails(
+				&apiv1.LimitExceededError{})),
+			sdkError: &LimitExceededError{Message: "message"},
+		},
+		{
+			transportErr: protobuf.NewError(yarpcerrors.CodeResourceExhausted, "message", protobuf.WithErrorDetails(
+				&apiv1.ServiceBusyError{})),
+			sdkError: &ServiceBusyError{Message: "message"},
+		},
+		{
+			transportErr: protobuf.NewError(yarpcerrors.CodeUnknown, "message"),
+			sdkError: protobuf.NewError(yarpcerrors.CodeUnknown, "message"),
+		},
+		{
+			transportErr: errors.New("non-proto error"),
+			sdkError: errors.New("non-proto error"),
+		},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.sdkError, ConvertError(tt.transportErr))
+	}
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Introduces error types distinct from rpc types. Ultimately we don't want to leak any rpc types via public client API surface. Therefore adding internal error types and mapping from yarpc error codes/details to them. These are based on errors returned by the [server](https://github.com/uber/cadence/blob/master/common/types/mapper/proto/errors.go#L34).

Note: this is merging to go-sdk branch used for grpc development (not master).

<!-- Tell your future self why have you made these changes -->
**Why?**
GRPC migration

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
