### PR TITLE
Bump cadence.Version to 0.18.4

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -35,7 +35,7 @@ package internal
 // that are writing workflows. So every time we change API
 // that can affect them we have to change this number.
 // Format: MAJOR.MINOR.PATCH
-const LibraryVersion = "0.18.0"
+const LibraryVersion = "0.18.4"
 
 // FeatureVersion is a semver that represents the
 // feature set of this cadence client library support.


### PR DESCRIPTION
Will be merged and cherry-picked prior to tagging a release, but not before.