### PR TITLE
changing dynamic poller scaling strategy.

### DIFF
--- a/internal/common/autoscaler/recommender.go
+++ b/internal/common/autoscaler/recommender.go
@@ -51,7 +51,11 @@ func (l *linearRecommender) Recommend(currentResource ResourceUnit, currentUsage
 		if l.targetUsages[usageType] == 0 { // avoid division by zero
 			r = math.MaxFloat64
 		} else {
-			r = currentResource.Value() * currentUsages[usageType].Value() / l.targetUsages[usageType].Value()
+			if currentUsages[usageType].Value() == float64(1000) {
+				r = l.upper.Value()
+			} else {
+				r = currentResource.Value() * currentUsages[usageType].Value() / l.targetUsages[usageType].Value()
+			}
 		}
 		// boundary check
 		r = math.Min(l.upper.Value(), math.Max(l.lower.Value(), r))

--- a/internal/common/autoscaler/recommender_test.go
+++ b/internal/common/autoscaler/recommender_test.go
@@ -41,6 +41,14 @@ func Test_linearRecommender_Recommend(t *testing.T) {
 		},
 	}
 
+	highUpperValue := fields{
+		lower: 5,
+		upper: 100,
+		targetUsages: map[UsageType]MilliUsage{
+			PollerUtilizationRate: 500,
+		},
+	}
+
 	tests := []struct {
 		name   string
 		fields fields
@@ -112,6 +120,17 @@ func Test_linearRecommender_Recommend(t *testing.T) {
 				},
 			},
 			want: ResourceUnit(15),
+		},
+		{
+			name:   "over utilized, since we do not how many tasks are in the queue (because poller usage at 100%), scale up to max",
+			fields: highUpperValue,
+			args: args{
+				currentResource: 10,
+				currentUsages: map[UsageType]MilliUsage{
+					PollerUtilizationRate: 1000,
+				},
+			},
+			want: ResourceUnit(100),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/internal_poller_autoscaler_test.go
+++ b/internal/internal_poller_autoscaler_test.go
@@ -21,15 +21,16 @@
 package internal
 
 import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/atomic"
 	s "go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/internal/common/autoscaler"
 	"go.uber.org/zap/zaptest"
-	"math/rand"
-	"sync"
-	"testing"
-	"time"
 )
 
 func Test_pollerAutoscaler(t *testing.T) {
@@ -114,7 +115,7 @@ func Test_pollerAutoscaler(t *testing.T) {
 				autoScalerEpoch:    1,
 				isDryRun:           false,
 			},
-			want: 4,
+			want: 10,
 		},
 		{
 			name: "over utilized, scale up to max",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Updating dynamic poller scaling strategy in the case that poller utilisation is 100%

<!-- Tell your future self why have you made these changes -->
**Why?**
currently how linear scaler works is that if utilisation is at 100% and the target utilisation is 50% then the number of pollers will double

so in case we have one poller and a large backlog of tasks to process our poller scaling will look like this

1 -> 2 -> 4 -> 8 -> 10 (maximum)

However this would mean that the latency to pick up tasks in case of bursty traffic would increase.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit test.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Amount of pollers may increase too suddenly and cause load issues for the worker (worst case)
