### PR TITLE
Fix bug with workflow shadower: ALL is documented as an allowed Status; test and fix.

### DIFF
--- a/internal/query_builder.go
+++ b/internal/query_builder.go
@@ -155,7 +155,7 @@ func ToWorkflowStatus(statusString string) (WorkflowStatus, error) {
 	switch status {
 	case WorkflowStatusOpen, WorkflowStatusClosed, WorkflowStatusCompleted,
 		WorkflowStatusFailed, WorkflowStatusCanceled, WorkflowStatusTerminated,
-		WorkflowStatusContinuedAsNew, WorkflowStatusTimedOut:
+		WorkflowStatusContinuedAsNew, WorkflowStatusTimedOut, WorkflowStatusALL:
 		return status, nil
 	default:
 		return "", fmt.Errorf("unknown workflow status: %v", statusString)

--- a/internal/query_builder_test.go
+++ b/internal/query_builder_test.go
@@ -199,6 +199,42 @@ func (s *queryBuilderSuite) TestToWorkflowStatus() {
 			expectErr:      false,
 			expectedStatus: WorkflowStatusTerminated,
 		},
+		{
+			msg:            "all",
+			statusString:   "ALL",
+			expectErr:      false,
+			expectedStatus: WorkflowStatusALL,
+		},
+		{
+			msg:            "closed",
+			statusString:   "CLOSED",
+			expectErr:      false,
+			expectedStatus: WorkflowStatusClosed,
+		},
+		{
+			msg:            "failed",
+			statusString:   "FAILED",
+			expectErr:      false,
+			expectedStatus: WorkflowStatusFailed,
+		},
+		{
+			msg:            "completed",
+			statusString:   "COMPLETED",
+			expectErr:      false,
+			expectedStatus: WorkflowStatusCompleted,
+		},
+		{
+			msg:            "canceled",
+			statusString:   "CANCELED",
+			expectErr:      false,
+			expectedStatus: WorkflowStatusCanceled,
+		},
+		{
+			msg:            "continued as new",
+			statusString:   "CONTINUED_AS_NEW",
+			expectErr:      false,
+			expectedStatus: WorkflowStatusContinuedAsNew,
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
Found this while trying to use the workflow shadower. ALL is documented as an allowed status and looks like it should work with the rest of the code, its just not being allowed through the initial filter.