### PR TITLE
Fix client side race condition

### DIFF
--- a/internal/context.go
+++ b/internal/context.go
@@ -22,6 +22,7 @@ package internal
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -287,6 +288,9 @@ type cancelCtx struct {
 
 	done Channel // closed by the first cancel call.
 
+	mu       sync.Mutex
+	canceled bool
+
 	children map[canceler]bool // set to nil by the first cancel call
 	err      error             // set to non-nil by the first cancel call
 }
@@ -306,6 +310,16 @@ func (c *cancelCtx) String() string {
 // cancel closes c.done, cancels each of c's children, and, if
 // removeFromParent is true, removes c from its parent's children.
 func (c *cancelCtx) cancel(removeFromParent bool, err error) {
+	c.mu.Lock()
+	if c.canceled {
+		c.mu.Unlock()
+		// calling cancel from multiple go routines isn't safe
+		// avoid a data race by only allowing the first call
+		return
+	}
+	c.canceled = true
+	c.mu.Unlock()
+
 	if err == nil {
 		panic("context: internal error: missing cancel error")
 	}

--- a/internal/context_test.go
+++ b/internal/context_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2017-2021 Uber Technologies Inc.
+// Portions of the Software are attributed to Copyright (c) 2020 Temporal Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestContext_RaceRegression(t *testing.T) {
+	/*
+		A race condition existed due to concurrently ending goroutines on shutdown (i.e. closing their chan without waiting
+		on them to finish shutdown), which executed... quite a lot of non-concurrency-safe code in a concurrent way.  All
+		decision-sensitive code is assumed to be run strictly sequentially.
+
+		Context cancellation was one identified by a customer, and it's fairly easy to test.
+		In principle this must be safe to do - contexts are supposed to be concurrency-safe.  Even if ours are not actually
+		safe (for valid reasons), our execution model needs to ensure they *act* like it's safe.
+	*/
+	s := WorkflowTestSuite{}
+	s.SetLogger(zaptest.NewLogger(t))
+	env := s.NewTestWorkflowEnvironment()
+	wf := func(ctx Context) error {
+		ctx, cancel := WithCancel(ctx)
+		racyCancel := func(ctx Context) {
+			defer cancel() // defer is necessary as Sleep will never return due to Goexit
+			_ = Sleep(ctx, time.Hour)
+		}
+		// start a handful to increase odds of a race being detected
+		for i := 0; i < 10; i++ {
+			Go(ctx, racyCancel)
+		}
+
+		_ = Sleep(ctx, time.Minute) // die early
+		return nil
+	}
+	env.RegisterWorkflow(wf)
+	env.ExecuteWorkflow(wf)
+	assert.NoError(t, env.GetWorkflowError())
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
The problem is described here: https://github.com/uber-go/cadence-client/pull/1117

That PR fixes leaking go routines but also introduces a race condition, this PR fixes the race. 


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
go test -race -test.count 1 -test.run TestContext_RaceRegression ./internal
go test -timeout 30s -run ^TestWorkflowUnitTest$ -testify.m ^(Test_StaleGoroutinesAreShutDown)$ go.uber.org/cadence/internal
```

Output of the first test without the fix: 
```
==================
WARNING: DATA RACE
Read at 0x00c0003feaa8 by goroutine 13:
  go.uber.org/cadence/internal.(*cancelCtx).cancel()
      /Users/enderd/cadence-client/internal/context.go:312 +0x71
  go.uber.org/cadence/internal.WithCancel.func1()
      /Users/enderd/cadence-client/internal/context.go:194 +0x78
  runtime.call16()
      /usr/local/Cellar/go/1.16.6/libexec/src/runtime/asm_amd64.s:550 +0x3d
  go.uber.org/cadence/internal.(*coroutineState).initialYield()
      /Users/enderd/cadence-client/internal/internal_workflow.go:796 +0xb9
  go.uber.org/cadence/internal.(*coroutineState).yield()
      /Users/enderd/cadence-client/internal/internal_workflow.go:805 +0x45c
  go.uber.org/cadence/internal.(*channelImpl).Receive()
      /Users/enderd/cadence-client/internal/internal_workflow.go:620 +0x35a
  go.uber.org/cadence/internal.(*futureImpl).Get()
      /Users/enderd/cadence-client/internal/internal_workflow.go:294 +0x92
  go.uber.org/cadence/internal.(*workflowEnvironmentInterceptor).Sleep()
      /Users/enderd/cadence-client/internal/workflow.go:906 +0x81
  go.uber.org/cadence/internal.Sleep()
      /Users/enderd/cadence-client/internal/workflow.go:901 +0xc1
  go.uber.org/cadence/internal.TestContext_RaceRegression.func1.1()
      /Users/enderd/cadence-client/internal/context_test.go:49 +0x99
  go.uber.org/cadence/internal.(*dispatcherImpl).newNamedCoroutine.func1()
      /Users/enderd/cadence-client/internal/internal_workflow.go:883 +0x11c

Previous write at 0x00c0003feaa8 by goroutine 16:
  go.uber.org/cadence/internal.(*cancelCtx).cancel()
      /Users/enderd/cadence-client/internal/context.go:315 +0x93
  go.uber.org/cadence/internal.WithCancel.func1()
      /Users/enderd/cadence-client/internal/context.go:194 +0x78
  runtime.call16()
      /usr/local/Cellar/go/1.16.6/libexec/src/runtime/asm_amd64.s:550 +0x3d
  go.uber.org/cadence/internal.(*coroutineState).initialYield()
      /Users/enderd/cadence-client/internal/internal_workflow.go:796 +0xb9
  go.uber.org/cadence/internal.(*coroutineState).yield()
      /Users/enderd/cadence-client/internal/internal_workflow.go:805 +0x45c
  go.uber.org/cadence/internal.(*channelImpl).Receive()
      /Users/enderd/cadence-client/internal/internal_workflow.go:620 +0x35a
  go.uber.org/cadence/internal.(*futureImpl).Get()
      /Users/enderd/cadence-client/internal/internal_workflow.go:294 +0x92
  go.uber.org/cadence/internal.(*workflowEnvironmentInterceptor).Sleep()
      /Users/enderd/cadence-client/internal/workflow.go:906 +0x81
  go.uber.org/cadence/internal.Sleep()
      /Users/enderd/cadence-client/internal/workflow.go:901 +0xc1
  go.uber.org/cadence/internal.TestContext_RaceRegression.func1.1()
      /Users/enderd/cadence-client/internal/context_test.go:49 +0x99
  go.uber.org/cadence/internal.(*dispatcherImpl).newNamedCoroutine.func1()
      /Users/enderd/cadence-client/internal/internal_workflow.go:883 +0x11c

Goroutine 13 (running) created at:
  go.uber.org/cadence/internal.(*dispatcherImpl).newNamedCoroutine()
      /Users/enderd/cadence-client/internal/internal_workflow.go:874 +0x3d1
  go.uber.org/cadence/internal.(*dispatcherImpl).newCoroutine()
      /Users/enderd/cadence-client/internal/internal_workflow.go:868 +0xeb
  go.uber.org/cadence/internal.Go()
      /Users/enderd/cadence-client/internal/workflow.go:394 +0x94
  go.uber.org/cadence/internal.TestContext_RaceRegression.func1()
      /Users/enderd/cadence-client/internal/context_test.go:53 +0xe9
  runtime.call32()
      /usr/local/Cellar/go/1.16.6/libexec/src/runtime/asm_amd64.s:551 +0x3d
  reflect.Value.Call()
      /usr/local/Cellar/go/1.16.6/libexec/src/reflect/value.go:337 +0xd8
  go.uber.org/cadence/internal.(*workflowEnvironmentInterceptor).ExecuteWorkflow()
      /Users/enderd/cadence-client/internal/workflow.go:423 +0x2e4
  go.uber.org/cadence/internal.(*workflowExecutor).Execute()
      /Users/enderd/cadence-client/internal/internal_worker.go:700 +0x41a
  go.uber.org/cadence/internal.(*workflowExecutorWrapper).Execute()
      /Users/enderd/cadence-client/internal/internal_workflow_testsuite.go:1459 +0x8f9
  go.uber.org/cadence/internal.(*syncWorkflowDefinition).Execute.func1()
      /Users/enderd/cadence-client/internal/internal_workflow.go:466 +0x243
  go.uber.org/cadence/internal.(*dispatcherImpl).newNamedCoroutine.func1()
      /Users/enderd/cadence-client/internal/internal_workflow.go:883 +0x11c

Goroutine 16 (running) created at:
  go.uber.org/cadence/internal.(*dispatcherImpl).newNamedCoroutine()
      /Users/enderd/cadence-client/internal/internal_workflow.go:874 +0x3d1
  go.uber.org/cadence/internal.(*dispatcherImpl).newCoroutine()
      /Users/enderd/cadence-client/internal/internal_workflow.go:868 +0xeb
  go.uber.org/cadence/internal.Go()
      /Users/enderd/cadence-client/internal/workflow.go:394 +0x94
  go.uber.org/cadence/internal.TestContext_RaceRegression.func1()
      /Users/enderd/cadence-client/internal/context_test.go:53 +0xe9
  runtime.call32()
      /usr/local/Cellar/go/1.16.6/libexec/src/runtime/asm_amd64.s:551 +0x3d
  reflect.Value.Call()
      /usr/local/Cellar/go/1.16.6/libexec/src/reflect/value.go:337 +0xd8
  go.uber.org/cadence/internal.(*workflowEnvironmentInterceptor).ExecuteWorkflow()
      /Users/enderd/cadence-client/internal/workflow.go:423 +0x2e4
  go.uber.org/cadence/internal.(*workflowExecutor).Execute()
      /Users/enderd/cadence-client/internal/internal_worker.go:700 +0x41a
  go.uber.org/cadence/internal.(*workflowExecutorWrapper).Execute()
      /Users/enderd/cadence-client/internal/internal_workflow_testsuite.go:1459 +0x8f9
  go.uber.org/cadence/internal.(*syncWorkflowDefinition).Execute.func1()
      /Users/enderd/cadence-client/internal/internal_workflow.go:466 +0x243
  go.uber.org/cadence/internal.(*dispatcherImpl).newNamedCoroutine.func1()
      /Users/enderd/cadence-client/internal/internal_workflow.go:883 +0x11c
==================
FAIL
FAIL    go.uber.org/cadence/internal    0.646s
FAIL
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
