### PR TITLE
Fix flaky test

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -421,7 +421,8 @@ func (ts *IntegrationTestSuite) TestChildWFWithParentClosePolicyTerminate() {
 	ts.NoError(err)
 	resp, err := ts.libClient.DescribeWorkflowExecution(context.Background(), childWorkflowID, "")
 	ts.NoError(err)
-	err = ts.getWorkflow(resp.WorkflowExecutionInfo.Execution.GetWorkflowId(), resp.WorkflowExecutionInfo.Execution.GetRunId())
+	// Need to wait for child workflow to finish as well otherwise test becomes flaky
+	err = ts.waitForWorkflowFinish(resp.WorkflowExecutionInfo.Execution.GetWorkflowId(), resp.WorkflowExecutionInfo.Execution.GetRunId())
 	resp, err = ts.libClient.DescribeWorkflowExecution(context.Background(), childWorkflowID, "")
 	ts.NoError(err)
 	ts.True(resp.WorkflowExecutionInfo.GetCloseTime() > 0)
@@ -585,7 +586,7 @@ func (ts *IntegrationTestSuite) registerWorkflowsAndActivities(w worker.Worker) 
 	ts.activities.register(w)
 }
 
-func (ts *IntegrationTestSuite) getWorkflow(wid string, runId string) error {
+func (ts *IntegrationTestSuite) waitForWorkflowFinish(wid string, runId string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 	wfRun := ts.libClient.GetWorkflow(ctx, wid, runId)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -419,11 +419,9 @@ func (ts *IntegrationTestSuite) TestChildWFWithParentClosePolicyTerminate() {
 	var childWorkflowID string
 	err := ts.executeWorkflow("test-childwf-parent-close-policy", ts.workflows.ChildWorkflowSuccessWithParentClosePolicyTerminate, &childWorkflowID)
 	ts.NoError(err)
-	resp, err := ts.libClient.DescribeWorkflowExecution(context.Background(), childWorkflowID, "")
-	ts.NoError(err)
 	// Need to wait for child workflow to finish as well otherwise test becomes flaky
-	ts.waitForWorkflowFinish(resp.WorkflowExecutionInfo.Execution.GetWorkflowId(), resp.WorkflowExecutionInfo.Execution.GetRunId())
-	resp, err = ts.libClient.DescribeWorkflowExecution(context.Background(), childWorkflowID, "")
+	ts.waitForWorkflowFinish(childWorkflowID, "")
+	resp, err := ts.libClient.DescribeWorkflowExecution(context.Background(), childWorkflowID, "")
 	ts.NoError(err)
 	ts.True(resp.WorkflowExecutionInfo.GetCloseTime() > 0)
 
@@ -590,8 +588,7 @@ func (ts *IntegrationTestSuite) waitForWorkflowFinish(wid string, runId string) 
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 	wfRun := ts.libClient.GetWorkflow(ctx, wid, runId)
-	var val interface{}
-	return wfRun.Get(ctx, &val)
+	return wfRun.Get(ctx, nil)
 }
 
 var _ interceptors.WorkflowInterceptorFactory = (*tracingInterceptorFactory)(nil)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -422,7 +422,7 @@ func (ts *IntegrationTestSuite) TestChildWFWithParentClosePolicyTerminate() {
 	resp, err := ts.libClient.DescribeWorkflowExecution(context.Background(), childWorkflowID, "")
 	ts.NoError(err)
 	// Need to wait for child workflow to finish as well otherwise test becomes flaky
-	err = ts.waitForWorkflowFinish(resp.WorkflowExecutionInfo.Execution.GetWorkflowId(), resp.WorkflowExecutionInfo.Execution.GetRunId())
+	ts.waitForWorkflowFinish(resp.WorkflowExecutionInfo.Execution.GetWorkflowId(), resp.WorkflowExecutionInfo.Execution.GetRunId())
 	resp, err = ts.libClient.DescribeWorkflowExecution(context.Background(), childWorkflowID, "")
 	ts.NoError(err)
 	ts.True(resp.WorkflowExecutionInfo.GetCloseTime() > 0)
@@ -591,8 +591,7 @@ func (ts *IntegrationTestSuite) waitForWorkflowFinish(wid string, runId string) 
 	defer cancel()
 	wfRun := ts.libClient.GetWorkflow(ctx, wid, runId)
 	var val interface{}
-	err := wfRun.Get(ctx, &val)
-	return err
+	return wfRun.Get(ctx, &val)
 }
 
 var _ interceptors.WorkflowInterceptorFactory = (*tracingInterceptorFactory)(nil)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -421,7 +421,11 @@ func (ts *IntegrationTestSuite) TestChildWFWithParentClosePolicyTerminate() {
 	ts.NoError(err)
 	resp, err := ts.libClient.DescribeWorkflowExecution(context.Background(), childWorkflowID, "")
 	ts.NoError(err)
+	err = ts.getWorkflow(resp.WorkflowExecutionInfo.Execution.GetWorkflowId(), resp.WorkflowExecutionInfo.Execution.GetRunId())
+	resp, err = ts.libClient.DescribeWorkflowExecution(context.Background(), childWorkflowID, "")
+	ts.NoError(err)
 	ts.True(resp.WorkflowExecutionInfo.GetCloseTime() > 0)
+
 }
 
 func (ts *IntegrationTestSuite) TestChildWFWithParentClosePolicyAbandon() {
@@ -579,6 +583,15 @@ func (ts *IntegrationTestSuite) startWorkflowOptions(wfID string) client.StartWo
 func (ts *IntegrationTestSuite) registerWorkflowsAndActivities(w worker.Worker) {
 	ts.workflows.register(w)
 	ts.activities.register(w)
+}
+
+func (ts *IntegrationTestSuite) getWorkflow(wid string, runId string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+	wfRun := ts.libClient.GetWorkflow(ctx, wid, runId)
+	var val interface{}
+	err := wfRun.Get(ctx, &val)
+	return err
 }
 
 var _ interceptors.WorkflowInterceptorFactory = (*tracingInterceptorFactory)(nil)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Fixing flaky integration test since master build was failing. Test was flaky because it was testing that child workflow gets terminated when parent workflow finishes. The test was running into race condition.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
pipeline run.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
