### PR TITLE
Stop retrying get-workflow-history with an impossibly-short timeout

### DIFF
--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -512,12 +512,18 @@ func (wc *workflowClient) GetWorkflowHistory(
 		var err error
 	Loop:
 		for {
+			var isFinalLongPoll bool
 			err = backoff.Retry(ctx,
 				func() error {
 					var err1 error
 					tchCtx, cancel, opt := newChannelContext(ctx, wc.featureFlags, func(builder *contextBuilder) {
 						if isLongPoll {
 							builder.Timeout = defaultGetHistoryTimeoutInSecs * time.Second
+							deadline, ok := ctx.Deadline()
+							if ok && deadline.Before(time.Now().Add(builder.Timeout)) {
+								// insufficient time for another poll, so this needs to be the last attempt
+								isFinalLongPoll = true
+							}
 						}
 					})
 					defer cancel()
@@ -546,6 +552,13 @@ func (wc *workflowClient) GetWorkflowHistory(
 				return nil, err
 			}
 			if isLongPoll && len(response.History.Events) == 0 && len(response.NextPageToken) != 0 {
+				if isFinalLongPoll {
+					// essentially a deadline exceeded, the last attempt did not get a result.
+					// this is necessary because the server does not know if we are able to try again,
+					// so it returns an empty result slightly before a timeout occurs, so the next
+					// attempt's token can be returned if it wishes to retry.
+					return nil, fmt.Errorf("timed out waiting for the workflow to finish: %w", context.DeadlineExceeded)
+				}
 				request.NextPageToken = response.NextPageToken
 				continue Loop
 			}


### PR DESCRIPTION
Previously, when a `GetWorkflow(...).Get(...)` call timed out while waiting
for the workflow to complete, this happened:
- N-1 requests of the default long-poll timeout occurred, and it correctly retried
- The final request would have something like 5 seconds left, so it performs that call
- The server gives up the request *slightly before* that timeout so it can return the
  next page token for a future request to use (as happened in the N-1 earlier requests)
- Since no history was received and there's still time left in the context (~50ms
  internally), another impossibly-short request was sent
- This request fails immediately with a "insufficient time for long poll request" error.
- *This error* is what is returned from `Get(...)`

Which is pretty clearly sub-optimal.
Both because we sent a request that is almost guaranteed to fail, and because the error
returned to the caller is fairly generic looking / doesn't describe what happened.

What happened is that we ran out of time.
So this now returns a DeadlineExceeded error, like any other timeout, and does not
cause that final request to occur.

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
