### PR TITLE
Clear workflow state when not cached and not complete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,11 +134,13 @@ bins: thriftc $(ALL_SRC) $(BUILD)/copyright lint $(BUILD)/dummy
 unit_test: $(BUILD)/dummy
 	@mkdir -p $(COVER_ROOT)
 	@echo "mode: atomic" > $(UT_COVER_FILE)
-	@for dir in $(UT_DIRS); do \
+	@failed=0; \
+	for dir in $(UT_DIRS); do \
 		mkdir -p $(COVER_ROOT)/"$$dir"; \
-		go test "$$dir" $(TEST_ARG) -coverprofile=$(COVER_ROOT)/"$$dir"/cover.out || exit 1; \
+		go test "$$dir" $(TEST_ARG) -coverprofile=$(COVER_ROOT)/"$$dir"/cover.out || failed=1; \
 		cat $(COVER_ROOT)/"$$dir"/cover.out | grep -v "mode: atomic" >> $(UT_COVER_FILE); \
-	done;
+	done; \
+	exit $$failed
 
 integ_test_sticky_off: $(BUILD)/dummy
 	@mkdir -p $(COVER_ROOT)

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -475,7 +475,8 @@ func (w *workflowExecutionContextImpl) Lock() {
 	w.mutex.Lock()
 }
 
-func (w *workflowExecutionContextImpl) Unlock(err error) {
+func (w *workflowExecutionContextImpl) Unlock(isInCache bool, err error) {
+	cleared := false
 	if err != nil || w.err != nil || w.isWorkflowCompleted || (w.wth.disableStickyExecution && !w.hasPendingLocalActivityWork()) {
 		// TODO: in case of closed, it assumes the close decision always succeed. need server side change to return
 		// error to indicate the close failure case. This should be rear case. For now, always remove the cache, and
@@ -484,8 +485,26 @@ func (w *workflowExecutionContextImpl) Unlock(err error) {
 			removeWorkflowContext(w.workflowInfo.WorkflowExecution.RunID)
 		} else {
 			// sticky is disabled, manually clear the workflow state.
+			if isInCache {
+				// sanity check, afaict this never happens.  but log/metric to collect evidence if it does.
+				// if it occurs it's almost certainly a logic bug (leads to double-clearing), though possibly not a damaging one.
+				// we should able to remove this after running for a while in canary / prod, our collection of users trigger quite a few edge cases.
+				w.wth.logger.DPanic("Workflow state should not have been cleared, it should be handled by cache eviction",
+					zap.String(tagWorkflowType, w.workflowInfo.WorkflowType.Name),
+					zap.String(tagWorkflowID, w.workflowInfo.WorkflowExecution.ID),
+					zap.String(tagRunID, w.workflowInfo.WorkflowExecution.RunID),
+					zap.Stack(tagPanicStack))
+				// temporary, remove after running in production for a while
+				w.wth.metricsScope.Counter("bug-clear-state")
+			}
 			w.clearState()
+			cleared = true
 		}
+	}
+	// !isInCache is the main scenario being caught here, but double-clearing is undesirable.
+	// it *might* be harmless to double-clear, but it's certainly irrational, and risks future problems.
+	if !isInCache && !cleared {
+		w.clearState()
 	}
 
 	w.mutex.Unlock()
@@ -648,7 +667,7 @@ func (wth *workflowTaskHandlerImpl) createWorkflowContext(task *s.PollForDecisio
 func (wth *workflowTaskHandlerImpl) getOrCreateWorkflowContext(
 	task *s.PollForDecisionTaskResponse,
 	historyIterator HistoryIterator,
-) (workflowContext *workflowExecutionContextImpl, err error) {
+) (workflowContext *workflowExecutionContextImpl, isInCache bool, err error) {
 	metricsScope := wth.metricsScope.GetTaggedScope(tagWorkflowType, task.WorkflowType.GetName())
 	defer func() {
 		if err == nil && workflowContext != nil && workflowContext.laTunnel == nil {
@@ -666,6 +685,7 @@ func (wth *workflowTaskHandlerImpl) getOrCreateWorkflowContext(
 	if task.Query == nil || (task.Query != nil && !isFullHistory) {
 		workflowContext = getWorkflowContext(runID)
 	}
+	isInCache = workflowContext != nil
 
 	if workflowContext != nil {
 		workflowContext.Lock()
@@ -695,13 +715,15 @@ func (wth *workflowTaskHandlerImpl) getOrCreateWorkflowContext(
 
 		if !wth.disableStickyExecution && task.Query == nil {
 			workflowContext, _ = putWorkflowContext(runID, workflowContext)
+			// was false, but putWorkflowContext added it
+			isInCache = true
 		}
 		workflowContext.Lock()
 	}
 
 	err = workflowContext.resetStateIfDestroyed(task, historyIterator)
 	if err != nil {
-		workflowContext.Unlock(err)
+		workflowContext.Unlock(isInCache, err)
 	}
 
 	return
@@ -762,13 +784,13 @@ func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 			zap.Int64("PreviousStartedEventId", task.GetPreviousStartedEventId()))
 	})
 
-	workflowContext, err := wth.getOrCreateWorkflowContext(task, workflowTask.historyIterator)
+	workflowContext, isInCache, err := wth.getOrCreateWorkflowContext(task, workflowTask.historyIterator)
 	if err != nil {
 		return nil, err
 	}
 
 	defer func() {
-		workflowContext.Unlock(errRet)
+		workflowContext.Unlock(isInCache, errRet)
 	}()
 
 	var response interface{}

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -1551,7 +1551,7 @@ func (t *TaskHandlersTestSuite) TestRegression_QueriesDoNotLeakGoroutines() {
 	newLeaks := goleak.Find()
 	t.Error(newLeaks, "expected at least one leaking goroutine")
 	t.Equal(countLeaks(oneCachedLeak), countLeaks(newLeaks),
-		"expected the query to leak no new goroutines.  before query:\n%v\n\nafter query:%v", oneCachedLeak, newLeaks)
+		"expected the query to leak no new goroutines.  before query:\n%v\n\nafter query:\n%v", oneCachedLeak, newLeaks)
 }
 
 func Test_NonDeterministicCheck(t *testing.T) {


### PR DESCRIPTION
This resolves a bug a user encountered, where a full sticky cache + a query for a non-cached workflow would result in a goroutine leak due to the associated event handler never being shut down. Since this leak retains all in-workflow data, it can eventually lead to an out-of-memory crash, though it does not cause any logic errors (these abandoned goroutines are forever idle once abandoned).  There are probably also other scenarios where this is possible.

Since the code paths leading to unlock are rather complex, I've included a DPanic log (panics in debug mode, logs at panic level elsewhere) and metric to check an assumption that I believe to be correct, but have not been able to be entirely confident about.  Once this has run in production for a while on a few domains, and verified to not happen, we can likely remove that log and metric.

---

Separately: this function seems to be far too complex, and is almost certainly duplicating checks made elsewhere, which should not be duplicated like this.  There have been multiple issues with state-clearing that have lead to adding conditions to this func, which is a clear sign of a code smell.

State / cache decisions like this should be made in exactly one place ever, and built up as obviously as possible, to ensure gaps like this never occur.  In this case we'll likely need to invert the dependency flow somehow, so callers control when cache is cleared based on whether or not it is cached, rather than double-checking internally like this.

We should also probably add go.uber.org/goleak to basically all of our tests, to help ensure we do not have goroutine leaks.  This may not have been caught by that, as the steps leading to it are a bit odd and rely on singleton config (sticky cache size), but it may find or prevent others.  (we should really rip out these globals too)