### PR TITLE
Cdnc 2847 Add version metrics to the clients

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -53,7 +53,7 @@ const (
 	WorkflowClientFeatureVersion string = "workflow_client_feature_version"
 	// WorkflowClientLibraryVersion is the string for the workflow client library metric
 	WorkflowClientLibraryVersion string = "workflow_client_library_version"
-	// WorkflowClientVersionMetricName is the string for the domain client metric name
+	// WorkflowClientVersionMetricName is the string for the workflow client metric name
 	WorkflowClientVersionMetricName string = "workflow_client_version_metric"
 )
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -580,7 +580,7 @@ func NewClient(service workflowserviceclient.Interface, domain string, options *
 		WorkflowClientLibraryVersion: LibraryVersion,
 		WorkflowClientFeatureVersion: FeatureVersion,
 	}
-	go EmitVersionMetrics(metricScope, metricTags, WorkflowClientVersionMetricName)
+	EmitVersionMetrics(metricScope, metricTags, WorkflowClientVersionMetricName)
 	return &workflowClient{
 		workflowService:    service,
 		domain:             domain,
@@ -616,7 +616,7 @@ func NewDomainClient(service workflowserviceclient.Interface, options *ClientOpt
 		DomainClientLibraryVersion: LibraryVersion,
 		DomainClientFeatureVersion: FeatureVersion,
 	}
-	go EmitVersionMetrics(metricScope, metricTags, DomainClientVersionMetricName)
+	EmitVersionMetrics(metricScope, metricTags, DomainClientVersionMetricName)
 	return &domainClient{
 		workflowService: service,
 		metricsScope:    metricScope,
@@ -682,11 +682,5 @@ func NewValues(data []byte) Values {
 
 // EmitVersionMetrics emits the version metrics of the client
 func EmitVersionMetrics(scope tally.Scope, tags map[string]string, metricName string) {
-	ticker := time.NewTicker(time.Minute)
-	for {
-		select {
-		case <-ticker.C:
-			scope.Tagged(tags).Gauge(metricName).Update(1)
-		}
-	}
+	scope.Tagged(tags).Gauge(metricName).Update(1)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Added a metric for the workflow client and domain client versions


<!-- Tell your future self why have you made these changes -->
So we can have graphs to see which versions are running


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Was able to deploy to canary staging without issue and query and see the metrics in Grafana

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Just a metric shouldn't be any risk
