### PR TITLE
Close the test dispatcher when completing

### DIFF
--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -538,6 +538,7 @@ func executeDispatcher(ctx Context, dispatcher dispatcher) {
 	env := getWorkflowEnvironment(ctx)
 	panicErr := dispatcher.ExecuteUntilAllBlocked()
 	if panicErr != nil {
+		dispatcher.Close()
 		env.Complete(nil, panicErr)
 		return
 	}
@@ -554,6 +555,7 @@ func executeDispatcher(ctx Context, dispatcher dispatcher) {
 		env.GetMetricsScope().Counter(metrics.UnhandledSignalsCounter).Inc(1)
 	}
 
+	dispatcher.Close()
 	env.Complete(rp.workflowResult, rp.error)
 }
 


### PR DESCRIPTION
Currently, a test workflow like this will not ever run the code after the goroutine's sleep, nor the
code in the defer:
```
func(ctx workflow.Context) error {
  workflow.Go(func(ctx workflow.Context) {
    defer func() { fmt.Println("in defer") }()
    workflow.Sleep(ctx, time.Hour) // wait longer than the workflow lives
    fmt.Println("after sleep")
  })
  workflow.Sleep(ctx, time.Minute) // just to make sure the goroutine starts
  return nil
}
```
The workflow will correctly end, but since the dispatcher was never closed, any not-yet-complete
goroutines would never exit, and we'd leak goroutines.

Semantically this should be a safe change:
- Any post-complete decisions would not be executed or recorded, and this retains that.
- When panicking, anything that would be *recorded* in a defer will not be recorded, so no
  replay-state-aware user code should be affected.  And any code that ignores replay state will
  now execute like it should, where before it would not.

So safe / correct code should be unaffected, leaks should be reduced, and latent mistakes should
now cause errors.