### PR TITLE
Fix TestQueryTask_WorkflowCacheEvicted

### DIFF
--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -512,6 +512,15 @@ func (s *WorkersTestSuite) TestQueryTask_WorkflowCacheEvicted() {
 		DisableActivityWorker: true,
 		Identity:              "test-worker-identity",
 		DataConverter:         dc,
+		// set concurrent decision task execution to 1,
+		// otherwise query task may be polled and start execution
+		// before decision task put created workflowContext into the cache,
+		// resulting in a cache hit for query
+		// by setting concurrent execution size to 1, we ensure when polling
+		// query task, cache already contains the workflowContext for this workflow,
+		// and we can force clear the cache when polling the query task.
+		// See the mock function for the second PollForDecisionTask call above.
+		MaxConcurrentDecisionTaskExecutionSize: 1,
 	}
 	worker := newAggregatedWorker(s.service, domain, taskList, options)
 	worker.RegisterWorkflowWithOptions(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix TestQueryTask_WorkflowCacheEvicted
Before the fix
```
➜ internal (master) ✔ go test -run TestWorkersTestSuite -testify.m TestQueryTask_WorkflowCacheEvicted -race -count=1000
--- FAIL: TestWorkersTestSuite (0.01s)
    --- FAIL: TestWorkersTestSuite/TestQueryTask_WorkflowCacheEvicted (0.00s)
        internal_workers_test.go:77: missing call(s) to *workflowservicetest.MockClient.RespondDecisionTaskCompleted(is anything, is anything, is anything, is anything, is anything, is anything) /Users/ycyang/gocode/src/go.uber.org/cadence/.gen/go/cadence/workflowservicetest/client.go:1030
        internal_workers_test.go:77: aborting test due to missing call(s)
--- FAIL: TestWorkersTestSuite (0.01s)
    --- FAIL: TestWorkersTestSuite/TestQueryTask_WorkflowCacheEvicted (0.00s)
        internal_workers_test.go:77: missing call(s) to *workflowservicetest.MockClient.GetWorkflowExecutionHistory(is anything, is anything, is anything, is anything, is anything, is anything) /Users/ycyang/gocode/src/go.uber.org/cadence/.gen/go/cadence/workflowservicetest/client.go:320
        internal_workers_test.go:77: aborting test due to missing call(s)
FAIL
exit status 1
FAIL    go.uber.org/cadence/internal    9.947s
```

After the fix
```
➜ internal (fix-test) ✔ go test -run TestWorkersTestSuite -testify.m TestQueryTask_WorkflowCacheEvicted -race -count=1000           
PASS
ok      go.uber.org/cadence/internal    8.556s
```

<!-- Tell your future self why have you made these changes -->
**Why?**
- The test is flaky.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
