### PR TITLE
Upgrade x/sys to work with Go 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	go.uber.org/zap v1.13.0
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974
+	golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb // indirect
 	golang.org/x/time v0.0.0-20170927054726-6dc17368e09b
 	honnef.co/go/tools v0.0.1-2019.2.3
 )

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pborman/uuid v0.0.0-20160209185913-a97ce2ca70fa
 	github.com/robfig/cron v1.2.0
+	github.com/streadway/quantile v0.0.0-20220407130108-4246515d968d // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/uber-go/tally v3.3.15+incompatible
 	github.com/uber/cadence-idl v0.0.0-20220223020740-f2f5b7fc2bbd

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,8 @@ golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb h1:PVGECzEo9Y3uOidtkHGdd347NjLtITfJFO9BxFpmRoo=
+golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,9 @@ github.com/samuel/go-thrift v0.0.0-20191111193933-5165175b40af h1:EiWVfh8mr40yFZ
 github.com/samuel/go-thrift v0.0.0-20191111193933-5165175b40af/go.mod h1:Vrkh1pnjV9Bl8c3P9zH0/D4NlOHWP5d4/hF4YTULaec=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/streadway/quantile v0.0.0-20150917103942-b0c588724d25 h1:7z3LSn867ex6VSaahyKadf4WtSsJIgne6A1WLOAGM8A=
 github.com/streadway/quantile v0.0.0-20150917103942-b0c588724d25/go.mod h1:lbP8tGiBjZ5YWIc2fzuRpTaz0b/53vT6PEs3QuAWzuU=
+github.com/streadway/quantile v0.0.0-20220407130108-4246515d968d h1:X4+kt6zM/OVO6gbJdAfJR60MGPsqCzbtXNnjoGqdfAs=
+github.com/streadway/quantile v0.0.0-20220407130108-4246515d968d/go.mod h1:lbP8tGiBjZ5YWIc2fzuRpTaz0b/53vT6PEs3QuAWzuU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
@@ -249,7 +250,6 @@ golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200117145432-59e60aa80a0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb h1:PVGECzEo9Y3uOidtkHGdd347NjLtITfJFO9BxFpmRoo=
 golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/common/auth/service_wrapper.go
+++ b/internal/common/auth/service_wrapper.go
@@ -455,14 +455,14 @@ func (w *workflowServiceAuthWrapper) GetTaskListsByDomain(ctx context.Context, r
 		return nil, err
 	}
 	opts = append(opts, *tokenHeader)
-	result, err := w.service.GetTaskListsByDomain(ctx,request, opts...)
+	result, err := w.service.GetTaskListsByDomain(ctx, request, opts...)
 	return result, err
 }
 
 func (w *workflowServiceAuthWrapper) RefreshWorkflowTasks(ctx context.Context, request *shared.RefreshWorkflowTasksRequest, opts ...yarpc.CallOption) error {
 	tokenHeader, err := w.getYarpcJWTHeader()
 	if err != nil {
-		return  err
+		return err
 	}
 	opts = append(opts, *tokenHeader)
 	err = w.service.RefreshWorkflowTasks(ctx, request, opts...)

--- a/internal/compatibility/adapter.go
+++ b/internal/compatibility/adapter.go
@@ -38,8 +38,6 @@ type thrift2protoAdapter struct {
 	visibility apiv1.VisibilityAPIYARPCClient
 }
 
-
-
 func NewThrift2ProtoAdapter(
 	domain apiv1.DomainAPIYARPCClient,
 	workflow apiv1.WorkflowAPIYARPCClient,
@@ -245,7 +243,7 @@ func (a thrift2protoAdapter) GetTaskListsByDomain(ctx context.Context, Request *
 
 func (a thrift2protoAdapter) RefreshWorkflowTasks(ctx context.Context, request *shared.RefreshWorkflowTasksRequest, opts ...yarpc.CallOption) error {
 	_, err := a.workflow.RefreshWorkflowTasks(ctx, proto.RefreshWorkflowTasksRequest(request), opts...)
-	return  thrift.Error(err)
+	return thrift.Error(err)
 }
 
 type domainAPIthriftAdapter struct {
@@ -435,4 +433,3 @@ func (a visibilityAPIthriftAdapter) GetSearchAttributes(ctx context.Context, req
 	response, err := a.service.GetSearchAttributes(ctx, opts...)
 	return proto.GetSearchAttributesResponse(response), proto.Error(err)
 }
-

--- a/internal/compatibility/proto/request.go
+++ b/internal/compatibility/proto/request.go
@@ -616,8 +616,8 @@ func RefreshWorkflowTasksRequest(r *shared.RefreshWorkflowTasksRequest) *apiv1.R
 		return nil
 	}
 	request := apiv1.RefreshWorkflowTasksRequest{
-		Domain:          r.GetDomain(),
-		WorkflowExecution:   WorkflowExecution(r.Execution),
+		Domain:            r.GetDomain(),
+		WorkflowExecution: WorkflowExecution(r.Execution),
 	}
 	return &request
 }


### PR DESCRIPTION
Builds with 1.18 are currently failing with numerous errors like:
```
> make bins
go build -o .build/dummy internal/cmd/dummy/dummy.go
# golang.org/x/sys/unix
../../../pkg/mod/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f/unix/syscall_darwin.1_13.go:29:3: //go:linkname must refer to declared function or variable
../../../pkg/mod/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f/unix/zsyscall_darwin_amd64.1_13.go:27:3: //go:linkname must refer to declared function or variable
```

This is pretty easily addressed with `go get -u go.lang.org/x/sys`,
which (plus `make build` to verify) is all this commit _would_ contain...

... but github.com/streadway/quantile was using a `import "."`, which apparently
Go 1.18 disallows for modules.  Which breaks `go mod tidy` rather awkwardly.
TIL.
Now that https://github.com/streadway/quantile/pull/8 is merged though, the new
`master` works, so that has been updated as well.

---

Previously:

It would probably be good to upgrade other things and do a `go mod tidy`,
but unfortunately that is currently failing with:
```
go.uber.org/cadence/internal imports
	go.uber.org/yarpc imports
	github.com/uber/tchannel-go tested by
	github.com/uber/tchannel-go.test imports
	github.com/streadway/quantile tested by
	github.com/streadway/quantile.test imports
	.: "." is relative, but relative import paths are not supported in module mode
```
I've opened a PR for the core fix: https://github.com/streadway/quantile/pull/8
And I've asked yarpc/tchannel internally to see if they can address this as well,
as I'm really not sure how long that will take to merge.

In the meantime, as far as I can tell, we *just* can't do `go mod tidy`.
Updating / installing / etc of dependencies works fine.