### PR TITLE
[discuss] Implement bugfix for child-workflow bug in #1138

### DIFF
--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -2793,7 +2793,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflowAlreadyRunning() {
 		ctx1 := WithChildWorkflowOptions(ctx, ChildWorkflowOptions{
 			WorkflowID:                   "Test_ChildWorkflowAlreadyRunning",
 			ExecutionStartToCloseTimeout: time.Minute,
-			//WorkflowIDReusePolicy:        WorkflowIDReusePolicyAllowDuplicate,
+			// WorkflowIDReusePolicy:        WorkflowIDReusePolicyAllowDuplicate,
 		})
 
 		var result1, result2 string
@@ -3109,7 +3109,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_Regression_ExecuteChildWorkflowWithCanc
 	// - <0 == do not cancel
 	// - 0  == cancel synchronously
 	// - >0 == cancel after waiting that long
-	check := func(cancelTime time.Duration, expected string) {
+	check := func(cancelTime time.Duration, bugport bool, expected string) {
 		env := s.NewTestWorkflowEnvironment()
 		env.Test(s.T())
 		env.RegisterWorkflowWithOptions(func(ctx Context) error {
@@ -3129,6 +3129,9 @@ func (s *WorkflowTestSuiteUnitTest) Test_Regression_ExecuteChildWorkflowWithCanc
 			ctx = WithChildWorkflowOptions(ctx, ChildWorkflowOptions{
 				ExecutionStartToCloseTimeout: 2 * time.Minute,
 				TaskStartToCloseTimeout:      2 * time.Minute,
+				Bugports: Bugports{
+					StartChildWorkflowsOnCanceledContext: bugport,
+				},
 			})
 			err := ExecuteChildWorkflow(ctx, "child").Get(ctx, nil)
 
@@ -3150,14 +3153,20 @@ func (s *WorkflowTestSuiteUnitTest) Test_Regression_ExecuteChildWorkflowWithCanc
 	}
 	s.Run("sanity check", func() {
 		// workflow should run the child successfully normally...
-		check(-1, "no err")
+		check(-1, false, "no err")
 	})
 	s.Run("canceled after child starts", func() {
 		// ... and cancel the child when the child is canceled...
-		check(30*time.Second, "canceled")
+		check(30*time.Second, false, "canceled")
 	})
 	s.Run("canceled before child starts", func() {
 		// ... and should not start the child (i.e. be canceled) when canceled before it is started.
-		check(0, "canceled")
+		check(0, false, "canceled")
+	})
+	s.Run("canceled before child starts with bugport enabled", func() {
+		// prior to v0.18.4, canceling before the child was started would still start the child,
+		// and it would continue running.
+		// the bugport provides this old behavior to ease migration, at least until we feel the need to remove it.
+		check(0, true, "no err")
 	})
 }

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -3158,8 +3158,6 @@ func (s *WorkflowTestSuiteUnitTest) Test_Regression_ExecuteChildWorkflowWithCanc
 	})
 	s.Run("canceled before child starts", func() {
 		// ... and should not start the child (i.e. be canceled) when canceled before it is started.
-		check(0, "no err") // but it does not!  this is a bug to fix.
-		// this should be:
-		// check(0, "canceled")
+		check(0, "canceled")
 	})
 }

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -3103,3 +3103,63 @@ func (s *WorkflowTestSuiteUnitTest) Test_AwaitWithTimeout() {
 	_ = env.GetWorkflowResult(&result)
 	s.False(result)
 }
