### PR TITLE
Simplify worker options configuration value propagation

### DIFF
--- a/internal/common/autoscaler/auto_scaler.go
+++ b/internal/common/autoscaler/auto_scaler.go
@@ -1,0 +1,1 @@
+package autoscaler

--- a/internal/interceptors.go
+++ b/internal/interceptors.go
@@ -72,7 +72,7 @@ type WorkflowInterceptor interface {
 
 var _ WorkflowInterceptor = (*WorkflowInterceptorBase)(nil)
 
-// WorkflowInterceptorBase is a helper type that can simplify creation of WorkflowInterceptors
+// WorkflowInterceptorBase is a helper type that can simplify creation of WorkflowInterceptorChainFactories
 type WorkflowInterceptorBase struct {
 	Next WorkflowInterceptor
 }

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -112,12 +112,12 @@ type (
 		isReplay              bool // flag to indicate if workflow is in replay mode
 		enableLoggingInReplay bool // flag to indicate if workflow should enable logging in replay mode
 
-		metricsScope         tally.Scope
-		registry             *registry
-		dataConverter        DataConverter
-		contextPropagators   []ContextPropagator
-		tracer               opentracing.Tracer
-		workflowInterceptors []WorkflowInterceptorFactory
+		metricsScope                 tally.Scope
+		registry                     *registry
+		dataConverter                DataConverter
+		contextPropagators           []ContextPropagator
+		tracer                       opentracing.Tracer
+		workflowInterceptorFactories []WorkflowInterceptorFactory
 	}
 
 	localActivityTask struct {
@@ -201,24 +201,24 @@ func newWorkflowExecutionEventHandler(
 	dataConverter DataConverter,
 	contextPropagators []ContextPropagator,
 	tracer opentracing.Tracer,
-	workflowInterceptors []WorkflowInterceptorFactory,
+	workflowInterceptorFactories []WorkflowInterceptorFactory,
 ) workflowExecutionEventHandler {
 	context := &workflowEnvironmentImpl{
-		workflowInfo:          workflowInfo,
-		decisionsHelper:       newDecisionsHelper(),
-		sideEffectResult:      make(map[int32][]byte),
-		mutableSideEffect:     make(map[string][]byte),
-		changeVersions:        make(map[string]Version),
-		pendingLaTasks:        make(map[string]*localActivityTask),
-		unstartedLaTasks:      make(map[string]struct{}),
-		openSessions:          make(map[string]*SessionInfo),
-		completeHandler:       completeHandler,
-		enableLoggingInReplay: enableLoggingInReplay,
-		registry:              registry,
-		dataConverter:         dataConverter,
-		contextPropagators:    contextPropagators,
-		tracer:                tracer,
-		workflowInterceptors:  workflowInterceptors,
+		workflowInfo:                 workflowInfo,
+		decisionsHelper:              newDecisionsHelper(),
+		sideEffectResult:             make(map[int32][]byte),
+		mutableSideEffect:            make(map[string][]byte),
+		changeVersions:               make(map[string]Version),
+		pendingLaTasks:               make(map[string]*localActivityTask),
+		unstartedLaTasks:             make(map[string]struct{}),
+		openSessions:                 make(map[string]*SessionInfo),
+		completeHandler:              completeHandler,
+		enableLoggingInReplay:        enableLoggingInReplay,
+		registry:                     registry,
+		dataConverter:                dataConverter,
+		contextPropagators:           contextPropagators,
+		tracer:                       tracer,
+		workflowInterceptorFactories: workflowInterceptorFactories,
 	}
 	context.logger = logger.With(
 		zapcore.Field{Key: tagWorkflowType, Type: zapcore.StringType, String: workflowInfo.WorkflowType.Name},
@@ -771,7 +771,7 @@ func (wc *workflowEnvironmentImpl) GetRegistry() *registry {
 }
 
 func (wc *workflowEnvironmentImpl) GetWorkflowInterceptors() []WorkflowInterceptorFactory {
-	return wc.workflowInterceptors
+	return wc.workflowInterceptorFactories
 }
 
 func (weh *workflowExecutionEventHandlerImpl) ProcessEvent(

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -396,7 +396,7 @@ func newWorkflowTaskHandler(
 		dataConverter:                  params.DataConverter,
 		contextPropagators:             params.ContextPropagators,
 		tracer:                         params.Tracer,
-		workflowInterceptors:           params.WorkflowInterceptors,
+		workflowInterceptors:           params.WorkflowInterceptorChainFactories,
 	}
 }
 

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -125,7 +125,7 @@ type (
 		dataConverter                  DataConverter
 		contextPropagators             []ContextPropagator
 		tracer                         opentracing.Tracer
-		workflowInterceptors           []WorkflowInterceptorFactory
+		workflowInterceptorFactories   []WorkflowInterceptorFactory
 	}
 
 	activityProvider func(name string) activity
@@ -396,7 +396,7 @@ func newWorkflowTaskHandler(
 		dataConverter:                  params.DataConverter,
 		contextPropagators:             params.ContextPropagators,
 		tracer:                         params.Tracer,
-		workflowInterceptors:           params.WorkflowInterceptorChainFactories,
+		workflowInterceptorFactories:   params.WorkflowInterceptorChainFactories,
 	}
 }
 
@@ -591,7 +591,7 @@ func (w *workflowExecutionContextImpl) createEventHandler() {
 		w.wth.dataConverter,
 		w.wth.contextPropagators,
 		w.wth.tracer,
-		w.wth.workflowInterceptors,
+		w.wth.workflowInterceptorFactories,
 	)
 	w.eventHandler.Store(eventHandler)
 }

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -314,18 +314,22 @@ func (t *TaskHandlersTestSuite) testWorkflowTaskWorkflowExecutionStartedHelper(p
 func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowExecutionStarted() {
 	params := workerExecutionParameters{
 		TaskList: testWorkflowTaskTasklist,
-		Identity: "test-id-1",
-		Logger:   t.logger,
+		WorkerOptions: WorkerOptions{
+			Identity: "test-id-1",
+			Logger:   t.logger,
+		},
 	}
 	t.testWorkflowTaskWorkflowExecutionStartedHelper(params)
 }
 
 func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowExecutionStarted_WithDataConverter() {
 	params := workerExecutionParameters{
-		TaskList:      testWorkflowTaskTasklist,
-		Identity:      "test-id-1",
-		Logger:        t.logger,
-		DataConverter: newTestDataConverter(),
+		TaskList: testWorkflowTaskTasklist,
+		WorkerOptions: WorkerOptions{
+			Identity:      "test-id-1",
+			Logger:        t.logger,
+			DataConverter: newTestDataConverter(),
+		},
 	}
 	t.testWorkflowTaskWorkflowExecutionStartedHelper(params)
 }
@@ -354,8 +358,10 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_BinaryChecksum() {
 	task := createWorkflowTask(testEvents, 8, "BinaryChecksumWorkflow")
 	params := workerExecutionParameters{
 		TaskList: taskList,
-		Identity: "test-id-1",
-		Logger:   t.logger,
+		WorkerOptions: WorkerOptions{
+			Identity: "test-id-1",
+			Logger:   t.logger,
+		},
 	}
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, t.registry)
 	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
@@ -394,8 +400,10 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_ActivityTaskScheduled() {
 	task := createWorkflowTask(testEvents[0:3], 0, "HelloWorld_Workflow")
 	params := workerExecutionParameters{
 		TaskList: taskList,
-		Identity: "test-id-1",
-		Logger:   t.logger,
+		WorkerOptions: WorkerOptions{
+			Identity: "test-id-1",
+			Logger:   t.logger,
+		},
 	}
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, t.registry)
 	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
@@ -440,8 +448,10 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow() {
 	}
 	params := workerExecutionParameters{
 		TaskList: taskList,
-		Identity: "test-id-1",
-		Logger:   t.logger,
+		WorkerOptions: WorkerOptions{
+			Identity: "test-id-1",
+			Logger:   t.logger,
+		},
 	}
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, t.registry)
 
@@ -491,8 +501,10 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_2() {
 	}
 	params := workerExecutionParameters{
 		TaskList: taskList,
-		Identity: "test-id-1",
-		Logger:   t.logger,
+		WorkerOptions: WorkerOptions{
+			Identity: "test-id-1",
+			Logger:   t.logger,
+		},
 	}
 
 	// TODO: the following comment is not true, previousStartEventID is either 0 or points to a valid decisionTaskStartedID
@@ -559,10 +571,12 @@ func (t *TaskHandlersTestSuite) TestCacheEvictionWhenErrorOccurs() {
 		}),
 	}
 	params := workerExecutionParameters{
-		TaskList:                       taskList,
-		Identity:                       "test-id-1",
-		Logger:                         zap.NewNop(),
-		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		TaskList: taskList,
+		WorkerOptions: WorkerOptions{
+			Identity:                       "test-id-1",
+			Logger:                         zap.NewNop(),
+			NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		},
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, t.registry)
@@ -593,10 +607,12 @@ func (t *TaskHandlersTestSuite) TestWithMissingHistoryEvents() {
 		createTestEventDecisionTaskStarted(7),
 	}
 	params := workerExecutionParameters{
-		TaskList:                       taskList,
-		Identity:                       "test-id-1",
-		Logger:                         zap.NewNop(),
-		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		TaskList: taskList,
+		WorkerOptions: WorkerOptions{
+			Identity:                       "test-id-1",
+			Logger:                         zap.NewNop(),
+			NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		},
 	}
 
 	for _, startEventID := range []int64{0, 3} {
@@ -633,10 +649,12 @@ func (t *TaskHandlersTestSuite) TestWithTruncatedHistory() {
 		}),
 	}
 	params := workerExecutionParameters{
-		TaskList:                       taskList,
-		Identity:                       "test-id-1",
-		Logger:                         zap.NewNop(),
-		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		TaskList: taskList,
+		WorkerOptions: WorkerOptions{
+			Identity:                       "test-id-1",
+			Logger:                         zap.NewNop(),
+			NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		},
 	}
 
 	testCases := []struct {
@@ -708,10 +726,12 @@ func (t *TaskHandlersTestSuite) testSideEffectDeferHelper(disableSticky bool) {
 	}
 
 	params := workerExecutionParameters{
-		TaskList:               taskList,
-		Identity:               "test-id-1",
-		Logger:                 zap.NewNop(),
-		DisableStickyExecution: disableSticky,
+		TaskList: taskList,
+		WorkerOptions: WorkerOptions{
+			Identity:               "test-id-1",
+			Logger:                 zap.NewNop(),
+			DisableStickyExecution: disableSticky,
+		},
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, t.registry)
@@ -750,11 +770,13 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	task := createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
 	stopC := make(chan struct{})
 	params := workerExecutionParameters{
-		TaskList:                       taskList,
-		Identity:                       "test-id-1",
-		Logger:                         zap.NewNop(),
-		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
-		WorkerStopChannel:              stopC,
+		TaskList: taskList,
+		WorkerOptions: WorkerOptions{
+			Identity:                       "test-id-1",
+			Logger:                         zap.NewNop(),
+			NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		},
+		WorkerStopChannel: stopC,
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, t.registry)
@@ -812,10 +834,12 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowReturnsPanicError() {
 	}
 	task := createWorkflowTask(testEvents, 3, "ReturnPanicWorkflow")
 	params := workerExecutionParameters{
-		TaskList:                       taskList,
-		Identity:                       "test-id-1",
-		Logger:                         zap.NewNop(),
-		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		TaskList: taskList,
+		WorkerOptions: WorkerOptions{
+			Identity:                       "test-id-1",
+			Logger:                         zap.NewNop(),
+			NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		},
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, t.registry)
@@ -840,10 +864,12 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowPanics() {
 	}
 	task := createWorkflowTask(testEvents, 3, "PanicWorkflow")
 	params := workerExecutionParameters{
-		TaskList:                       taskList,
-		Identity:                       "test-id-1",
-		Logger:                         zap.NewNop(),
-		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		TaskList: taskList,
+		WorkerOptions: WorkerOptions{
+			Identity:                       "test-id-1",
+			Logger:                         zap.NewNop(),
+			NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		},
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, t.registry)
@@ -899,10 +925,12 @@ func (t *TaskHandlersTestSuite) TestGetWorkflowInfo() {
 	}
 	task := createWorkflowTask(testEvents, 3, workflowType)
 	params := workerExecutionParameters{
-		TaskList:                       taskList,
-		Identity:                       "test-id-1",
-		Logger:                         zap.NewNop(),
-		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		TaskList: taskList,
+		WorkerOptions: WorkerOptions{
+			Identity:                       "test-id-1",
+			Logger:                         zap.NewNop(),
+			NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		},
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, t.registry)
@@ -932,10 +960,12 @@ func (t *TaskHandlersTestSuite) TestGetWorkflowInfo() {
 func (t *TaskHandlersTestSuite) TestConsistentQuery_InvalidQueryTask() {
 	taskList := "taskList"
 	params := workerExecutionParameters{
-		TaskList:                       taskList,
-		Identity:                       "test-id-1",
-		Logger:                         zap.NewNop(),
-		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		TaskList: taskList,
+		WorkerOptions: WorkerOptions{
+			Identity:                       "test-id-1",
+			Logger:                         zap.NewNop(),
+			NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		},
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, t.registry)
@@ -983,8 +1013,10 @@ func (t *TaskHandlersTestSuite) TestConsistentQuery_Success() {
 
 	params := workerExecutionParameters{
 		TaskList: taskList,
-		Identity: "test-id-1",
-		Logger:   t.logger,
+		WorkerOptions: WorkerOptions{
+			Identity: "test-id-1",
+			Logger:   t.logger,
+		},
 	}
 
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, t.registry)
@@ -1048,8 +1080,10 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_CancelActivityBeforeSent() {
 
 	params := workerExecutionParameters{
 		TaskList: taskList,
-		Identity: "test-id-1",
-		Logger:   t.logger,
+		WorkerOptions: WorkerOptions{
+			Identity: "test-id-1",
+			Logger:   t.logger,
+		},
 	}
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, t.registry)
 	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
@@ -1073,8 +1107,10 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_PageToken() {
 
 	params := workerExecutionParameters{
 		TaskList: taskList,
-		Identity: "test-id-1",
-		Logger:   t.logger,
+		WorkerOptions: WorkerOptions{
+			Identity: "test-id-1",
+			Logger:   t.logger,
+		},
 	}
 
 	nextEvents := []*s.HistoryEvent{
@@ -1136,10 +1172,12 @@ func (t *TaskHandlersTestSuite) TestLocalActivityRetry_DecisionHeartbeatFail() {
 	task := createWorkflowTask(testEvents, 0, "RetryLocalActivityWorkflow")
 	stopCh := make(chan struct{})
 	params := workerExecutionParameters{
-		TaskList:          testWorkflowTaskTasklist,
-		Identity:          "test-id-1",
-		Logger:            t.logger,
-		Tracer:            opentracing.NoopTracer{},
+		TaskList: testWorkflowTaskTasklist,
+		WorkerOptions: WorkerOptions{
+			Identity: "test-id-1",
+			Logger:   t.logger,
+			Tracer:   opentracing.NoopTracer{},
+		},
 		WorkerStopChannel: stopCh,
 	}
 	defer close(stopCh)
@@ -1370,9 +1408,11 @@ func (t *TaskHandlersTestSuite) TestActivityExecutionDeadline() {
 	for i, d := range deadlineTests {
 		a.d = d.actWaitDuration
 		wep := workerExecutionParameters{
-			Logger:        t.logger,
-			DataConverter: getDefaultDataConverter(),
-			Tracer:        opentracing.NoopTracer{},
+			WorkerOptions: WorkerOptions{
+				Logger:        t.logger,
+				DataConverter: getDefaultDataConverter(),
+				Tracer:        opentracing.NoopTracer{},
+			},
 		}
 		activityHandler := newActivityTaskHandler(mockService, wep, registry)
 		pats := &s.PollForActivityTaskResponse{
@@ -1427,8 +1467,10 @@ func (t *TaskHandlersTestSuite) TestActivityExecutionWorkerStop() {
 	workerStopCh := make(chan struct{}, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	wep := workerExecutionParameters{
-		Logger:            t.logger,
-		DataConverter:     getDefaultDataConverter(),
+		WorkerOptions: WorkerOptions{
+			Logger:        t.logger,
+			DataConverter: getDefaultDataConverter(),
+		},
 		UserContext:       ctx,
 		UserContextCancel: cancel,
 		WorkerStopChannel: workerStopCh,
@@ -1503,10 +1545,12 @@ func (t *TaskHandlersTestSuite) TestRegression_QueriesDoNotLeakGoroutines() {
 
 	taskList := "tl1"
 	params := workerExecutionParameters{
-		TaskList:               taskList,
-		Identity:               "test-id-1",
-		Logger:                 t.logger,
-		DisableStickyExecution: false,
+		TaskList: taskList,
+		WorkerOptions: WorkerOptions{
+			Identity:               "test-id-1",
+			Logger:                 t.logger,
+			DisableStickyExecution: false,
+		},
 	}
 	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, t.registry)
 

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -118,63 +118,16 @@ type (
 
 	// workerExecutionParameters defines worker configure/execution options.
 	workerExecutionParameters struct {
+		WorkerOptions
+
 		// Task list name to poll.
 		TaskList string
-
-		// Defines how many concurrent activity executions by this worker.
-		MaxConcurrentActivityExecutionSize int
-
-		// Defines rate limiting on number of activity tasks that can be executed per second per worker.
-		WorkerActivitiesPerSecond float64
-
-		// MaxConcurrentActivityTaskPollers is the max number of pollers for activity task list
-		MaxConcurrentActivityTaskPollers int
-
-		// Defines how many concurrent decision task executions by this worker.
-		MaxConcurrentDecisionTaskExecutionSize int
-
-		// Defines rate limiting on number of decision tasks that can be executed per second per worker.
-		WorkerDecisionTasksPerSecond float64
-
-		// MaxConcurrentDecisionTaskPollers is the max number of pollers for decision task list
-		MaxConcurrentDecisionTaskPollers int
-
-		// Defines how many concurrent local activity executions by this worker.
-		MaxConcurrentLocalActivityExecutionSize int
-
-		// Defines rate limiting on number of local activities that can be executed per second per worker.
-		WorkerLocalActivitiesPerSecond float64
-
-		// TaskListActivitiesPerSecond is the throttling limit for activity tasks controlled by the server
-		TaskListActivitiesPerSecond float64
-
-		// User can provide an identity for the debuggability. If not provided the framework has
-		// a default option.
-		Identity string
-
-		MetricsScope tally.Scope
-
-		Logger *zap.Logger
-
-		// Enable logging in replay mode
-		EnableLoggingInReplay bool
 
 		// Context to store user provided key/value pairs
 		UserContext context.Context
 
 		// Context cancel function to cancel user context
 		UserContextCancel context.CancelFunc
-
-		// Disable sticky execution
-		DisableStickyExecution bool
-
-		StickyScheduleToStartTimeout time.Duration
-
-		// NonDeterministicWorkflowPolicy is used for configuring how client's decision task handler deals with
-		// mismatched history events (presumably arising from non-deterministic workflow definitions).
-		NonDeterministicWorkflowPolicy NonDeterministicWorkflowPolicy
-
-		DataConverter DataConverter
 
 		// WorkerStopTimeout is the time delay before hard terminate worker
 		WorkerStopTimeout time.Duration
@@ -184,15 +137,6 @@ type (
 
 		// SessionResourceID is a unique identifier of the resource the session will consume
 		SessionResourceID string
-
-		ContextPropagators []ContextPropagator
-
-		Tracer opentracing.Tracer
-
-		WorkflowInterceptorChainFactories []WorkflowInterceptorFactory
-
-		// flags to turn on/off some server side features
-		FeatureFlags FeatureFlags
 	}
 )
 
@@ -1007,31 +951,10 @@ func newAggregatedWorker(
 	backgroundActivityContext, backgroundActivityContextCancel := context.WithCancel(ctx)
 
 	workerParams := workerExecutionParameters{
-		TaskList:                                taskList,
-		MaxConcurrentActivityExecutionSize:      wOptions.MaxConcurrentActivityExecutionSize,
-		WorkerActivitiesPerSecond:               wOptions.WorkerActivitiesPerSecond,
-		MaxConcurrentActivityTaskPollers:        wOptions.MaxConcurrentActivityTaskPollers,
-		MaxConcurrentLocalActivityExecutionSize: wOptions.MaxConcurrentLocalActivityExecutionSize,
-		WorkerLocalActivitiesPerSecond:          wOptions.WorkerLocalActivitiesPerSecond,
-		MaxConcurrentDecisionTaskExecutionSize:  wOptions.MaxConcurrentDecisionTaskExecutionSize,
-		WorkerDecisionTasksPerSecond:            wOptions.WorkerDecisionTasksPerSecond,
-		MaxConcurrentDecisionTaskPollers:        wOptions.MaxConcurrentDecisionTaskPollers,
-		Identity:                                wOptions.Identity,
-		MetricsScope:                            wOptions.MetricsScope,
-		Logger:                                  wOptions.Logger,
-		EnableLoggingInReplay:                   wOptions.EnableLoggingInReplay,
-		UserContext:                             backgroundActivityContext,
-		UserContextCancel:                       backgroundActivityContextCancel,
-		DisableStickyExecution:                  wOptions.DisableStickyExecution,
-		StickyScheduleToStartTimeout:            wOptions.StickyScheduleToStartTimeout,
-		TaskListActivitiesPerSecond:             wOptions.TaskListActivitiesPerSecond,
-		NonDeterministicWorkflowPolicy:          wOptions.NonDeterministicWorkflowPolicy,
-		DataConverter:                           wOptions.DataConverter,
-		WorkerStopTimeout:                       wOptions.WorkerStopTimeout,
-		ContextPropagators:                      wOptions.ContextPropagators,
-		Tracer:                                  wOptions.Tracer,
-		WorkflowInterceptorChainFactories:       wOptions.WorkflowInterceptorChainFactories,
-		FeatureFlags:                            wOptions.FeatureFlags,
+		WorkerOptions:     wOptions,
+		TaskList:          taskList,
+		UserContext:       backgroundActivityContext,
+		UserContextCancel: backgroundActivityContextCancel,
 	}
 
 	ensureRequiredParams(&workerParams)

--- a/internal/internal_worker_interfaces_test.go
+++ b/internal/internal_worker_interfaces_test.go
@@ -178,11 +178,11 @@ func (s *InterfacesTestSuite) TestInterface() {
 	domain := "testDomain"
 	// Workflow execution parameters.
 	workflowExecutionParameters := workerExecutionParameters{
-		TaskList:                     "testTaskList",
-		MaxConcurrentActivityPollers: 4,
-		MaxConcurrentDecisionPollers: 4,
-		Logger:                       zaptest.NewLogger(s.T()),
-		Tracer:                       opentracing.NoopTracer{},
+		TaskList:                         "testTaskList",
+		MaxConcurrentActivityTaskPollers: 4,
+		MaxConcurrentDecisionTaskPollers: 4,
+		Logger:                           zaptest.NewLogger(s.T()),
+		Tracer:                           opentracing.NoopTracer{},
 	}
 
 	domainStatus := m.DomainStatusRegistered
@@ -209,11 +209,11 @@ func (s *InterfacesTestSuite) TestInterface() {
 
 	// Create activity execution parameters.
 	activityExecutionParameters := workerExecutionParameters{
-		TaskList:                     "testTaskList",
-		MaxConcurrentActivityPollers: 10,
-		MaxConcurrentDecisionPollers: 10,
-		Logger:                       zaptest.NewLogger(s.T()),
-		Tracer:                       opentracing.NoopTracer{},
+		TaskList:                         "testTaskList",
+		MaxConcurrentActivityTaskPollers: 10,
+		MaxConcurrentDecisionTaskPollers: 10,
+		Logger:                           zaptest.NewLogger(s.T()),
+		Tracer:                           opentracing.NoopTracer{},
 	}
 
 	// Register activity instances and launch the worker.

--- a/internal/internal_worker_interfaces_test.go
+++ b/internal/internal_worker_interfaces_test.go
@@ -178,11 +178,12 @@ func (s *InterfacesTestSuite) TestInterface() {
 	domain := "testDomain"
 	// Workflow execution parameters.
 	workflowExecutionParameters := workerExecutionParameters{
-		TaskList:                         "testTaskList",
-		MaxConcurrentActivityTaskPollers: 4,
-		MaxConcurrentDecisionTaskPollers: 4,
-		Logger:                           zaptest.NewLogger(s.T()),
-		Tracer:                           opentracing.NoopTracer{},
+		TaskList: "testTaskList",
+		WorkerOptions: WorkerOptions{
+			MaxConcurrentActivityTaskPollers: 4,
+			MaxConcurrentDecisionTaskPollers: 4,
+			Logger:                           zaptest.NewLogger(s.T()),
+			Tracer:                           opentracing.NoopTracer{}},
 	}
 
 	domainStatus := m.DomainStatusRegistered
@@ -209,11 +210,12 @@ func (s *InterfacesTestSuite) TestInterface() {
 
 	// Create activity execution parameters.
 	activityExecutionParameters := workerExecutionParameters{
-		TaskList:                         "testTaskList",
-		MaxConcurrentActivityTaskPollers: 10,
-		MaxConcurrentDecisionTaskPollers: 10,
-		Logger:                           zaptest.NewLogger(s.T()),
-		Tracer:                           opentracing.NoopTracer{},
+		TaskList: "testTaskList",
+		WorkerOptions: WorkerOptions{
+			MaxConcurrentActivityTaskPollers: 10,
+			MaxConcurrentDecisionTaskPollers: 10,
+			Logger:                           zaptest.NewLogger(s.T()),
+			Tracer:                           opentracing.NoopTracer{}},
 	}
 
 	// Register activity instances and launch the worker.

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -996,23 +996,23 @@ func TestWorkerOptionDefaults(t *testing.T) {
 	require.Nil(t, decisionWorker.executionParameters.ContextPropagators)
 
 	expected := workerExecutionParameters{
-		TaskList:                             taskList,
-		MaxConcurrentActivityPollers:         defaultConcurrentPollRoutineSize,
-		MaxConcurrentDecisionPollers:         defaultConcurrentPollRoutineSize,
-		ConcurrentLocalActivityExecutionSize: defaultMaxConcurrentLocalActivityExecutionSize,
-		ConcurrentActivityExecutionSize:      defaultMaxConcurrentActivityExecutionSize,
-		ConcurrentDecisionTaskExecutionSize:  defaultMaxConcurrentTaskExecutionSize,
-		WorkerActivitiesPerSecond:            defaultTaskListActivitiesPerSecond,
-		WorkerDecisionTasksPerSecond:         defaultWorkerTaskExecutionRate,
-		TaskListActivitiesPerSecond:          defaultTaskListActivitiesPerSecond,
-		WorkerLocalActivitiesPerSecond:       defaultWorkerLocalActivitiesPerSecond,
-		StickyScheduleToStartTimeout:         stickyDecisionScheduleToStartTimeoutSeconds * time.Second,
-		DataConverter:                        getDefaultDataConverter(),
-		Tracer:                               opentracing.NoopTracer{},
-		Logger:                               decisionWorker.executionParameters.Logger,
-		MetricsScope:                         decisionWorker.executionParameters.MetricsScope,
-		Identity:                             decisionWorker.executionParameters.Identity,
-		UserContext:                          decisionWorker.executionParameters.UserContext,
+		TaskList:                                taskList,
+		MaxConcurrentActivityTaskPollers:        defaultConcurrentPollRoutineSize,
+		MaxConcurrentDecisionTaskPollers:        defaultConcurrentPollRoutineSize,
+		MaxConcurrentLocalActivityExecutionSize: defaultMaxConcurrentLocalActivityExecutionSize,
+		MaxConcurrentActivityExecutionSize:      defaultMaxConcurrentActivityExecutionSize,
+		MaxConcurrentDecisionTaskExecutionSize:  defaultMaxConcurrentTaskExecutionSize,
+		WorkerActivitiesPerSecond:               defaultTaskListActivitiesPerSecond,
+		WorkerDecisionTasksPerSecond:            defaultWorkerTaskExecutionRate,
+		TaskListActivitiesPerSecond:             defaultTaskListActivitiesPerSecond,
+		WorkerLocalActivitiesPerSecond:          defaultWorkerLocalActivitiesPerSecond,
+		StickyScheduleToStartTimeout:            stickyDecisionScheduleToStartTimeoutSeconds * time.Second,
+		DataConverter:                           getDefaultDataConverter(),
+		Tracer:                                  opentracing.NoopTracer{},
+		Logger:                                  decisionWorker.executionParameters.Logger,
+		MetricsScope:                            decisionWorker.executionParameters.MetricsScope,
+		Identity:                                decisionWorker.executionParameters.Identity,
+		UserContext:                             decisionWorker.executionParameters.UserContext,
 	}
 
 	assertWorkerExecutionParamsEqual(t, expected, decisionWorker.executionParameters)
@@ -1054,22 +1054,22 @@ func TestWorkerOptionNonDefaults(t *testing.T) {
 	require.True(t, len(decisionWorker.executionParameters.ContextPropagators) > 0)
 
 	expected := workerExecutionParameters{
-		TaskList:                             taskList,
-		MaxConcurrentActivityPollers:         options.MaxConcurrentActivityTaskPollers,
-		MaxConcurrentDecisionPollers:         options.MaxConcurrentDecisionTaskPollers,
-		ConcurrentLocalActivityExecutionSize: options.MaxConcurrentLocalActivityExecutionSize,
-		ConcurrentActivityExecutionSize:      options.MaxConcurrentActivityExecutionSize,
-		ConcurrentDecisionTaskExecutionSize:  options.MaxConcurrentDecisionTaskExecutionSize,
-		WorkerActivitiesPerSecond:            options.WorkerActivitiesPerSecond,
-		WorkerDecisionTasksPerSecond:         options.WorkerDecisionTasksPerSecond,
-		TaskListActivitiesPerSecond:          options.TaskListActivitiesPerSecond,
-		WorkerLocalActivitiesPerSecond:       options.WorkerLocalActivitiesPerSecond,
-		StickyScheduleToStartTimeout:         options.StickyScheduleToStartTimeout,
-		DataConverter:                        options.DataConverter,
-		Tracer:                               options.Tracer,
-		Logger:                               options.Logger,
-		MetricsScope:                         options.MetricsScope,
-		Identity:                             options.Identity,
+		TaskList:                                taskList,
+		MaxConcurrentActivityTaskPollers:        options.MaxConcurrentActivityTaskPollers,
+		MaxConcurrentDecisionTaskPollers:        options.MaxConcurrentDecisionTaskPollers,
+		MaxConcurrentLocalActivityExecutionSize: options.MaxConcurrentLocalActivityExecutionSize,
+		MaxConcurrentActivityExecutionSize:      options.MaxConcurrentActivityExecutionSize,
+		MaxConcurrentDecisionTaskExecutionSize:  options.MaxConcurrentDecisionTaskExecutionSize,
+		WorkerActivitiesPerSecond:               options.WorkerActivitiesPerSecond,
+		WorkerDecisionTasksPerSecond:            options.WorkerDecisionTasksPerSecond,
+		TaskListActivitiesPerSecond:             options.TaskListActivitiesPerSecond,
+		WorkerLocalActivitiesPerSecond:          options.WorkerLocalActivitiesPerSecond,
+		StickyScheduleToStartTimeout:            options.StickyScheduleToStartTimeout,
+		DataConverter:                           options.DataConverter,
+		Tracer:                                  options.Tracer,
+		Logger:                                  options.Logger,
+		MetricsScope:                            options.MetricsScope,
+		Identity:                                options.Identity,
 	}
 
 	assertWorkerExecutionParamsEqual(t, expected, decisionWorker.executionParameters)
@@ -1084,15 +1084,15 @@ func assertWorkerExecutionParamsEqual(t *testing.T, paramsA workerExecutionParam
 	require.Equal(t, paramsA.Identity, paramsB.Identity)
 	require.Equal(t, paramsA.DataConverter, paramsB.DataConverter)
 	require.Equal(t, paramsA.Tracer, paramsB.Tracer)
-	require.Equal(t, paramsA.ConcurrentLocalActivityExecutionSize, paramsB.ConcurrentLocalActivityExecutionSize)
-	require.Equal(t, paramsA.ConcurrentActivityExecutionSize, paramsB.ConcurrentActivityExecutionSize)
-	require.Equal(t, paramsA.ConcurrentDecisionTaskExecutionSize, paramsB.ConcurrentDecisionTaskExecutionSize)
+	require.Equal(t, paramsA.MaxConcurrentLocalActivityExecutionSize, paramsB.MaxConcurrentLocalActivityExecutionSize)
+	require.Equal(t, paramsA.MaxConcurrentActivityExecutionSize, paramsB.MaxConcurrentActivityExecutionSize)
+	require.Equal(t, paramsA.MaxConcurrentDecisionTaskExecutionSize, paramsB.MaxConcurrentDecisionTaskExecutionSize)
 	require.Equal(t, paramsA.WorkerActivitiesPerSecond, paramsB.WorkerActivitiesPerSecond)
 	require.Equal(t, paramsA.WorkerDecisionTasksPerSecond, paramsB.WorkerDecisionTasksPerSecond)
 	require.Equal(t, paramsA.TaskListActivitiesPerSecond, paramsB.TaskListActivitiesPerSecond)
 	require.Equal(t, paramsA.StickyScheduleToStartTimeout, paramsB.StickyScheduleToStartTimeout)
-	require.Equal(t, paramsA.MaxConcurrentDecisionPollers, paramsB.MaxConcurrentDecisionPollers)
-	require.Equal(t, paramsA.MaxConcurrentActivityPollers, paramsB.MaxConcurrentActivityPollers)
+	require.Equal(t, paramsA.MaxConcurrentDecisionTaskPollers, paramsB.MaxConcurrentDecisionTaskPollers)
+	require.Equal(t, paramsA.MaxConcurrentActivityTaskPollers, paramsB.MaxConcurrentActivityTaskPollers)
 	require.Equal(t, paramsA.NonDeterministicWorkflowPolicy, paramsB.NonDeterministicWorkflowPolicy)
 	require.Equal(t, paramsA.EnableLoggingInReplay, paramsB.EnableLoggingInReplay)
 	require.Equal(t, paramsA.DisableStickyExecution, paramsB.DisableStickyExecution)

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -151,17 +151,19 @@ func (s *internalWorkerTestSuite) testDecisionTaskHandlerHelper(params workerExe
 
 func (s *internalWorkerTestSuite) TestDecisionTaskHandler() {
 	params := workerExecutionParameters{
-		Identity: "identity",
-		Logger:   getTestLogger(s.T()),
+		WorkerOptions: WorkerOptions{
+			Identity: "identity",
+			Logger:   getTestLogger(s.T())},
 	}
 	s.testDecisionTaskHandlerHelper(params)
 }
 
 func (s *internalWorkerTestSuite) TestDecisionTaskHandler_WithDataConverter() {
 	params := workerExecutionParameters{
-		Identity:      "identity",
-		Logger:        getTestLogger(s.T()),
-		DataConverter: newTestDataConverter(),
+		WorkerOptions: WorkerOptions{
+			Identity:      "identity",
+			Logger:        getTestLogger(s.T()),
+			DataConverter: newTestDataConverter()},
 	}
 	s.testDecisionTaskHandlerHelper(params)
 }
@@ -996,23 +998,24 @@ func TestWorkerOptionDefaults(t *testing.T) {
 	require.Nil(t, decisionWorker.executionParameters.ContextPropagators)
 
 	expected := workerExecutionParameters{
-		TaskList:                                taskList,
-		MaxConcurrentActivityTaskPollers:        defaultConcurrentPollRoutineSize,
-		MaxConcurrentDecisionTaskPollers:        defaultConcurrentPollRoutineSize,
-		MaxConcurrentLocalActivityExecutionSize: defaultMaxConcurrentLocalActivityExecutionSize,
-		MaxConcurrentActivityExecutionSize:      defaultMaxConcurrentActivityExecutionSize,
-		MaxConcurrentDecisionTaskExecutionSize:  defaultMaxConcurrentTaskExecutionSize,
-		WorkerActivitiesPerSecond:               defaultTaskListActivitiesPerSecond,
-		WorkerDecisionTasksPerSecond:            defaultWorkerTaskExecutionRate,
-		TaskListActivitiesPerSecond:             defaultTaskListActivitiesPerSecond,
-		WorkerLocalActivitiesPerSecond:          defaultWorkerLocalActivitiesPerSecond,
-		StickyScheduleToStartTimeout:            stickyDecisionScheduleToStartTimeoutSeconds * time.Second,
-		DataConverter:                           getDefaultDataConverter(),
-		Tracer:                                  opentracing.NoopTracer{},
-		Logger:                                  decisionWorker.executionParameters.Logger,
-		MetricsScope:                            decisionWorker.executionParameters.MetricsScope,
-		Identity:                                decisionWorker.executionParameters.Identity,
-		UserContext:                             decisionWorker.executionParameters.UserContext,
+		TaskList: taskList,
+		WorkerOptions: WorkerOptions{
+			MaxConcurrentActivityTaskPollers:        defaultConcurrentPollRoutineSize,
+			MaxConcurrentDecisionTaskPollers:        defaultConcurrentPollRoutineSize,
+			MaxConcurrentLocalActivityExecutionSize: defaultMaxConcurrentLocalActivityExecutionSize,
+			MaxConcurrentActivityExecutionSize:      defaultMaxConcurrentActivityExecutionSize,
+			MaxConcurrentDecisionTaskExecutionSize:  defaultMaxConcurrentTaskExecutionSize,
+			WorkerActivitiesPerSecond:               defaultTaskListActivitiesPerSecond,
+			WorkerDecisionTasksPerSecond:            defaultWorkerTaskExecutionRate,
+			TaskListActivitiesPerSecond:             defaultTaskListActivitiesPerSecond,
+			WorkerLocalActivitiesPerSecond:          defaultWorkerLocalActivitiesPerSecond,
+			StickyScheduleToStartTimeout:            stickyDecisionScheduleToStartTimeoutSeconds * time.Second,
+			DataConverter:                           getDefaultDataConverter(),
+			Tracer:                                  opentracing.NoopTracer{},
+			Logger:                                  decisionWorker.executionParameters.Logger,
+			MetricsScope:                            decisionWorker.executionParameters.MetricsScope,
+			Identity:                                decisionWorker.executionParameters.Identity},
+		UserContext: decisionWorker.executionParameters.UserContext,
 	}
 
 	assertWorkerExecutionParamsEqual(t, expected, decisionWorker.executionParameters)
@@ -1054,22 +1057,23 @@ func TestWorkerOptionNonDefaults(t *testing.T) {
 	require.True(t, len(decisionWorker.executionParameters.ContextPropagators) > 0)
 
 	expected := workerExecutionParameters{
-		TaskList:                                taskList,
-		MaxConcurrentActivityTaskPollers:        options.MaxConcurrentActivityTaskPollers,
-		MaxConcurrentDecisionTaskPollers:        options.MaxConcurrentDecisionTaskPollers,
-		MaxConcurrentLocalActivityExecutionSize: options.MaxConcurrentLocalActivityExecutionSize,
-		MaxConcurrentActivityExecutionSize:      options.MaxConcurrentActivityExecutionSize,
-		MaxConcurrentDecisionTaskExecutionSize:  options.MaxConcurrentDecisionTaskExecutionSize,
-		WorkerActivitiesPerSecond:               options.WorkerActivitiesPerSecond,
-		WorkerDecisionTasksPerSecond:            options.WorkerDecisionTasksPerSecond,
-		TaskListActivitiesPerSecond:             options.TaskListActivitiesPerSecond,
-		WorkerLocalActivitiesPerSecond:          options.WorkerLocalActivitiesPerSecond,
-		StickyScheduleToStartTimeout:            options.StickyScheduleToStartTimeout,
-		DataConverter:                           options.DataConverter,
-		Tracer:                                  options.Tracer,
-		Logger:                                  options.Logger,
-		MetricsScope:                            options.MetricsScope,
-		Identity:                                options.Identity,
+		TaskList: taskList,
+		WorkerOptions: WorkerOptions{
+			MaxConcurrentActivityTaskPollers:        options.MaxConcurrentActivityTaskPollers,
+			MaxConcurrentDecisionTaskPollers:        options.MaxConcurrentDecisionTaskPollers,
+			MaxConcurrentLocalActivityExecutionSize: options.MaxConcurrentLocalActivityExecutionSize,
+			MaxConcurrentActivityExecutionSize:      options.MaxConcurrentActivityExecutionSize,
+			MaxConcurrentDecisionTaskExecutionSize:  options.MaxConcurrentDecisionTaskExecutionSize,
+			WorkerActivitiesPerSecond:               options.WorkerActivitiesPerSecond,
+			WorkerDecisionTasksPerSecond:            options.WorkerDecisionTasksPerSecond,
+			TaskListActivitiesPerSecond:             options.TaskListActivitiesPerSecond,
+			WorkerLocalActivitiesPerSecond:          options.WorkerLocalActivitiesPerSecond,
+			StickyScheduleToStartTimeout:            options.StickyScheduleToStartTimeout,
+			DataConverter:                           options.DataConverter,
+			Tracer:                                  options.Tracer,
+			Logger:                                  options.Logger,
+			MetricsScope:                            options.MetricsScope,
+			Identity:                                options.Identity},
 	}
 
 	assertWorkerExecutionParamsEqual(t, expected, decisionWorker.executionParameters)

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -91,11 +91,12 @@ func (s *WorkersTestSuite) TestWorkflowWorker() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	executionParameters := workerExecutionParameters{
-		TaskList:                         "testTaskList",
-		MaxConcurrentDecisionTaskPollers: 5,
-		Logger:                           logger,
-		UserContext:                      ctx,
-		UserContextCancel:                cancel,
+		TaskList: "testTaskList",
+		WorkerOptions: WorkerOptions{
+			MaxConcurrentDecisionTaskPollers: 5,
+			Logger:                           logger},
+		UserContext:       ctx,
+		UserContextCancel: cancel,
 	}
 	overrides := &workerOverrides{workflowTaskHandler: newSampleWorkflowTaskHandler()}
 	workflowWorker := newWorkflowWorkerInternal(
@@ -122,9 +123,10 @@ func (s *WorkersTestSuite) testActivityWorker(useLocallyDispatched bool) {
 	s.service.EXPECT().RespondActivityTaskCompleted(gomock.Any(), gomock.Any(), callOptions()...).Return(nil).AnyTimes()
 
 	executionParameters := workerExecutionParameters{
-		TaskList:                         "testTaskList",
-		MaxConcurrentActivityTaskPollers: 5,
-		Logger:                           zaptest.NewLogger(s.T()),
+		TaskList: "testTaskList",
+		WorkerOptions: WorkerOptions{
+			MaxConcurrentActivityTaskPollers: 5,
+			Logger:                           zaptest.NewLogger(s.T())},
 	}
 	overrides := &workerOverrides{activityTaskHandler: newSampleActivityTaskHandler(), useLocallyDispatchedActivityPoller: useLocallyDispatched}
 	a := &greeterActivity{}
@@ -165,14 +167,15 @@ func (s *WorkersTestSuite) TestActivityWorkerStop() {
 	stopC := make(chan struct{})
 	ctx, cancel := context.WithCancel(context.Background())
 	executionParameters := workerExecutionParameters{
-		TaskList:                           "testTaskList",
-		MaxConcurrentActivityTaskPollers:   5,
-		MaxConcurrentActivityExecutionSize: 2,
-		Logger:                             zaptest.NewLogger(s.T()),
-		UserContext:                        ctx,
-		UserContextCancel:                  cancel,
-		WorkerStopTimeout:                  time.Second * 2,
-		WorkerStopChannel:                  stopC,
+		TaskList: "testTaskList",
+		WorkerOptions: WorkerOptions{
+			MaxConcurrentActivityTaskPollers:   5,
+			MaxConcurrentActivityExecutionSize: 2,
+			Logger:                             zaptest.NewLogger(s.T())},
+		UserContext:       ctx,
+		UserContextCancel: cancel,
+		WorkerStopTimeout: time.Second * 2,
+		WorkerStopChannel: stopC,
 	}
 	activityTaskHandler := newNoResponseActivityTaskHandler()
 	overrides := &workerOverrides{activityTaskHandler: activityTaskHandler}
@@ -202,9 +205,10 @@ func (s *WorkersTestSuite) TestPollForDecisionTask_InternalServiceError() {
 	s.service.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), callOptions()...).Return(&m.PollForDecisionTaskResponse{}, &m.InternalServiceError{}).AnyTimes()
 
 	executionParameters := workerExecutionParameters{
-		TaskList:                         "testDecisionTaskList",
-		MaxConcurrentDecisionTaskPollers: 5,
-		Logger:                           zaptest.NewLogger(s.T()),
+		TaskList: "testDecisionTaskList",
+		WorkerOptions: WorkerOptions{
+			MaxConcurrentDecisionTaskPollers: 5,
+			Logger:                           zaptest.NewLogger(s.T())},
 	}
 	overrides := &workerOverrides{workflowTaskHandler: newSampleWorkflowTaskHandler()}
 	workflowWorker := newWorkflowWorkerInternal(

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -91,11 +91,11 @@ func (s *WorkersTestSuite) TestWorkflowWorker() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	executionParameters := workerExecutionParameters{
-		TaskList:                     "testTaskList",
-		MaxConcurrentDecisionPollers: 5,
-		Logger:                       logger,
-		UserContext:                  ctx,
-		UserContextCancel:            cancel,
+		TaskList:                         "testTaskList",
+		MaxConcurrentDecisionTaskPollers: 5,
+		Logger:                           logger,
+		UserContext:                      ctx,
+		UserContextCancel:                cancel,
 	}
 	overrides := &workerOverrides{workflowTaskHandler: newSampleWorkflowTaskHandler()}
 	workflowWorker := newWorkflowWorkerInternal(
@@ -122,9 +122,9 @@ func (s *WorkersTestSuite) testActivityWorker(useLocallyDispatched bool) {
 	s.service.EXPECT().RespondActivityTaskCompleted(gomock.Any(), gomock.Any(), callOptions()...).Return(nil).AnyTimes()
 
 	executionParameters := workerExecutionParameters{
-		TaskList:                     "testTaskList",
-		MaxConcurrentActivityPollers: 5,
-		Logger:                       zaptest.NewLogger(s.T()),
+		TaskList:                         "testTaskList",
+		MaxConcurrentActivityTaskPollers: 5,
+		Logger:                           zaptest.NewLogger(s.T()),
 	}
 	overrides := &workerOverrides{activityTaskHandler: newSampleActivityTaskHandler(), useLocallyDispatchedActivityPoller: useLocallyDispatched}
 	a := &greeterActivity{}
@@ -165,14 +165,14 @@ func (s *WorkersTestSuite) TestActivityWorkerStop() {
 	stopC := make(chan struct{})
 	ctx, cancel := context.WithCancel(context.Background())
 	executionParameters := workerExecutionParameters{
-		TaskList:                        "testTaskList",
-		MaxConcurrentActivityPollers:    5,
-		ConcurrentActivityExecutionSize: 2,
-		Logger:                          zaptest.NewLogger(s.T()),
-		UserContext:                     ctx,
-		UserContextCancel:               cancel,
-		WorkerStopTimeout:               time.Second * 2,
-		WorkerStopChannel:               stopC,
+		TaskList:                           "testTaskList",
+		MaxConcurrentActivityTaskPollers:   5,
+		MaxConcurrentActivityExecutionSize: 2,
+		Logger:                             zaptest.NewLogger(s.T()),
+		UserContext:                        ctx,
+		UserContextCancel:                  cancel,
+		WorkerStopTimeout:                  time.Second * 2,
+		WorkerStopChannel:                  stopC,
 	}
 	activityTaskHandler := newNoResponseActivityTaskHandler()
 	overrides := &workerOverrides{activityTaskHandler: activityTaskHandler}
@@ -202,9 +202,9 @@ func (s *WorkersTestSuite) TestPollForDecisionTask_InternalServiceError() {
 	s.service.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), callOptions()...).Return(&m.PollForDecisionTaskResponse{}, &m.InternalServiceError{}).AnyTimes()
 
 	executionParameters := workerExecutionParameters{
-		TaskList:                     "testDecisionTaskList",
-		MaxConcurrentDecisionPollers: 5,
-		Logger:                       zaptest.NewLogger(s.T()),
+		TaskList:                         "testDecisionTaskList",
+		MaxConcurrentDecisionTaskPollers: 5,
+		Logger:                           zaptest.NewLogger(s.T()),
 	}
 	overrides := &workerOverrides{workflowTaskHandler: newSampleWorkflowTaskHandler()}
 	workflowWorker := newWorkflowWorkerInternal(

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1612,16 +1612,12 @@ func (m *mockWrapper) executeMockWithActualArgs(ctx interface{}, inputArgs []int
 
 func (env *testWorkflowEnvironmentImpl) newTestActivityTaskHandler(taskList string, dataConverter DataConverter) ActivityTaskHandler {
 	wOptions := augmentWorkerOptions(env.workerOptions)
+	wOptions.DataConverter = dataConverter
 	params := workerExecutionParameters{
-		TaskList:           taskList,
-		Identity:           wOptions.Identity,
-		MetricsScope:       wOptions.MetricsScope,
-		Logger:             wOptions.Logger,
-		UserContext:        wOptions.BackgroundActivityContext,
-		DataConverter:      dataConverter,
-		WorkerStopChannel:  env.workerStopChannel,
-		ContextPropagators: wOptions.ContextPropagators,
-		Tracer:             wOptions.Tracer,
+		WorkerOptions:     wOptions,
+		TaskList:          taskList,
+		UserContext:       wOptions.BackgroundActivityContext,
+		WorkerStopChannel: env.workerStopChannel,
 	}
 	ensureRequiredParams(&params)
 	if params.UserContext == nil {

--- a/internal/workflow_replayer.go
+++ b/internal/workflow_replayer.go
@@ -268,14 +268,16 @@ func (r *WorkflowReplayer) replayWorkflowHistory(
 		logger = zap.NewNop()
 	}
 	workerParams := workerExecutionParameters{
-		TaskList:                          replayTaskListName,
-		Identity:                          replayWorkerIdentity,
-		DataConverter:                     r.options.DataConverter,
-		ContextPropagators:                r.options.ContextPropagators,
-		WorkflowInterceptorChainFactories: r.options.WorkflowInterceptorChainFactories,
-		Tracer:                            r.options.Tracer,
-		Logger:                            logger,
-		DisableStickyExecution:            true,
+		WorkerOptions: WorkerOptions{
+			Identity:                          replayWorkerIdentity,
+			DataConverter:                     r.options.DataConverter,
+			ContextPropagators:                r.options.ContextPropagators,
+			WorkflowInterceptorChainFactories: r.options.WorkflowInterceptorChainFactories,
+			Tracer:                            r.options.Tracer,
+			Logger:                            logger,
+			DisableStickyExecution:            true,
+		},
+		TaskList: replayTaskListName,
 	}
 
 	metricScope := tally.NoopScope

--- a/internal/workflow_replayer.go
+++ b/internal/workflow_replayer.go
@@ -268,14 +268,14 @@ func (r *WorkflowReplayer) replayWorkflowHistory(
 		logger = zap.NewNop()
 	}
 	workerParams := workerExecutionParameters{
-		TaskList:               replayTaskListName,
-		Identity:               replayWorkerIdentity,
-		DataConverter:          r.options.DataConverter,
-		ContextPropagators:     r.options.ContextPropagators,
-		WorkflowInterceptors:   r.options.WorkflowInterceptorChainFactories,
-		Tracer:                 r.options.Tracer,
-		Logger:                 logger,
-		DisableStickyExecution: true,
+		TaskList:                          replayTaskListName,
+		Identity:                          replayWorkerIdentity,
+		DataConverter:                     r.options.DataConverter,
+		ContextPropagators:                r.options.ContextPropagators,
+		WorkflowInterceptorChainFactories: r.options.WorkflowInterceptorChainFactories,
+		Tracer:                            r.options.Tracer,
+		Logger:                            logger,
+		DisableStickyExecution:            true,
 	}
 
 	metricScope := tally.NoopScope

--- a/internal/workflow_shadower_worker.go
+++ b/internal/workflow_shadower_worker.go
@@ -64,7 +64,7 @@ func newShadowWorker(
 	replayer := NewWorkflowReplayerWithOptions(ReplayOptions{
 		DataConverter:                     params.DataConverter,
 		ContextPropagators:                params.ContextPropagators,
-		WorkflowInterceptorChainFactories: params.WorkflowInterceptors,
+		WorkflowInterceptorChainFactories: params.WorkflowInterceptorChainFactories,
 		Tracer:                            params.Tracer,
 		FeatureFlags:                      params.FeatureFlags,
 	})
@@ -87,7 +87,7 @@ func newShadowWorker(
 	// this is required for data converter, for the other three, it should be ok to still use
 	// the value provided by user.
 	params.DataConverter = getDefaultDataConverter()
-	params.WorkflowInterceptors = []WorkflowInterceptorFactory{}
+	params.WorkflowInterceptorChainFactories = []WorkflowInterceptorFactory{}
 	params.ContextPropagators = []ContextPropagator{}
 	params.Tracer = opentracing.NoopTracer{}
 

--- a/internal/workflow_shadower_worker_test.go
+++ b/internal/workflow_shadower_worker_test.go
@@ -68,7 +68,8 @@ func (s *shadowWorkerSuite) TestNewShadowWorker() {
 		ShadowOptions{},
 		workerExecutionParameters{
 			TaskList: testTaskList,
-			Logger:   zaptest.NewLogger(s.T()),
+			WorkerOptions: WorkerOptions{
+				Logger: zaptest.NewLogger(s.T())},
 		},
 		registry,
 	)
@@ -99,7 +100,8 @@ func (s *shadowWorkerSuite) TestStartShadowWorker_Failed_InvalidShadowOption() {
 		},
 		workerExecutionParameters{
 			TaskList: testTaskList,
-			Logger:   zaptest.NewLogger(s.T()),
+			WorkerOptions: WorkerOptions{
+				Logger: zaptest.NewLogger(s.T())},
 		},
 		newRegistry(),
 	)
@@ -118,7 +120,8 @@ func (s *shadowWorkerSuite) TestStartShadowWorker_Failed_DomainNotExist() {
 		ShadowOptions{},
 		workerExecutionParameters{
 			TaskList: testTaskList,
-			Logger:   zaptest.NewLogger(s.T()),
+			WorkerOptions: WorkerOptions{
+				Logger: zaptest.NewLogger(s.T())},
 		},
 		newRegistry(),
 	)
@@ -136,7 +139,8 @@ func (s *shadowWorkerSuite) TestStartShadowWorker_Failed_TaskListNotSpecified() 
 		testDomain,
 		ShadowOptions{},
 		workerExecutionParameters{
-			Logger: zaptest.NewLogger(s.T()),
+			WorkerOptions: WorkerOptions{
+				Logger: zaptest.NewLogger(s.T())},
 		},
 		newRegistry(),
 	)
@@ -159,7 +163,8 @@ func (s *shadowWorkerSuite) TestStartShadowWorker_Failed_StartWorkflowError() {
 		ShadowOptions{},
 		workerExecutionParameters{
 			TaskList: testTaskList,
-			Logger:   zaptest.NewLogger(s.T()),
+			WorkerOptions: WorkerOptions{
+				Logger: zaptest.NewLogger(s.T())},
 		},
 		newRegistry(),
 	)
@@ -202,7 +207,8 @@ func (s *shadowWorkerSuite) TestStartShadowWorker_Succeed() {
 		},
 		workerExecutionParameters{
 			TaskList: testTaskList,
-			Logger:   zaptest.NewLogger(s.T()),
+			WorkerOptions: WorkerOptions{
+				Logger: zaptest.NewLogger(s.T())},
 		},
 		newRegistry(),
 	)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

use embedding to simplify assignment

<!-- Tell your future self why have you made these changes -->
**Why?**

There are duplicate fields in `workerExecutionParameters` and `WorkerOptions` that unnecessarily complicates the logic. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
