### PR TITLE
Fix goland scope to be specific to the cadence-client repo instead of the cadence repo.

### DIFF
--- a/.idea/scopes/Go___Not_Tests___Not_RPC.xml
+++ b/.idea/scopes/Go___Not_Tests___Not_RPC.xml
@@ -1,3 +1,3 @@
 <component name="DependencyValidationManager">
-  <scope name="Go + Not Tests + Not RPC" pattern="file[cadence]:*.go&amp;&amp;!file[cadence]:*_test.go&amp;&amp;!file[cadence]:.gen//*&amp;&amp;!file[cadence]:idls//*" />
+  <scope name="Go + Not Tests + Not RPC" pattern="file[cadence-client]:*.go&amp;&amp;!file[cadence-client]:*_test.go&amp;&amp;!file[cadence-client]:.gen//*&amp;&amp;!file[cadence-client]:idls//*" />
 </component>


### PR DESCRIPTION
Fix goland scope to be specific to the cadence-client repo instead of the cadence repo