+
+func (s *WorkflowTestSuiteUnitTest) Test_Regression_ExecuteChildWorkflowWithCanceledContext() {
+	// cancelTime of:
+	// - <0 == do not cancel
+	// - 0  == cancel synchronously
+	// - >0 == cancel after waiting that long
+	check := func(cancelTime time.Duration, expected string) {
+		env := s.NewTestWorkflowEnvironment()
+		env.Test(s.T())
+		env.RegisterWorkflowWithOptions(func(ctx Context) error {
+			return Sleep(ctx, time.Minute)
+		}, RegisterWorkflowOptions{Name: "child"})
+		env.RegisterWorkflowWithOptions(func(ctx Context) (string, error) {
+			ctx, cancel := WithCancel(ctx)
+			if cancelTime == 0 {
+				cancel()
+			} else if cancelTime > 0 {
+				Go(ctx, func(ctx Context) {
+					_ = Sleep(ctx, cancelTime)
+					cancel()
+				})
+			}
+
+			ctx = WithChildWorkflowOptions(ctx, ChildWorkflowOptions{
+				ExecutionStartToCloseTimeout: 2 * time.Minute,
+				TaskStartToCloseTimeout:      2 * time.Minute,
+			})
+			err := ExecuteChildWorkflow(ctx, "child").Get(ctx, nil)
+
+			if err == nil {
+				return "no err", nil
+			} else if _, ok := err.(*CanceledError); ok {
+				return "canceled", nil
+			}
+			return "unknown: " + err.Error(), nil
+		}, RegisterWorkflowOptions{Name: "parent"})
+
+		env.ExecuteWorkflow("parent")
+		s.True(env.IsWorkflowCompleted())
+		s.NoError(env.GetWorkflowError())
+
+		var result string
+		s.NoError(env.GetWorkflowResult(&result))
+		s.Equal(expected, result)
+	}
+	s.Run("sanity check", func() {
+		// workflow should run the child successfully normally...
+		check(-1, "no err")
+	})
+	s.Run("canceled after child starts", func() {
+		// ... and cancel the child when the child is canceled...
+		check(30*time.Second, "canceled")
+	})
+	s.Run("canceled before child starts", func() {
+		// ... and should not start the child (i.e. be canceled) when canceled before it is started.
+		check(0, "no err") // but it does not!  this is a bug to fix.
+		// this should be:
+		// check(0, "canceled")
+	})
+}

