### PR TITLE
Decouple Client from worker part of SDK

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -294,7 +294,8 @@ type ServiceInvoker interface {
 	// without detail.
 	BackgroundHeartbeat() error
 	Close(flushBufferedHeartbeat bool)
-	GetClient(domain string, options *ClientOptions) Client
+
+	SignalWorkflow(ctx context.Context, domain, workflowID, runID, signalName string, signalInput []byte) error
 }
 
 // WithActivityTask adds activity specific information into context.

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -326,24 +326,7 @@ func (wc *workflowClient) SignalWorkflow(ctx context.Context, workflowID string,
 	if err != nil {
 		return err
 	}
-
-	request := &s.SignalWorkflowExecutionRequest{
-		Domain: common.StringPtr(wc.domain),
-		WorkflowExecution: &s.WorkflowExecution{
-			WorkflowId: common.StringPtr(workflowID),
-			RunId:      getRunID(runID),
-		},
-		SignalName: common.StringPtr(signalName),
-		Input:      input,
-		Identity:   common.StringPtr(wc.identity),
-	}
-
-	return backoff.Retry(ctx,
-		func() error {
-			tchCtx, cancel, opt := newChannelContext(ctx)
-			defer cancel()
-			return wc.workflowService.SignalWorkflowExecution(tchCtx, request, opt...)
-		}, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
+	return signalWorkflow(ctx, wc.workflowService, wc.identity, wc.domain, workflowID, runID, signalName, input)
 }
 
 // SignalWithStartWorkflow sends a signal to a running workflow.

--- a/internal/session.go
+++ b/internal/session.go
@@ -540,9 +540,20 @@ func (env *sessionEnvironmentImpl) AddSessionToken() {
 
 func (env *sessionEnvironmentImpl) SignalCreationResponse(ctx context.Context, sessionID string) error {
 	activityEnv := getActivityEnv(ctx)
-	client := activityEnv.serviceInvoker.GetClient(activityEnv.workflowDomain, &ClientOptions{})
-	return client.SignalWorkflow(ctx, activityEnv.workflowExecution.ID, activityEnv.workflowExecution.RunID,
-		sessionID, env.getCreationResponse())
+
+	signalInput, err := encodeArg(activityEnv.dataConverter, env.getCreationResponse())
+	if err != nil {
+		return err
+	}
+
+	return activityEnv.serviceInvoker.SignalWorkflow(
+		ctx,
+		activityEnv.workflowDomain,
+		activityEnv.workflowExecution.ID,
+		activityEnv.workflowExecution.RunID,
+		sessionID,
+		signalInput,
+		)
 }
 
 func (env *sessionEnvironmentImpl) getCreationResponse() *sessionCreationResponse {

--- a/internal/session.go
+++ b/internal/session.go
@@ -541,7 +541,7 @@ func (env *sessionEnvironmentImpl) AddSessionToken() {
 func (env *sessionEnvironmentImpl) SignalCreationResponse(ctx context.Context, sessionID string) error {
 	activityEnv := getActivityEnv(ctx)
 
-	signalInput, err := encodeArg(activityEnv.dataConverter, env.getCreationResponse())
+	signalInput, err := encodeArg(getDefaultDataConverter(), env.getCreationResponse())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Decouple `Client` from "worker" part of the SDK. There was only a single place where NewClient is instantiated from within worker. Several other places (related to heartbeats) instead call a common function shared between Client and workers. Do the same here as well.

<!-- Tell your future self why have you made these changes -->
**Why?**
This coupling makes it harder to make grpc changes, as switching `workflowserviceclient.Interface` in one place quickly propagates everywhere. With this change, it becomes possible to independently change `Client` and workers - thus enabling smaller changes.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
