### PR TITLE
Modernize makefile, to make it stable like github.com/uber/cadence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,12 +10,10 @@
 *.html
 .tmp/
 /vendor
-bins
-cadence-client
-bins
 test.log
 /dummy
 .build
 .bins
+.bin
 .DS_Store
 .gobincache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,8 @@ This doc is intended for contributors to `cadence-client` (hopefully that's you!
 
 ## Development Environment
 
-* Go. Install on OS X with `brew install go`. The minimum required Go version is 1.10.
-* `thrift`. Install on OS X with `brew install thrift`.
-* `thrift-gen`. Install with `go get github.com/uber/tchannel-go/thrift/thrift-gen`.
+* Go. Install on OS X with `brew install go`. The minimum required Go version is visible in the go.mod file.
+* `make build` should download and build anything else necessary.
 
 ## Checking out the code
 
@@ -16,34 +15,50 @@ Make sure the repository is cloned to the correct location:
 (Note: the path is `go.uber.org/cadence/` instead of github repo)
 
 ```bash
-go get go.uber.org/cadence/...
+go get -d go.uber.org/cadence
 cd $GOPATH/src/go.uber.org/cadence
 ```
 
 ## Dependency management
 
-Dependencies are tracked via `Gopkg.toml`. If you're not familiar with `dep`,
-read the [docs](https://https://golang.github.io/dep/docs/introduction.html).
+Dependencies are tracked via go modules (tool-only dependencies in `tools.go`), and we no longer support dep/glide/etc
+at all.  If you wish to check for dependencies that may be good to update, try `make deps`.
+
+Dependencies should generally be as _low_ of a version as possible, not whatever is "current",
+unless the project has a proven history of API stability and reliability.  go.uber.org/yarpc is a good example of this.  
+Dependency upgrades may force our users to upgrade as well, so only upgrade them when necessary,
+like on a new needed feature or an important bugfix.
+
+## API stability
+
+While we are pre-1.0 we do our best to maintain backwards compatibility at a binary *and semantic* level, but there will
+be some gaps where this is not practical.  Any known breakages should be mentioned in the associated Github releases
+(soon: also changelog.md).  
+Generally speaking though, all obviously-intentionally-exposed APIs must be highly stable, take care to maintain it.
+
+As a concrete example of gaps that may occur, any use of our generated Thrift or gRPC APIs is quite fragile.  High level
+APIs that accidentally expose this will be _relatively_ stable at the top level of fields/methods, but e.g. use of the
+client.GetWorkflowHistory iterator (which exposes _many_ raw RPC types) is effectively stable only by accident.
+
+In the future we intend to have a clearer split between long-term-stable APIs and ones that are only best-effort.
+Ideally the best-effort APIs will be for special cases only, e.g. RPC clients, and users that access them should be made
+aware of the instability (and how to update when breakages occur) where possible.
 
 ## Licence headers
 
 This project is Open Source Software, and requires a header at the beginning of
-all source files. To verify that all files contain the header execute:
+all source files. `make build` should enforce this for you.
 
-```lang=bash
-make copyright
-```
-
-## Commit Messages
-
-Overcommit adds some requirements to your commit messages. At Uber, we follow the
-[Chris Beams](http://chris.beams.io/posts/git-commit/) guide to writing git
-commit messages. Read it, follow it, learn it, love it.
+To re-generate copyright headers, e.g. to add missing ones, run `make copyright`.
 
 ## Testing
 
-Run all the tests with coverage and race detector enabled:
-
+To run all the tests with coverage and race detector enabled, start a cadence server (e.g. via `docker compose up`) and:
 ```bash
 make test
+```
+
+You can run only unit tests, which is quicker and likely sufficient while in the middle of development, with:
+```bash
+make unit_test
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,128 +1,164 @@
-.PHONY: git-submodules test bins clean cover cover_ci
+# get rid of default behaviors, they're just noise
+MAKEFLAGS += --no-builtin-rules
+.SUFFIXES:
 
-# default target
-default: test
+default: help
 
-OS = $(shell uname -s)
-ARCH = $(shell uname -m)
+# ###########################################
+#                TL;DR DOCS:
+# ###########################################
+# - Targets should never, EVER be *actual source files*.
+#   Always use book-keeping files in $(BUILD).
+#   Otherwise e.g. changing git branches could confuse Make about what it needs to do.
+# - Similarly, prerequisites should be those book-keeping files,
+#   not source files that are prerequisites for book-keeping.
+#   e.g. depend on .build/fmt, not $(ALL_SRC), and not both.
+# - Be strict and explicit about prerequisites / order of execution / etc.
+# - Test your changes with `-j 27 --output-sync` or something!
+# - Test your changes with `make -d ...`!  It should be reasonable!
 
-IMPORT_ROOT := go.uber.org/cadence
-THRIFT_GENDIR := .gen/go
-THRIFTRW_SRC := idls/thrift/cadence.thrift idls/thrift/shadower.thrift
-# one or more thriftrw-generated file(s), to create / depend on generated code
-THRIFTRW_OUT := $(THRIFT_GENDIR)/cadence/cadence.go
+# temporary build products and book-keeping targets that are always good to / safe to clean.
+BUILD := .build
+# less-than-temporary build products, e.g. tools.
+# usually unnecessary to clean, and may require downloads to restore, so this folder is not automatically cleaned.
+BIN := .bin
+
+# ====================================
+# book-keeping files that are used to control sequencing.
+#
+# you should use these as prerequisites in almost all cases, not the source files themselves.
+# these are defined in roughly the reverse order that they are executed, for easier reading.
+#
+# recipes and any other prerequisites are defined only once, further below.
+# ====================================
+
+# all bins depend on: $(BUILD)/lint
+# note that vars that do not yet exist are empty, so any prerequisites defined below are ineffective here.
+$(BUILD)/lint: $(BUILD)/fmt $(BUILD)/dummy # lint will fail if fmt or dummy fails, so run them first
+$(BUILD)/dummy: $(BUILD)/fmt # do a build after fmt-ing
+$(BUILD)/fmt: $(BUILD)/copyright # formatting must occur only after all other go-file-modifications are done
+$(BUILD)/copyright: $(BUILD)/codegen # must add copyright to generated code
+$(BUILD)/codegen: $(BUILD)/thrift # thrift is currently the only codegen, but this way it's easier to extend
+$(BUILD)/thrift:
+
+# ====================================
+# helper vars
+# ====================================
+
+PROJECT_ROOT = go.uber.org/cadence
+
+# helper for executing bins that need other bins, just `$(BIN_PATH) the_command ...`
+# I'd recommend not exporting this in general, to reduce the chance of accidentally using non-versioned tools.
+BIN_PATH := PATH="$(abspath $(BIN)):$$PATH"
+
+# default test args, easy to override
 TEST_ARG ?= -v -race
 
-# general build-product folder, cleaned as part of `make clean`
-BUILD := .build
-# general bins folder.  NOT cleaned via `make clean`
-BINS := .bins
-
-INTEG_TEST_ROOT := ./test
-COVER_ROOT := $(BUILD)/coverage
-UT_COVER_FILE := $(COVER_ROOT)/unit_test_cover.out
-INTEG_STICKY_OFF_COVER_FILE := $(COVER_ROOT)/integ_test_sticky_off_cover.out
-INTEG_STICKY_ON_COVER_FILE := $(COVER_ROOT)/integ_test_sticky_on_cover.out
-INTEG_GRPC_COVER_FILE := $(COVER_ROOT)/integ_test_grpc_cover.out
-
-# Automatically gather all srcs + a "sentinel" thriftrw output file (which forces generation).
-ALL_SRC := $(THRIFTRW_OUT) $(shell \
-	find . -name "*.go" | \
-	grep -v \
-	-e .gen/ \
-	-e .build/ \
+# automatically gather all source files that currently exist.
+# works by ignoring everything in the parens (and does not descend into matching folders) due to `-prune`,
+# and everything else goes to the other side of the `-o` branch, which is `-print`ed.
+# this is dramatically faster than a `find . | grep -v vendor` pipeline, and scales far better.
+FRESH_ALL_SRC = $(shell \
+	find . \
+	\( \
+		-path './vendor/*' \
+		-o -path './idls/*' \
+		-o -path './$(BUILD)/*' \
+		-o -path './$(BIN)/*' \
+	\) \
+	-prune \
+	-o -name '*.go' -print \
 )
+# most things can use a cached copy, e.g. all dependencies.
+# this will not include any files that are created during a `make` run, e.g. via protoc,
+# but that generally should not matter (e.g. dependencies are computed at parse time, so it
+# won't affect behavior either way - choose the fast option).
+#
+# if you require a fully up-to-date list, e.g. for shell commands, use FRESH_ALL_SRC instead.
+ALL_SRC := $(FRESH_ALL_SRC)
+# as lint ignores generated code, it can use the cached copy in all cases.
+LINT_SRC := $(filter-out %_test.go ./.gen/% ./mock% ./tools.go ./internal/compatibility/%, $(ALL_SRC))
 
-UT_DIRS := $(filter-out $(INTEG_TEST_ROOT)%, $(sort $(dir $(filter %_test.go,$(ALL_SRC)))))
+# ====================================
+# $(BIN) targets
+# ====================================
 
-# Files that needs to run lint.  excludes testify mocks and the thrift sentinel.
-LINT_SRC := $(filter-out ./mock% ./tools.go $(THRIFTRW_OUT),$(ALL_SRC))
+# utility target.
+# use as an order-only prerequisite for targets that do not implicitly create these folders.
+$(BIN) $(BUILD):
+	@mkdir -p $@
 
-$(BINS)/thriftrw: go.mod
+$(BIN)/thriftrw: go.mod
 	go build -mod=readonly -o $@ go.uber.org/thriftrw
 
-$(BINS)/thriftrw-plugin-yarpc: go.mod
+$(BIN)/thriftrw-plugin-yarpc: go.mod
 	go build -mod=readonly -o $@ go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc
 
-$(BINS)/golint: go.mod
+$(BIN)/golint: go.mod
 	go build -mod=readonly -o $@ golang.org/x/lint/golint
 
-$(BINS)/staticcheck: go.mod
+$(BIN)/staticcheck: go.mod
 	go build -mod=readonly -o $@ honnef.co/go/tools/cmd/staticcheck
 
-$(BINS)/errcheck: go.mod
+$(BIN)/errcheck: go.mod
 	go build -mod=readonly -o $@ github.com/kisielk/errcheck
 
-$(THRIFTRW_OUT): $(THRIFTRW_SRC) $(BINS)/thriftrw $(BINS)/thriftrw-plugin-yarpc
-	@echo 'thriftrw: $(THRIFTRW_SRC)'
-	@mkdir -p $(dir $@)
-	@# needs to be able to find the thriftrw-plugin-yarpc bin in PATH
-	$(foreach source,$(THRIFTRW_SRC),\
-		PATH="$(BINS)" \
-		    $(BINS)/thriftrw \
-		        --plugin=yarpc \
-		        --pkg-prefix=$(IMPORT_ROOT)/$(THRIFT_GENDIR) \
-		        --out=$(THRIFT_GENDIR) $(source);)
+# copyright header checker/writer.  only requires stdlib, so no other dependencies are needed.
+$(BIN)/copyright: internal/cmd/tools/copyright/licensegen.go go.mod
+	go build -mod=readonly -o $@ ./internal/cmd/tools/copyright/licensegen.go
 
-git-submodules:
-	git submodule update --init --recursive
-
-yarpc-install: $(BINS)/thriftrw $(BINS)/thriftrw-plugin-yarpc
-
-thriftc: git-submodules yarpc-install $(THRIFTRW_OUT) copyright
-
-clean_thrift:
-	rm -rf .gen
-
-# `make copyright` or depend on "copyright" to force-run licensegen,
-# or depend on $(BUILD)/copyright to let it run as needed.
-copyright $(BUILD)/copyright: $(ALL_SRC)
-	@mkdir -p $(BUILD)
-	go run ./internal/cmd/tools/copyright/licensegen.go --verifyOnly
-	@touch $(BUILD)/copyright
-
-$(BUILD)/dummy:
+# dummy binary that ensures most/all packages build, without needing to wait for tests.
+$(BUILD)/dummy: $(ALL_SRC) go.mod
 	go build -o $@ internal/cmd/dummy/dummy.go
 
-bins: thriftc $(ALL_SRC) $(BUILD)/copyright lint $(BUILD)/dummy
+# ====================================
+# Codegen targets
+# ====================================
 
-unit_test: $(BUILD)/dummy
-	@mkdir -p $(COVER_ROOT)
-	@echo "mode: atomic" > $(UT_COVER_FILE)
-	@failed=0; \
-	for dir in $(UT_DIRS); do \
-		mkdir -p $(COVER_ROOT)/"$$dir"; \
-		go test "$$dir" $(TEST_ARG) -coverprofile=$(COVER_ROOT)/"$$dir"/cover.out || failed=1; \
-		cat $(COVER_ROOT)/"$$dir"/cover.out | grep -v "mode: atomic" >> $(UT_COVER_FILE); \
-	done; \
-	exit $$failed
+# IDL submodule must be populated, or files will not exist -> prerequisites will be wrong -> build will fail.
+# Because it must exist before the makefile is parsed, this cannot be done automatically as part of a build.
+# Instead: call this func in targets that require the submodule to exist, so that target will not be built.
+#
+# THRIFT_FILES is just an easy identifier for "the submodule has files", others would work fine as well.
+define ensure_idl_submodule
+$(if $(wildcard THRIFT_FILES),,$(error idls/ submodule must exist, or build will fail.  Run `git submodule update --init` and try again))
+endef
 
-integ_test_sticky_off: $(BUILD)/dummy
-	@mkdir -p $(COVER_ROOT)
-	STICKY_OFF=true go test $(TEST_ARG) ./test -coverprofile=$(INTEG_STICKY_OFF_COVER_FILE) -coverpkg=./...
+# codegen is done when thrift is done (it's just a naming-convenience, $(BUILD)/thrift would be fine too)
+$(BUILD)/codegen: $(BUILD)/thrift | $(BUILD)
+	@touch $@
 
-integ_test_sticky_on: $(BUILD)/dummy
-	@mkdir -p $(COVER_ROOT)
-	STICKY_OFF=false go test $(TEST_ARG) ./test -coverprofile=$(INTEG_STICKY_ON_COVER_FILE) -coverpkg=./...
+THRIFT_FILES := idls/thrift/cadence.thrift idls/thrift/shadower.thrift
+# book-keeping targets to build.  one per thrift file.
+# idls/thrift/thing.thrift -> .build/thing.thrift
+# the reverse is done in the recipe.
+THRIFT_GEN := $(subst idls/thrift/,.build/,$(THRIFT_FILES))
 
-integ_test_grpc: $(BUILD)/dummy
-	@mkdir -p $(COVER_ROOT)
-	STICKY_OFF=false go test $(TEST_ARG) ./test -coverprofile=$(INTEG_GRPC_COVER_FILE) -coverpkg=./...
+# dummy targets to detect when the idls submodule does not exist, to provide a better error message
+$(THRIFT_FILES):
+	$(call ensure_idl_submodule)
 
-test: thriftc unit_test integ_test_sticky_off integ_test_sticky_on
+# thrift is done when all sub-thrifts are done.
+$(BUILD)/thrift: $(THRIFT_GEN) | $(BUILD)
+	@touch $@
 
-$(COVER_ROOT)/cover.out: $(UT_COVER_FILE) $(INTEG_STICKY_OFF_COVER_FILE) $(INTEG_STICKY_ON_COVER_FILE) $(INTEG_GRPC_COVER_FILE)
-	@echo "mode: atomic" > $(COVER_ROOT)/cover.out
-	cat $(UT_COVER_FILE) | grep -v "mode: atomic" | grep -v ".gen" >> $(COVER_ROOT)/cover.out
-	cat $(INTEG_STICKY_OFF_COVER_FILE) | grep -v "mode: atomic" | grep -v ".gen" >> $(COVER_ROOT)/cover.out
-	cat $(INTEG_STICKY_ON_COVER_FILE) | grep -v "mode: atomic" | grep -v ".gen" >> $(COVER_ROOT)/cover.out
-	cat $(INTEG_GRPC_COVER_FILE) | grep -v "mode: atomic" | grep -v ".gen" >> $(COVER_ROOT)/cover.out
+# how to generate each thrift book-keeping file.
+#
+# note that each generated file depends on ALL thrift files - this is necessary because they can import each other.
+# ideally this would --no-recurse like the server does, but currently that produces a new output file, and parallel
+# compiling appears to work fine.  seems likely it only risks rare flaky builds.
+$(THRIFT_GEN): $(THRIFT_FILES) $(BIN)/thriftrw $(BIN)/thriftrw-plugin-yarpc | $(BUILD)
+	@echo 'thriftrw for $(subst .build/,idls/thrift/,$@)...'
+	@$(BIN_PATH) $(BIN)/thriftrw \
+		--plugin=yarpc \
+		--pkg-prefix=$(PROJECT_ROOT)/.gen/go \
+		--out=.gen/go \
+		$(subst .build/,idls/thrift/,$@)
+	@touch $@
 
-cover: $(COVER_ROOT)/cover.out
-	go tool cover -html=$(COVER_ROOT)/cover.out;
-
-cover_ci: $(COVER_ROOT)/cover.out
-	goveralls -coverprofile=$(COVER_ROOT)/cover.out -service=buildkite || echo -e "\x1b[31mCoveralls failed\x1b[m";
+# ====================================
+# other intermediates
+# ====================================
 
 # golint fails to report many lint failures if it is only given a single file
 # to work on at a time, and it can't handle multiple packages at once, *and*
@@ -135,33 +171,93 @@ cover_ci: $(COVER_ROOT)/cover.out
 # - filter to only files in LINT_SRC
 # - if it's not empty, run golint against the list
 define lint_if_present
-test -n "$1" && $(BINS)/golint -set_exit_status $1
+test -n "$1" && $(BIN)/golint -set_exit_status $1
 endef
 
-lint: $(BINS)/golint $(ALL_SRC)
-	$(foreach pkg,\
+# TODO: replace this with revive, like the server.
+# keep in sync with `lint`
+$(BUILD)/lint: $(BIN)/golint $(ALL_SRC)
+	@$(foreach pkg, \
 		$(sort $(dir $(LINT_SRC))), \
 		$(call lint_if_present,$(filter $(wildcard $(pkg)*.go),$(LINT_SRC))) || ERR=1; \
-	) test -z "$$ERR" || exit 1
-	@OUTPUT=`gofmt -l $(ALL_SRC) 2>&1`; \
-	if [ "$$OUTPUT" ]; then \
-		echo "Run 'make fmt'. gofmt must be run on the following files:"; \
-		echo "$$OUTPUT"; \
-		exit 1; \
-	fi
+	) test -z "$$ERR"; touch $@; exit $$ERR
 
-staticcheck: $(BINS)/staticcheck $(ALL_SRC)
-	$(BINS)/staticcheck ./...
+# fmt and copyright are mutually cyclic with their inputs, so if a copyright header is modified:
+# - copyright -> makes changes
+# - fmt sees changes -> makes changes
+# - now copyright thinks it needs to run again (but does nothing)
+# - which means fmt needs to run again (but does nothing)
+# and now after two passes it's finally stable, because they stopped making changes.
+#
+# this is not fatal, we can just run 2x.
+# to be fancier though, we can detect when *both* are run, and re-touch the book-keeping files to prevent the second run.
+# this STRICTLY REQUIRES that `copyright` and `fmt` are mutually stable, and that copyright runs before fmt.
+# if either changes, this will need to change.
+MAYBE_TOUCH_COPYRIGHT=
 
-errcheck: $(BINS)/errcheck $(ALL_SRC)
-	$(BINS)/errcheck ./...
-
-fmt:
+# TODO: switch to goimports, so we can pin the version
+$(BUILD)/fmt: $(ALL_SRC) | $(BUILD)
+	@echo "gofmt..."
+	@# use FRESH_ALL_SRC so it won't miss any generated files produced earlier
 	@gofmt -w $(ALL_SRC)
+	@# ideally, mimic server: $(BIN)/goimports -local "go.uber.org/cadence" -w $(FRESH_ALL_SRC)
+	@touch $@
+	@$(MAYBE_TOUCH_COPYRIGHT)
 
+$(BUILD)/copyright: $(ALL_SRC) $(BIN)/copyright | $(BUILD)
+	$(BIN)/copyright --verifyOnly
+	@$(eval MAYBE_TOUCH_COPYRIGHT=touch $@)
+	@touch $@
+
+$(BUILD)/dummy: $(ALL_SRC) go.mod
+
+# ====================================
+# developer-oriented targets
+#
+# many of these share logic with other intermediates, but are useful to make .PHONY for output on demand.
+# as the Makefile is fast, it's reasonable to just delete the book-keeping file recursively make.
+# this way the effort is shared with future `make` runs.
+# ====================================
+
+.PHONY: build
+build: $(BUILD)/dummy ## ensure all packages build
+
+.PHONY: lint
+# useful to actually re-run to get output again, as the intermediate will not be run unless necessary.
+# dummy is used only because it occurs before $(BUILD)/lint, fmt would likely be sufficient too.
+# keep in sync with `$(BUILD)/lint`
+lint: $(BUILD)/dummy ## (re)run golint
+	@$(foreach pkg, \
+		$(sort $(dir $(LINT_SRC))), \
+		$(call lint_if_present,$(filter $(wildcard $(pkg)*.go),$(LINT_SRC))) || ERR=1; \
+	) test -z "$$ERR"; touch $(BUILD)/lint; exit $$ERR
+
+.PHONY: fmt
+# intentionally not re-making, gofmt is slow and it's clear when it's unnecessary
+fmt: $(BUILD)/fmt ## run gofmt
+
+.PHONY: copyright
+# not identical to the intermediate target, but does provide the same codegen (or more).
+copyright: $(BIN)/copyright ## update copyright headers
+	$(BIN)/copyright
+	@touch $(BUILD)/copyright
+
+.PHONY: staticcheck
+staticcheck: $(BIN)/staticcheck $(BUILD)/fmt ## (re)run staticcheck
+	$(BIN)/staticcheck ./...
+
+.PHONY: errcheck
+errcheck: $(BIN)/errcheck $(BUILD)/fmt ## (re)run errcheck
+	$(BIN)/errcheck ./...
+
+.PHONY: all
+all: $(BUILD)/lint ## refresh codegen, lint, and ensure the dummy binary builds, if necessary
+
+.PHONY: clean
 clean:
-	rm -Rf $(BUILD)
-	rm -Rf .gen
+	rm -Rf $(BUILD) .gen
+	@# remove old things (no longer in use).  this can be removed "eventually", when we feel like they're unlikely to exist.
+	rm -Rf .bins dummy
 
 # broken up into multiple += so I can interleave comments.
 # this all becomes a single line of output.
@@ -184,10 +280,69 @@ JQ_DEPS_AGE += --raw-output
 # exclude `"Indirect": true` dependencies.  direct ones have no "Indirect" key at all.
 JQ_DEPS_ONLY_DIRECT = | select(has("Indirect") | not)
 
+.PHONY: deps
 deps: ## Check for dependency updates, for things that are directly imported
 	@make --no-print-directory DEPS_FILTER='$(JQ_DEPS_ONLY_DIRECT)' deps-all
 
+.PHONY: deps-all
 deps-all: ## Check for all dependency updates
 	@go list -u -m -json all \
 		| $(JQ_DEPS_AGE) \
 		| sort -n
+
+.PHONY: help
+help:
+	@# print help first, so it's visible
+	@printf "\033[36m%-20s\033[0m %s\n" 'help' 'Prints a help message showing any specially-commented targets'
+	@# then everything matching "target: ## magic comments"
+	@cat $(MAKEFILE_LIST) | grep -e "^[a-zA-Z_\-]*:.* ## .*" | awk 'BEGIN {FS = ":.*? ## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' | sort
+
+# v==================== not yet cleaned up =======================v
+
+INTEG_TEST_ROOT := ./test
+COVER_ROOT := $(BUILD)/coverage
+UT_COVER_FILE := $(COVER_ROOT)/unit_test_cover.out
+INTEG_STICKY_OFF_COVER_FILE := $(COVER_ROOT)/integ_test_sticky_off_cover.out
+INTEG_STICKY_ON_COVER_FILE := $(COVER_ROOT)/integ_test_sticky_on_cover.out
+INTEG_GRPC_COVER_FILE := $(COVER_ROOT)/integ_test_grpc_cover.out
+
+UT_DIRS := $(filter-out $(INTEG_TEST_ROOT)%, $(sort $(dir $(filter %_test.go,$(ALL_SRC)))))
+
+.PHONY: unit_test integ_test_sticky_off integ_test_sticky_on integ_test_grpc cover cover_ci
+test: unit_test integ_test_sticky_off integ_test_sticky_on ## run all tests (requires a running cadence instance)
+
+unit_test: $(ALL_SRC) ## run all unit tests
+	@mkdir -p $(COVER_ROOT)
+	@echo "mode: atomic" > $(UT_COVER_FILE)
+	@failed=0; \
+	for dir in $(UT_DIRS); do \
+		mkdir -p $(COVER_ROOT)/"$$dir"; \
+		go test "$$dir" $(TEST_ARG) -coverprofile=$(COVER_ROOT)/"$$dir"/cover.out || failed=1; \
+		cat $(COVER_ROOT)/"$$dir"/cover.out | grep -v "mode: atomic" >> $(UT_COVER_FILE); \
+	done; \
+	exit $$failed
+
+integ_test_sticky_off: $(ALL_SRC)
+	@mkdir -p $(COVER_ROOT)
+	STICKY_OFF=true go test $(TEST_ARG) ./test -coverprofile=$(INTEG_STICKY_OFF_COVER_FILE) -coverpkg=./...
+
+integ_test_sticky_on: $(ALL_SRC)
+	@mkdir -p $(COVER_ROOT)
+	STICKY_OFF=false go test $(TEST_ARG) ./test -coverprofile=$(INTEG_STICKY_ON_COVER_FILE) -coverpkg=./...
+
+integ_test_grpc: $(ALL_SRC)
+	@mkdir -p $(COVER_ROOT)
+	STICKY_OFF=false go test $(TEST_ARG) ./test -coverprofile=$(INTEG_GRPC_COVER_FILE) -coverpkg=./...
+
+$(COVER_ROOT)/cover.out: $(UT_COVER_FILE) $(INTEG_STICKY_OFF_COVER_FILE) $(INTEG_STICKY_ON_COVER_FILE) $(INTEG_GRPC_COVER_FILE)
+	@echo "mode: atomic" > $(COVER_ROOT)/cover.out
+	cat $(UT_COVER_FILE) | grep -v "mode: atomic" | grep -v ".gen" >> $(COVER_ROOT)/cover.out
+	cat $(INTEG_STICKY_OFF_COVER_FILE) | grep -v "mode: atomic" | grep -v ".gen" >> $(COVER_ROOT)/cover.out
+	cat $(INTEG_STICKY_ON_COVER_FILE) | grep -v "mode: atomic" | grep -v ".gen" >> $(COVER_ROOT)/cover.out
+	cat $(INTEG_GRPC_COVER_FILE) | grep -v "mode: atomic" | grep -v ".gen" >> $(COVER_ROOT)/cover.out
+
+cover: $(COVER_ROOT)/cover.out
+	go tool cover -html=$(COVER_ROOT)/cover.out;
+
+cover_ci: $(COVER_ROOT)/cover.out
+	goveralls -coverprofile=$(COVER_ROOT)/cover.out -service=buildkite || echo -e "\x1b[31mCoveralls failed\x1b[m";


### PR DESCRIPTION
Builds now work reliably, even in parallel, and it recovers from previous
builds (whether successful or not) without running more than necessary.

We should switch to revive and goimports like the server does, and ideally
both will move to `go test ./...` eventually (with build tags or something
to exclude integration tests) to make the tests run more normally.  We can
also take advantage of Go's built-in coverage merging and reports that way.

But those are for another day.  This is just setting a saner foundation.

---

At a very high level, this brings the client's makefile in line with the
server's, and adds `make build` and `make all` targets for dev-simplicity
(and visibility).
These targets will do a full build / lint _only when necessary_, i.e. after
changes have been made.  They should be more than sufficient for most uses,
as they now ensure thrift/fmt/copyright headers consistently, but you can run
`make lint` to get the output again if desired, and some stages can be run
independently without running later ones (like fmt).

To see current top-level targets, just run `make`.  It'll print help output:
```
❯ make
help                 Prints a help message showing any specially-commented targets
all                  refresh codegen, lint, and ensure the dummy binary builds, if necessary
build                ensure all packages build
copyright            update copyright headers
deps                 Check for dependency updates, for things that are directly imported
deps-all             Check for all dependency updates
errcheck             (re)run errcheck
fmt                  run gofmt
lint                 (re)run golint
staticcheck          (re)run staticcheck
test                 run all tests (requires a running cadence instance)
unit_test            run all unit tests
```