--- a/test/replaytests/child_bug.json
+++ b/test/replaytests/child_bug.json
@@ -1,0 +1,217 @@
+[
+  {
+    "eventId": 1,
+    "eventType": "WorkflowExecutionStarted",
+    "taskId": 1048925,
+    "timestamp": 1635394320054371800,
+    "version": 0,
+    "workflowExecutionStartedEventAttributes": {
+      "attempt": 0,
+      "continuedExecutionRunId": "",
+      "cronSchedule": "",
+      "executionStartToCloseTimeoutSeconds": 300,
+      "firstDecisionTaskBackoffSeconds": 0,
+      "firstExecutionRunId": "4962aeea-a5e0-4f1e-bcb7-098c38c19fd1",
+      "identity": "cadence-cli@local",
+      "input": "",
+      "originalExecutionRunId": "4962aeea-a5e0-4f1e-bcb7-098c38c19fd1",
+      "taskList": {
+        "name": "task_list"
+      },
+      "taskStartToCloseTimeoutSeconds": 2,
+      "workflowType": {
+        "name": "parent"
+      }
+    }
+  },
+  {
+    "decisionTaskScheduledEventAttributes": {
+      "attempt": 0,
+      "startToCloseTimeoutSeconds": 2,
+      "taskList": {
+        "name": "task_list"
+      }
+    },
+    "eventId": 2,
+    "eventType": "DecisionTaskScheduled",
+    "taskId": 1048926,
+    "timestamp": 1635394320054487000,
+    "version": 0
+  },
+  {
+    "decisionTaskStartedEventAttributes": {
+      "identity": "44608@local@task_list",
+      "requestId": "1144deaf-aa6f-464f-9a1b-65cee85439fc",
+      "scheduledEventId": 2
+    },
+    "eventId": 3,
+    "eventType": "DecisionTaskStarted",
+    "taskId": 1048934,
+    "timestamp": 1635394320123179000,
+    "version": 0
+  },
+  {
+    "decisionTaskCompletedEventAttributes": {
+      "binaryChecksum": "unknown",
+      "identity": "44608@local@task_list",
+      "scheduledEventId": 2,
+      "startedEventId": 3
+    },
+    "eventId": 4,
+    "eventType": "DecisionTaskCompleted",
+    "taskId": 1048937,
+    "timestamp": 1635394320185062700,
+    "version": 0
+  },
+  {
+    "eventId": 5,
+    "eventType": "StartChildWorkflowExecutionInitiated",
+    "startChildWorkflowExecutionInitiatedEventAttributes": {
+      "cronSchedule": "",
+      "decisionTaskCompletedEventId": 4,
+      "domain": "local",
+      "executionStartToCloseTimeoutSeconds": 30,
+      "header": {},
+      "parentClosePolicy": "TERMINATE",
+      "taskList": {
+        "name": "task_list"
+      },
+      "taskStartToCloseTimeoutSeconds": 30,
+      "workflowId": "4962aeea-a5e0-4f1e-bcb7-098c38c19fd1_0",
+      "workflowIdReusePolicy": "TerminateIfRunning",
+      "workflowType": {
+        "name": "child"
+      }
+    },
+    "taskId": 1048938,
+    "timestamp": 1635394320186925600,
+    "version": 0
+  },
+  {
+    "childWorkflowExecutionStartedEventAttributes": {
+      "domain": "local",
+      "header": {},
+      "initiatedEventId": 5,
+      "workflowExecution": {
+        "runId": "748709af-0150-4493-8a57-d0d358ac1aad",
+        "workflowId": "4962aeea-a5e0-4f1e-bcb7-098c38c19fd1_0"
+      },
+      "workflowType": {
+        "name": "child-sleep"
+      }
+    },
+    "eventId": 6,
+    "eventType": "ChildWorkflowExecutionStarted",
+    "taskId": 1048945,
+    "timestamp": 1635394320249768000,
+    "version": 0
+  },
+  {
+    "decisionTaskScheduledEventAttributes": {
+      "attempt": 0,
+      "startToCloseTimeoutSeconds": 2,
+      "taskList": {
+        "name": "local:97607b30-6825-48ad-a7ad-1bc050d3d549"
+      }
+    },
+    "eventId": 7,
+    "eventType": "DecisionTaskScheduled",
+    "taskId": 1048947,
+    "timestamp": 1635394320249960200,
+    "version": 0
+  },
+  {
+    "decisionTaskStartedEventAttributes": {
+      "identity": "44608@local@task_list",
+      "requestId": "f3626e79-c365-4514-8243-c1cd619f02c4",
+      "scheduledEventId": 7
+    },
+    "eventId": 8,
+    "eventType": "DecisionTaskStarted",
+    "taskId": 1048953,
+    "timestamp": 1635394320288285700,
+    "version": 0
+  },
+  {
+    "decisionTaskCompletedEventAttributes": {
+      "binaryChecksum": "unknown",
+      "identity": "44608@local@task_list",
+      "scheduledEventId": 7,
+      "startedEventId": 8
+    },
+    "eventId": 9,
+    "eventType": "DecisionTaskCompleted",
+    "taskId": 1048960,
+    "timestamp": 1635394320336447700,
+    "version": 0
+  },
+  {
+    "childWorkflowExecutionCompletedEventAttributes": {
+      "domain": "local",
+      "initiatedEventId": 5,
+      "startedEventId": 6,
+      "workflowExecution": {
+        "runId": "748709af-0150-4493-8a57-d0d358ac1aad",
+        "workflowId": "4962aeea-a5e0-4f1e-bcb7-098c38c19fd1_0"
+      },
+      "workflowType": {
+        "name": "child-sleep"
+      }
+    },
+    "eventId": 10,
+    "eventType": "ChildWorkflowExecutionCompleted",
+    "taskId": 1048980,
+    "timestamp": 1635394330479970800,
+    "version": 0
+  },
+  {
+    "decisionTaskScheduledEventAttributes": {
+      "attempt": 0,
+      "startToCloseTimeoutSeconds": 2,
+      "taskList": {
+        "name": "task_list"
+      }
+    },
+    "eventId": 11,
+    "eventType": "DecisionTaskScheduled",
+    "taskId": 1048982,
+    "timestamp": 1635394330480030200,
+    "version": 0
+  },
+  {
+    "decisionTaskStartedEventAttributes": {
+      "identity": "44608@local@task_list",
+      "requestId": "c3314aa8-33bb-45df-aad9-3cfdd118bfe7",
+      "scheduledEventId": 11
+    },
+    "eventId": 12,
+    "eventType": "DecisionTaskStarted",
+    "taskId": 1048985,
+    "timestamp": 1635394330507992000,
+    "version": 0
+  },
+  {
+    "decisionTaskCompletedEventAttributes": {
+      "binaryChecksum": "unknown",
+      "identity": "44608@local@task_list",
+      "scheduledEventId": 11,
+      "startedEventId": 12
+    },
+    "eventId": 13,
+    "eventType": "DecisionTaskCompleted",
+    "taskId": 1048988,
+    "timestamp": 1635394330549916200,
+    "version": 0
+  },
+  {
+    "eventId": 14,
+    "eventType": "WorkflowExecutionCompleted",
+    "taskId": 1048989,
+    "timestamp": 1635394330549969400,
+    "version": 0,
+    "workflowExecutionCompletedEventAttributes": {
+      "decisionTaskCompletedEventId": 13,
+      "result": ""
+    }
+  }
+]

