### PR TITLE
Sharing one of my favorite "scopes" in intellij, and making it easier to add more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
+
 *.out
 *.test
 *.xml
 *.swp
-.idea/
 .vscode/
 *.code-workspace
 *.iml
@@ -17,3 +17,9 @@ test.log
 .bin
 .DS_Store
 .gobincache
+
+# most idea stuff is local-machine specific...
+.idea/*
+# ...but this scopes folder is intended to be shared
+!.idea/scopes
+!.idea/scopes/*

--- a/.idea/scopes/Go___Not_Tests___Not_RPC.xml
+++ b/.idea/scopes/Go___Not_Tests___Not_RPC.xml
@@ -1,0 +1,3 @@
+<component name="DependencyValidationManager">
+  <scope name="Go + Not Tests + Not RPC" pattern="file[cadence]:*.go&amp;&amp;!file[cadence]:*_test.go&amp;&amp;!file[cadence]:.gen//*&amp;&amp;!file[cadence]:idls//*" />
+</component>


### PR DESCRIPTION
Goland is nice, and the type-based navigation is wildly superior to gopls-driven
stuff in my experience, so I tend to lean hard on it when I'm able.

By default though, Goland searches *everything*.  All the time.
That's totally reasonable as a default, but we can do better:

- Tests are not usually all that interesting when trying to understand and navigate code.
  (perhaps they should be, but that's more a platonic ideal than a reality)
- Generated RPC code is almost never useful to dive into.  The exposed API surface is sufficient,
  if it compiles, it's correct.
- Non-Go files are just less interesting in a Go project.

So this scope excludes ^ all that.
To add more shared ones, just check the "share through vcs" box and commit it.

To use it, just select the scope from the dropdown when you search.  E.g. "find in files" ->
change from "in project" to "scope" -> change the dropdown.  This custom scope will now appear,
and it'll remember what you last used, so it's a nice default.

This also works in "call hierarchy", "go to implementations" (open it in a panel to configure it,
with the gear on the side.  it's awful UI but it works), etc quite a lot of places.

This same kinda-obtuse search-scope query language can be used to mark things as generated or test
related, which will also help other parts of the IDE mark things as more or less relevant for you.
It's worth exploring a bit, scopes and filters can be used to do a lot: https://www.jetbrains.com/help/idea/scope-language-syntax-reference.html
