### PR TITLE
Fix NPE when canceling workflow without run id

### DIFF
--- a/internal/compatibility/proto/decision.go
+++ b/internal/compatibility/proto/decision.go
@@ -108,7 +108,7 @@ func Decision(d *shared.Decision) *apiv1.Decision {
 		decision.Attributes = &apiv1.Decision_RequestCancelExternalWorkflowExecutionDecisionAttributes{
 			RequestCancelExternalWorkflowExecutionDecisionAttributes: &apiv1.RequestCancelExternalWorkflowExecutionDecisionAttributes{
 				Domain:            attr.GetDomain(),
-				WorkflowExecution: WorkflowRunPair(attr.WorkflowId, attr.RunId),
+				WorkflowExecution: WorkflowRunPair(attr.GetWorkflowId(), attr.GetRunId()),
 				Control:           attr.Control,
 				ChildWorkflowOnly: attr.GetChildWorkflowOnly(),
 			},

--- a/internal/compatibility/proto/request.go
+++ b/internal/compatibility/proto/request.go
@@ -182,7 +182,7 @@ func RecordActivityTaskHeartbeatByIdRequest(t *shared.RecordActivityTaskHeartbea
 	}
 	return &apiv1.RecordActivityTaskHeartbeatByIDRequest{
 		Domain:            t.GetDomain(),
-		WorkflowExecution: WorkflowRunPair(t.WorkflowID, t.RunID),
+		WorkflowExecution: WorkflowRunPair(t.GetWorkflowID(), t.GetRunID()),
 		ActivityId:        t.GetActivityID(),
 		Details:           Payload(t.Details),
 		Identity:          t.GetIdentity(),
@@ -263,7 +263,7 @@ func RespondActivityTaskCanceledByIdRequest(t *shared.RespondActivityTaskCancele
 	}
 	return &apiv1.RespondActivityTaskCanceledByIDRequest{
 		Domain:            t.GetDomain(),
-		WorkflowExecution: WorkflowRunPair(t.WorkflowID, t.RunID),
+		WorkflowExecution: WorkflowRunPair(t.GetWorkflowID(), t.GetRunID()),
 		ActivityId:        t.GetActivityID(),
 		Details:           Payload(t.Details),
 		Identity:          t.GetIdentity(),
@@ -287,7 +287,7 @@ func RespondActivityTaskCompletedByIdRequest(t *shared.RespondActivityTaskComple
 	}
 	return &apiv1.RespondActivityTaskCompletedByIDRequest{
 		Domain:            t.GetDomain(),
-		WorkflowExecution: WorkflowRunPair(t.WorkflowID, t.RunID),
+		WorkflowExecution: WorkflowRunPair(t.GetWorkflowID(), t.GetRunID()),
 		ActivityId:        t.GetActivityID(),
 		Result:            Payload(t.Result),
 		Identity:          t.GetIdentity(),
@@ -311,7 +311,7 @@ func RespondActivityTaskFailedByIdRequest(t *shared.RespondActivityTaskFailedByI
 	}
 	return &apiv1.RespondActivityTaskFailedByIDRequest{
 		Domain:            t.GetDomain(),
-		WorkflowExecution: WorkflowRunPair(t.WorkflowID, t.RunID),
+		WorkflowExecution: WorkflowRunPair(t.GetWorkflowID(), t.GetRunID()),
 		ActivityId:        t.GetActivityID(),
 		Failure:           Failure(t.Reason, t.Details),
 		Identity:          t.GetIdentity(),

--- a/internal/compatibility/proto/types.go
+++ b/internal/compatibility/proto/types.go
@@ -57,13 +57,13 @@ func WorkflowExecution(t *shared.WorkflowExecution) *apiv1.WorkflowExecution {
 	}
 }
 
-func WorkflowRunPair(workflowId, runId *string) *apiv1.WorkflowExecution {
-	if workflowId == nil && runId == nil {
+func WorkflowRunPair(workflowId, runId string) *apiv1.WorkflowExecution {
+	if workflowId == "" && runId == "" {
 		return nil
 	}
 	return &apiv1.WorkflowExecution{
-		WorkflowId: *workflowId,
-		RunId:      *runId,
+		WorkflowId: workflowId,
+		RunId:      runId,
 	}
 }
 
@@ -471,7 +471,7 @@ func PendingChildExecutionInfo(t *shared.PendingChildExecutionInfo) *apiv1.Pendi
 		return nil
 	}
 	return &apiv1.PendingChildExecutionInfo{
-		WorkflowExecution: WorkflowRunPair(t.WorkflowID, t.RunID),
+		WorkflowExecution: WorkflowRunPair(t.GetWorkflowID(), t.GetRunID()),
 		WorkflowTypeName:  t.GetWorkflowTypName(),
 		InitiatedId:       t.GetInitiatedID(),
 		ParentClosePolicy: ParentClosePolicy(t.ParentClosePolicy),

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -433,6 +433,15 @@ func (ts *IntegrationTestSuite) TestChildWFWithParentClosePolicyAbandon() {
 	ts.True(resp.WorkflowExecutionInfo.GetCloseTime() == 0)
 }
 
+func (ts *IntegrationTestSuite) TestChildWFCancel() {
+	var childWorkflowID string
+	err := ts.executeWorkflow("test-childwf-cancel", ts.workflows.ChildWorkflowCancel, &childWorkflowID)
+	ts.NoError(err)
+	resp, err := ts.libClient.DescribeWorkflowExecution(context.Background(), childWorkflowID, "")
+	ts.NoError(err)
+	ts.Equal(shared.WorkflowExecutionCloseStatusCanceled, resp.WorkflowExecutionInfo.GetCloseStatus())
+}
+
 func (ts *IntegrationTestSuite) TestActivityCancelUsingReplay() {
 	replayer := worker.NewWorkflowReplayer()
 	replayer.RegisterWorkflowWithOptions(ts.workflows.ActivityCancelRepro, workflow.RegisterOptions{DisableAlreadyRegisteredCheck: true})


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixed NPE in proto mapper.

<!-- Tell your future self why have you made these changes -->
**Why?**
When canceling current workflow (without run id), this field can be nil.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added new integration test to reproduce, fix and verify.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