--- a/test/replaytests/reply_test.go
+++ b/test/replaytests/reply_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/cadence/worker"
+	"go.uber.org/cadence/workflow"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -40,4 +41,13 @@ func TestReplayWorkflowHistoryFromFile(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestReplayChildWorkflowBugBackport(t *testing.T) {
+	replayer := worker.NewWorkflowReplayer()
+	replayer.RegisterWorkflowWithOptions(childWorkflow, workflow.RegisterOptions{Name: "child"})
+	replayer.RegisterWorkflowWithOptions(childWorkflowBug, workflow.RegisterOptions{Name: "parent"})
+
+	err := replayer.ReplayWorkflowHistoryFromJSONFile(zaptest.NewLogger(t), "child_bug.json")
+	require.NoError(t, err)
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -44,6 +44,10 @@ type (
 	// ChildWorkflowOptions stores all child workflow specific parameters that will be stored inside of a Context.
 	ChildWorkflowOptions = internal.ChildWorkflowOptions
 
+	// Bugports contains opt-in flags for backports of old, buggy behavior that has been fixed.
+	// See the internal docs for details.
+	Bugports = internal.Bugports
+
 	// RegisterOptions consists of options for registering a workflow
 	RegisterOptions = internal.RegisterWorkflowOptions
 


### PR DESCRIPTION
The three commits in this PR are relevant for discussion, possibly also merging:

1. "Demonstrate ExecuteChildWorkflow bug + prepare test for a fix" is #1138, unmodified.
2. "[incomplete] Implement bugfix for child-workflow bug in `#1138`" is the "bare" bugfix, which I believe to be a complete fix... which is not backwards compatible because it changes behavior.
3. "Backported" un-bugfix in case people hit non-determinism errors" is a controllable way to undo the bugfix, and documentation on how to use it.

We can decide whether or not the current and future complexity is worth commit 3, but I think it's... not too bad?  
Other options include:

1. Ship the fix without the backport.
    - Simpler now and in the future.
    - No remediation possible for users that break, except "reset to before bug, and/or terminate".
2. Use `GetVersion` internally when the bug might be triggered, with the same logic as the field check here.
    - Simpler and invisible.
    - Not user controllable, so if they were relying on it, they'll break...... but maybe that's fine.  It's not always worth fighting Hyrum's Law.  If it is, we can also add commit 3's flag.
    - Requires recording that version marker for all future, non-buggy workflows, increasing size slightly.
3. Start recording client version numbers in decision task histories, so we can access it during replay, like `BinaryChecksum`.  Use "no version" to mean "contains bug" and act appropriately.
    - Honestly this is probably a good idea regardless, as it'd give us (and users) a lever / escape-hatch for dealing with version-specific bugs.
    - I'm not sure what this change will involve.  Server + web changes maybe?  If it's client-side only, I can build that instead.
    - This would behave the same as `GetVersion`, but (relatively) "free" from markers that a bug is being addressed, as well as for future bugs.