### PR TITLE
[grpc] Duplicate metrics api wrapper

### DIFF
--- a/internal/common/metrics/api_wrapper.go
+++ b/internal/common/metrics/api_wrapper.go
@@ -1,0 +1,354 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/uber-go/tally"
+	apiv1 "go.uber.org/cadence/v1/.gen/proto/api/v1"
+	"go.uber.org/cadence/v1/internal/api"
+	"go.uber.org/yarpc"
+)
+
+type (
+	apiMetricsWrapper struct {
+		service     api.Interface
+		scope       tally.Scope
+		childScopes map[string]tally.Scope
+		mutex       sync.Mutex
+	}
+
+	apiOperationScope struct {
+		scope     tally.Scope
+		startTime time.Time
+	}
+)
+
+// NewApiWrapper creates a new wrapper for cadence API that will emit metrics for each service call.
+func NewApiWrapper(service api.Interface, scope tally.Scope) api.Interface {
+	return &apiMetricsWrapper{service: service, scope: scope, childScopes: make(map[string]tally.Scope)}
+}
+
+func (w *apiMetricsWrapper) getScope(scopeName string) tally.Scope {
+	w.mutex.Lock()
+	scope, ok := w.childScopes[scopeName]
+	if ok {
+		w.mutex.Unlock()
+		return scope
+	}
+	scope = w.scope.SubScope(scopeName)
+	w.childScopes[scopeName] = scope
+	w.mutex.Unlock()
+	return scope
+}
+
+func (w *apiMetricsWrapper) getOperationScope(scopeName string) *apiOperationScope {
+	scope := w.getScope(scopeName)
+	scope.Counter(CadenceRequest).Inc(1)
+
+	return &apiOperationScope{scope: scope, startTime: time.Now()}
+}
+
+func (s *apiOperationScope) handleError(err error) {
+	s.scope.Timer(CadenceLatency).Record(time.Now().Sub(s.startTime))
+	if err != nil {
+		switch api.ConvertError(err).(type) {
+		case *api.EntityNotExistsError,
+			*api.BadRequestError,
+			*api.DomainAlreadyExistsError,
+			*api.WorkflowExecutionAlreadyStartedError,
+			*api.WorkflowExecutionAlreadyCompletedError,
+			*api.QueryFailedError:
+			s.scope.Counter(CadenceInvalidRequest).Inc(1)
+		default:
+			s.scope.Counter(CadenceError).Inc(1)
+		}
+	}
+}
+
+func (w *apiMetricsWrapper) DeprecateDomain(ctx context.Context, request *apiv1.DeprecateDomainRequest, opts ...yarpc.CallOption) (*apiv1.DeprecateDomainResponse, error) {
+	scope := w.getOperationScope(scopeNameDeprecateDomain)
+	result, err := w.service.DeprecateDomain(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) ListDomains(ctx context.Context, request *apiv1.ListDomainsRequest, opts ...yarpc.CallOption) (*apiv1.ListDomainsResponse, error) {
+	scope := w.getOperationScope(scopeNameListDomains)
+	result, err := w.service.ListDomains(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) DescribeDomain(ctx context.Context, request *apiv1.DescribeDomainRequest, opts ...yarpc.CallOption) (*apiv1.DescribeDomainResponse, error) {
+	scope := w.getOperationScope(scopeNameDescribeDomain)
+	result, err := w.service.DescribeDomain(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) DescribeWorkflowExecution(ctx context.Context, request *apiv1.DescribeWorkflowExecutionRequest, opts ...yarpc.CallOption) (*apiv1.DescribeWorkflowExecutionResponse, error) {
+	scope := w.getOperationScope(scopeNameDescribeWorkflowExecution)
+	result, err := w.service.DescribeWorkflowExecution(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) GetWorkflowExecutionHistory(ctx context.Context, request *apiv1.GetWorkflowExecutionHistoryRequest, opts ...yarpc.CallOption) (*apiv1.GetWorkflowExecutionHistoryResponse, error) {
+	scope := w.getOperationScope(scopeNameGetWorkflowExecutionHistory)
+	result, err := w.service.GetWorkflowExecutionHistory(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) ListClosedWorkflowExecutions(ctx context.Context, request *apiv1.ListClosedWorkflowExecutionsRequest, opts ...yarpc.CallOption) (*apiv1.ListClosedWorkflowExecutionsResponse, error) {
+	scope := w.getOperationScope(scopeNameListClosedWorkflowExecutions)
+	result, err := w.service.ListClosedWorkflowExecutions(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) ListOpenWorkflowExecutions(ctx context.Context, request *apiv1.ListOpenWorkflowExecutionsRequest, opts ...yarpc.CallOption) (*apiv1.ListOpenWorkflowExecutionsResponse, error) {
+	scope := w.getOperationScope(scopeNameListOpenWorkflowExecutions)
+	result, err := w.service.ListOpenWorkflowExecutions(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) ListWorkflowExecutions(ctx context.Context, request *apiv1.ListWorkflowExecutionsRequest, opts ...yarpc.CallOption) (*apiv1.ListWorkflowExecutionsResponse, error) {
+	scope := w.getOperationScope(scopeNameListWorkflowExecutions)
+	result, err := w.service.ListWorkflowExecutions(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) ListArchivedWorkflowExecutions(ctx context.Context, request *apiv1.ListArchivedWorkflowExecutionsRequest, opts ...yarpc.CallOption) (*apiv1.ListArchivedWorkflowExecutionsResponse, error) {
+	scope := w.getOperationScope(scopeNameListArchivedWorkflowExecutions)
+	result, err := w.service.ListArchivedWorkflowExecutions(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) ScanWorkflowExecutions(ctx context.Context, request *apiv1.ScanWorkflowExecutionsRequest, opts ...yarpc.CallOption) (*apiv1.ScanWorkflowExecutionsResponse, error) {
+	scope := w.getOperationScope(scopeNameScanWorkflowExecutions)
+	result, err := w.service.ScanWorkflowExecutions(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) CountWorkflowExecutions(ctx context.Context, request *apiv1.CountWorkflowExecutionsRequest, opts ...yarpc.CallOption) (*apiv1.CountWorkflowExecutionsResponse, error) {
+	scope := w.getOperationScope(scopeNameCountWorkflowExecutions)
+	result, err := w.service.CountWorkflowExecutions(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) PollForActivityTask(ctx context.Context, request *apiv1.PollForActivityTaskRequest, opts ...yarpc.CallOption) (*apiv1.PollForActivityTaskResponse, error) {
+	scope := w.getOperationScope(scopeNamePollForActivityTask)
+	result, err := w.service.PollForActivityTask(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) PollForDecisionTask(ctx context.Context, request *apiv1.PollForDecisionTaskRequest, opts ...yarpc.CallOption) (*apiv1.PollForDecisionTaskResponse, error) {
+	scope := w.getOperationScope(scopeNamePollForDecisionTask)
+	result, err := w.service.PollForDecisionTask(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) RecordActivityTaskHeartbeat(ctx context.Context, request *apiv1.RecordActivityTaskHeartbeatRequest, opts ...yarpc.CallOption) (*apiv1.RecordActivityTaskHeartbeatResponse, error) {
+	scope := w.getOperationScope(scopeNameRecordActivityTaskHeartbeat)
+	result, err := w.service.RecordActivityTaskHeartbeat(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) RecordActivityTaskHeartbeatByID(ctx context.Context, request *apiv1.RecordActivityTaskHeartbeatByIDRequest, opts ...yarpc.CallOption) (*apiv1.RecordActivityTaskHeartbeatByIDResponse, error) {
+	scope := w.getOperationScope(scopeNameRecordActivityTaskHeartbeatByID)
+	result, err := w.service.RecordActivityTaskHeartbeatByID(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) RegisterDomain(ctx context.Context, request *apiv1.RegisterDomainRequest, opts ...yarpc.CallOption) (*apiv1.RegisterDomainResponse, error) {
+	scope := w.getOperationScope(scopeNameRegisterDomain)
+	result, err := w.service.RegisterDomain(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) RequestCancelWorkflowExecution(ctx context.Context, request *apiv1.RequestCancelWorkflowExecutionRequest, opts ...yarpc.CallOption) (*apiv1.RequestCancelWorkflowExecutionResponse, error) {
+	scope := w.getOperationScope(scopeNameRequestCancelWorkflowExecution)
+	result, err := w.service.RequestCancelWorkflowExecution(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) RespondActivityTaskCanceled(ctx context.Context, request *apiv1.RespondActivityTaskCanceledRequest, opts ...yarpc.CallOption) (*apiv1.RespondActivityTaskCanceledResponse, error) {
+	scope := w.getOperationScope(scopeNameRespondActivityTaskCanceled)
+	result, err := w.service.RespondActivityTaskCanceled(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) RespondActivityTaskCompleted(ctx context.Context, request *apiv1.RespondActivityTaskCompletedRequest, opts ...yarpc.CallOption) (*apiv1.RespondActivityTaskCompletedResponse, error) {
+	scope := w.getOperationScope(scopeNameRespondActivityTaskCompleted)
+	result, err := w.service.RespondActivityTaskCompleted(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) RespondActivityTaskFailed(ctx context.Context, request *apiv1.RespondActivityTaskFailedRequest, opts ...yarpc.CallOption) (*apiv1.RespondActivityTaskFailedResponse, error) {
+	scope := w.getOperationScope(scopeNameRespondActivityTaskFailed)
+	result, err := w.service.RespondActivityTaskFailed(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) RespondActivityTaskCanceledByID(ctx context.Context, request *apiv1.RespondActivityTaskCanceledByIDRequest, opts ...yarpc.CallOption) (*apiv1.RespondActivityTaskCanceledByIDResponse, error) {
+	scope := w.getOperationScope(scopeNameRespondActivityTaskCanceledByID)
+	result, err := w.service.RespondActivityTaskCanceledByID(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) RespondActivityTaskCompletedByID(ctx context.Context, request *apiv1.RespondActivityTaskCompletedByIDRequest, opts ...yarpc.CallOption) (*apiv1.RespondActivityTaskCompletedByIDResponse, error) {
+	scope := w.getOperationScope(scopeNameRespondActivityTaskCompletedByID)
+	result, err := w.service.RespondActivityTaskCompletedByID(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) RespondActivityTaskFailedByID(ctx context.Context, request *apiv1.RespondActivityTaskFailedByIDRequest, opts ...yarpc.CallOption) (*apiv1.RespondActivityTaskFailedByIDResponse, error) {
+	scope := w.getOperationScope(scopeNameRespondActivityTaskFailedByID)
+	result, err := w.service.RespondActivityTaskFailedByID(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) RespondDecisionTaskCompleted(ctx context.Context, request *apiv1.RespondDecisionTaskCompletedRequest, opts ...yarpc.CallOption) (*apiv1.RespondDecisionTaskCompletedResponse, error) {
+	scope := w.getOperationScope(scopeNameRespondDecisionTaskCompleted)
+	response, err := w.service.RespondDecisionTaskCompleted(ctx, request, opts...)
+	scope.handleError(err)
+	return response, err
+}
+
+func (w *apiMetricsWrapper) RespondDecisionTaskFailed(ctx context.Context, request *apiv1.RespondDecisionTaskFailedRequest, opts ...yarpc.CallOption) (*apiv1.RespondDecisionTaskFailedResponse, error) {
+	scope := w.getOperationScope(scopeNameRespondDecisionTaskFailed)
+	result, err := w.service.RespondDecisionTaskFailed(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) SignalWorkflowExecution(ctx context.Context, request *apiv1.SignalWorkflowExecutionRequest, opts ...yarpc.CallOption) (*apiv1.SignalWorkflowExecutionResponse, error) {
+	scope := w.getOperationScope(scopeNameSignalWorkflowExecution)
+	result, err := w.service.SignalWorkflowExecution(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) SignalWithStartWorkflowExecution(ctx context.Context, request *apiv1.SignalWithStartWorkflowExecutionRequest, opts ...yarpc.CallOption) (*apiv1.SignalWithStartWorkflowExecutionResponse, error) {
+	scope := w.getOperationScope(scopeNameSignalWithStartWorkflowExecution)
+	result, err := w.service.SignalWithStartWorkflowExecution(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) StartWorkflowExecution(ctx context.Context, request *apiv1.StartWorkflowExecutionRequest, opts ...yarpc.CallOption) (*apiv1.StartWorkflowExecutionResponse, error) {
+	scope := w.getOperationScope(scopeNameStartWorkflowExecution)
+	result, err := w.service.StartWorkflowExecution(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) TerminateWorkflowExecution(ctx context.Context, request *apiv1.TerminateWorkflowExecutionRequest, opts ...yarpc.CallOption) (*apiv1.TerminateWorkflowExecutionResponse, error) {
+	scope := w.getOperationScope(scopeNameTerminateWorkflowExecution)
+	result, err := w.service.TerminateWorkflowExecution(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) ResetWorkflowExecution(ctx context.Context, request *apiv1.ResetWorkflowExecutionRequest, opts ...yarpc.CallOption) (*apiv1.ResetWorkflowExecutionResponse, error) {
+	scope := w.getOperationScope(scopeNameResetWorkflowExecution)
+	result, err := w.service.ResetWorkflowExecution(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) UpdateDomain(ctx context.Context, request *apiv1.UpdateDomainRequest, opts ...yarpc.CallOption) (*apiv1.UpdateDomainResponse, error) {
+	scope := w.getOperationScope(scopeNameUpdateDomain)
+	result, err := w.service.UpdateDomain(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) QueryWorkflow(ctx context.Context, request *apiv1.QueryWorkflowRequest, opts ...yarpc.CallOption) (*apiv1.QueryWorkflowResponse, error) {
+	scope := w.getOperationScope(scopeNameQueryWorkflow)
+	result, err := w.service.QueryWorkflow(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) ResetStickyTaskList(ctx context.Context, request *apiv1.ResetStickyTaskListRequest, opts ...yarpc.CallOption) (*apiv1.ResetStickyTaskListResponse, error) {
+	scope := w.getOperationScope(scopeNameResetStickyTaskList)
+	result, err := w.service.ResetStickyTaskList(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) DescribeTaskList(ctx context.Context, request *apiv1.DescribeTaskListRequest, opts ...yarpc.CallOption) (*apiv1.DescribeTaskListResponse, error) {
+	scope := w.getOperationScope(scopeNameDescribeTaskList)
+	result, err := w.service.DescribeTaskList(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) RespondQueryTaskCompleted(ctx context.Context, request *apiv1.RespondQueryTaskCompletedRequest, opts ...yarpc.CallOption) (*apiv1.RespondQueryTaskCompletedResponse, error) {
+	scope := w.getOperationScope(scopeNameRespondQueryTaskCompleted)
+	result, err := w.service.RespondQueryTaskCompleted(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) GetSearchAttributes(ctx context.Context, request *apiv1.GetSearchAttributesRequest, opts ...yarpc.CallOption) (*apiv1.GetSearchAttributesResponse, error) {
+	scope := w.getOperationScope(scopeNameGetSearchAttributes)
+	result, err := w.service.GetSearchAttributes(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) ListTaskListPartitions(ctx context.Context, request *apiv1.ListTaskListPartitionsRequest, opts ...yarpc.CallOption) (*apiv1.ListTaskListPartitionsResponse, error) {
+	scope := w.getOperationScope(scopeNameListTaskListPartitions)
+	result, err := w.service.ListTaskListPartitions(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}
+
+func (w *apiMetricsWrapper) GetClusterInfo(ctx context.Context, request *apiv1.GetClusterInfoRequest,  opts ...yarpc.CallOption) (*apiv1.GetClusterInfoResponse, error) {
+	scope := w.getOperationScope(scopeNameGetClusterInfo)
+	result, err := w.service.GetClusterInfo(ctx, request, opts...)
+	scope.handleError(err)
+	return result, err
+}

--- a/internal/common/metrics/api_wrapper_test.go
+++ b/internal/common/metrics/api_wrapper_test.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	apiv1 "go.uber.org/cadence/v1/.gen/proto/api/v1"
+	"go.uber.org/cadence/v1/internal/api"
+	"go.uber.org/yarpc"
+)
+
+func Test_ApiWrapper(t *testing.T) {
+	ctx, _ := context.WithTimeout(context.Background(), time.Minute)
+	tests := []testCase{
+		// one case for each service call
+		{"DeprecateDomain", []interface{}{ctx, &apiv1.DeprecateDomainRequest{}}, []interface{}{&apiv1.DeprecateDomainResponse{}, nil}, []string{CadenceRequest}},
+		{"DescribeDomain", []interface{}{ctx, &apiv1.DescribeDomainRequest{}}, []interface{}{&apiv1.DescribeDomainResponse{}, nil}, []string{CadenceRequest}},
+		{"GetWorkflowExecutionHistory", []interface{}{ctx, &apiv1.GetWorkflowExecutionHistoryRequest{}}, []interface{}{&apiv1.GetWorkflowExecutionHistoryResponse{}, nil}, []string{CadenceRequest}},
+		{"ListClosedWorkflowExecutions", []interface{}{ctx, &apiv1.ListClosedWorkflowExecutionsRequest{}}, []interface{}{&apiv1.ListClosedWorkflowExecutionsResponse{}, nil}, []string{CadenceRequest}},
+		{"ListOpenWorkflowExecutions", []interface{}{ctx, &apiv1.ListOpenWorkflowExecutionsRequest{}}, []interface{}{&apiv1.ListOpenWorkflowExecutionsResponse{}, nil}, []string{CadenceRequest}},
+		{"PollForActivityTask", []interface{}{ctx, &apiv1.PollForActivityTaskRequest{}}, []interface{}{&apiv1.PollForActivityTaskResponse{}, nil}, []string{CadenceRequest}},
+		{"PollForDecisionTask", []interface{}{ctx, &apiv1.PollForDecisionTaskRequest{}}, []interface{}{&apiv1.PollForDecisionTaskResponse{}, nil}, []string{CadenceRequest}},
+		{"RecordActivityTaskHeartbeat", []interface{}{ctx, &apiv1.RecordActivityTaskHeartbeatRequest{}}, []interface{}{&apiv1.RecordActivityTaskHeartbeatResponse{}, nil}, []string{CadenceRequest}},
+		{"RegisterDomain", []interface{}{ctx, &apiv1.RegisterDomainRequest{}}, []interface{}{&apiv1.RegisterDomainResponse{}, nil}, []string{CadenceRequest}},
+		{"RequestCancelWorkflowExecution", []interface{}{ctx, &apiv1.RequestCancelWorkflowExecutionRequest{}}, []interface{}{&apiv1.RequestCancelWorkflowExecutionResponse{}, nil}, []string{CadenceRequest}},
+		{"RespondActivityTaskCanceled", []interface{}{ctx, &apiv1.RespondActivityTaskCanceledRequest{}}, []interface{}{&apiv1.RespondActivityTaskCanceledResponse{}, nil}, []string{CadenceRequest}},
+		{"RespondActivityTaskCompleted", []interface{}{ctx, &apiv1.RespondActivityTaskCompletedRequest{}}, []interface{}{&apiv1.RespondActivityTaskCompletedResponse{}, nil}, []string{CadenceRequest}},
+		{"RespondActivityTaskFailed", []interface{}{ctx, &apiv1.RespondActivityTaskFailedRequest{}}, []interface{}{&apiv1.RespondActivityTaskFailedResponse{}, nil}, []string{CadenceRequest}},
+		{"RespondActivityTaskCanceledByID", []interface{}{ctx, &apiv1.RespondActivityTaskCanceledByIDRequest{}}, []interface{}{&apiv1.RespondActivityTaskCanceledByIDResponse{}, nil}, []string{CadenceRequest}},
+		{"RespondActivityTaskCompletedByID", []interface{}{ctx, &apiv1.RespondActivityTaskCompletedByIDRequest{}}, []interface{}{&apiv1.RespondActivityTaskCompletedByIDResponse{}, nil}, []string{CadenceRequest}},
+		{"RespondActivityTaskFailedByID", []interface{}{ctx, &apiv1.RespondActivityTaskFailedByIDRequest{}}, []interface{}{&apiv1.RespondActivityTaskFailedByIDResponse{}, nil}, []string{CadenceRequest}},
+		{"RespondDecisionTaskCompleted", []interface{}{ctx, &apiv1.RespondDecisionTaskCompletedRequest{}}, []interface{}{nil, nil}, []string{CadenceRequest}},
+		{"SignalWorkflowExecution", []interface{}{ctx, &apiv1.SignalWorkflowExecutionRequest{}}, []interface{}{&apiv1.SignalWorkflowExecutionResponse{}, nil}, []string{CadenceRequest}},
+		{"StartWorkflowExecution", []interface{}{ctx, &apiv1.StartWorkflowExecutionRequest{}}, []interface{}{&apiv1.StartWorkflowExecutionResponse{}, nil}, []string{CadenceRequest}},
+		{"TerminateWorkflowExecution", []interface{}{ctx, &apiv1.TerminateWorkflowExecutionRequest{}}, []interface{}{&apiv1.TerminateWorkflowExecutionResponse{}, nil}, []string{CadenceRequest}},
+		{"ResetWorkflowExecution", []interface{}{ctx, &apiv1.ResetWorkflowExecutionRequest{}}, []interface{}{&apiv1.ResetWorkflowExecutionResponse{}, nil}, []string{CadenceRequest}},
+		{"UpdateDomain", []interface{}{ctx, &apiv1.UpdateDomainRequest{}}, []interface{}{&apiv1.UpdateDomainResponse{}, nil}, []string{CadenceRequest}},
+		// one case of invalid request
+		{"PollForActivityTask", []interface{}{ctx, &apiv1.PollForActivityTaskRequest{}}, []interface{}{nil, &api.EntityNotExistsError{}}, []string{CadenceRequest, CadenceInvalidRequest}},
+		// one case of server error
+		{"PollForActivityTask", []interface{}{ctx, &apiv1.PollForActivityTaskRequest{}}, []interface{}{nil, &api.InternalServiceError{}}, []string{CadenceRequest, CadenceError}},
+		{"QueryWorkflow", []interface{}{ctx, &apiv1.QueryWorkflowRequest{}}, []interface{}{nil, &api.InternalServiceError{}}, []string{CadenceRequest, CadenceError}},
+		{"RespondQueryTaskCompleted", []interface{}{ctx, &apiv1.RespondQueryTaskCompletedRequest{}}, []interface{}{&apiv1.RespondQueryTaskCompletedResponse{}, &api.InternalServiceError{}}, []string{CadenceRequest, CadenceError}},
+	}
+
+	// run each test twice - once with the regular scope, once with a sanitized metrics scope
+	for _, test := range tests {
+		runApiWrapperTest(t, test, newApi, assertMetrics, fmt.Sprintf("%v_normal", test.serviceMethod))
+		runApiWrapperTest(t, test, newPromApi, assertPromMetrics, fmt.Sprintf("%v_prom_sanitized", test.serviceMethod))
+	}
+}
+
+func runApiWrapperTest(
+	t *testing.T,
+	test testCase,
+	serviceFunc func(*testing.T) (*api.MockInterface, api.Interface, io.Closer, *CapturingStatsReporter),
+	validationFunc func(*testing.T, *CapturingStatsReporter, string, []string),
+	name string,
+) {
+	t.Run(name, func(t *testing.T) {
+		t.Parallel()
+		// gomock mutates the returns slice, which leads to different test values between the two runs.
+		// copy the slice until gomock fixes it: https://github.com/golang/mock/issues/353
+		returns := append(make([]interface{}, 0, len(test.mockReturns)), test.mockReturns...)
+
+		mockService, wrapperService, closer, reporter := serviceFunc(t)
+		switch test.serviceMethod {
+		case "DeprecateDomain":
+			mockService.EXPECT().DeprecateDomain(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "DescribeDomain":
+			mockService.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "GetWorkflowExecutionHistory":
+			mockService.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "ListClosedWorkflowExecutions":
+			mockService.EXPECT().ListClosedWorkflowExecutions(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "ListOpenWorkflowExecutions":
+			mockService.EXPECT().ListOpenWorkflowExecutions(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "PollForActivityTask":
+			mockService.EXPECT().PollForActivityTask(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "PollForDecisionTask":
+			mockService.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "RecordActivityTaskHeartbeat":
+			mockService.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "RecordActivityTaskHeartbeatByID":
+			mockService.EXPECT().RecordActivityTaskHeartbeatByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "RegisterDomain":
+			mockService.EXPECT().RegisterDomain(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "RequestCancelWorkflowExecution":
+			mockService.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "RespondActivityTaskCanceled":
+			mockService.EXPECT().RespondActivityTaskCanceled(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "RespondActivityTaskCompleted":
+			mockService.EXPECT().RespondActivityTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "RespondActivityTaskFailed":
+			mockService.EXPECT().RespondActivityTaskFailed(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "RespondActivityTaskCanceledByID":
+			mockService.EXPECT().RespondActivityTaskCanceledByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "RespondActivityTaskCompletedByID":
+			mockService.EXPECT().RespondActivityTaskCompletedByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "RespondActivityTaskFailedByID":
+			mockService.EXPECT().RespondActivityTaskFailedByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "RespondDecisionTaskCompleted":
+			mockService.EXPECT().RespondDecisionTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "SignalWorkflowExecution":
+			mockService.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "SignaWithStartlWorkflowExecution":
+			mockService.EXPECT().SignalWithStartWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "StartWorkflowExecution":
+			mockService.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "TerminateWorkflowExecution":
+			mockService.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "ResetWorkflowExecution":
+			mockService.EXPECT().ResetWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "UpdateDomain":
+			mockService.EXPECT().UpdateDomain(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "QueryWorkflow":
+			mockService.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		case "RespondQueryTaskCompleted":
+			mockService.EXPECT().RespondQueryTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).Return(returns...)
+		}
+
+		callOption := yarpc.CallOption{}
+		inputs := make([]reflect.Value, len(test.callArgs))
+		for i, arg := range test.callArgs {
+			inputs[i] = reflect.ValueOf(arg)
+		}
+		inputs = append(inputs, reflect.ValueOf(callOption))
+		method := reflect.ValueOf(wrapperService).MethodByName(test.serviceMethod)
+		method.Call(inputs)
+		require.NoError(t, closer.Close())
+		validationFunc(t, reporter, test.serviceMethod, test.expectedCounters)
+	})
+}
+
+func newApi(t *testing.T) (
+	mockService *api.MockInterface,
+	wrapperService api.Interface,
+	closer io.Closer,
+	reporter *CapturingStatsReporter,
+) {
+	mockCtrl := gomock.NewController(t)
+	mockService = api.NewMockInterface(mockCtrl)
+	isReplay := false
+	scope, closer, reporter := NewMetricsScope(&isReplay)
+	wrapperService = NewApiWrapper(mockService, scope)
+	return
+}
+
+func newPromApi(t *testing.T) (
+	mockService *api.MockInterface,
+	wrapperService api.Interface,
+	closer io.Closer,
+	reporter *CapturingStatsReporter,
+) {
+	mockCtrl := gomock.NewController(t)
+	mockService = api.NewMockInterface(mockCtrl)
+	isReplay := false
+	scope, closer, reporter := newPromScope(&isReplay)
+	wrapperService = NewApiWrapper(mockService, scope)
+	return
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This is a copy of `internal/common/metrics/service_wrapper_test.go` that is wrapping on `api.Interface` instead of generated Thrift interface. This is necessary, as both interfaces will co-exist during the conversion period. After that, the old one will be removed.

<!-- Tell your future self why have you made these changes -->
**Why?**
GRPC migration

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
