### PR TITLE
Export GetRegisteredWorkflowTypes so I can use in shadowtest.

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -789,7 +789,7 @@ func (aw *aggregatedWorker) Start() error {
 	}
 
 	if aw.workflowWorker != nil {
-		if len(aw.registry.getRegisteredWorkflowTypes()) == 0 {
+		if len(aw.registry.GetRegisteredWorkflowTypes()) == 0 {
 			aw.logger.Info(
 				"Worker has no workflows registered, so workflow worker will not be started.",
 			)

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -250,7 +250,7 @@ func (s *internalWorkerTestSuite) TestNoActivitiesOrWorkflows() {
 	w := createWorker(s.T(), s.service)
 	w.registry = newRegistry()
 	assert.Empty(t, w.registry.getRegisteredActivities())
-	assert.Empty(t, w.registry.getRegisteredWorkflowTypes())
+	assert.Empty(t, w.registry.GetRegisteredWorkflowTypes())
 	assert.NoError(t, w.Start())
 }
 

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -517,7 +517,7 @@ func (env *testWorkflowEnvironmentImpl) executeWorkflowInternal(delayStart time.
 func (env *testWorkflowEnvironmentImpl) getWorkflowDefinition(wt WorkflowType) (workflowDefinition, error) {
 	wf, ok := env.registry.getWorkflowFn(wt.Name)
 	if !ok {
-		supported := strings.Join(env.registry.getRegisteredWorkflowTypes(), ", ")
+		supported := strings.Join(env.registry.GetRegisteredWorkflowTypes(), ", ")
 		return nil, fmt.Errorf("unable to find workflow type: %v. Supported types: [%v]", wt.Name, supported)
 	}
 	wd := &workflowExecutorWrapper{

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -243,7 +243,7 @@ func (r *registry) getWorkflowNoLock(registerName string) (interface{}, bool) {
 	return a, ok
 }
 
-func (r *registry) getRegisteredWorkflowTypes() []string {
+func (r *registry) GetRegisteredWorkflowTypes() []string {
 	r.Lock() // do not defer for Unlock to call next.getRegisteredWorkflowTypes without lock
 	var result []string
 	for t := range r.workflowFuncMap {
@@ -251,7 +251,7 @@ func (r *registry) getRegisteredWorkflowTypes() []string {
 	}
 	r.Unlock()
 	if r.next != nil {
-		nextTypes := r.next.getRegisteredWorkflowTypes()
+		nextTypes := r.next.GetRegisteredWorkflowTypes()
 		result = append(result, nextTypes...)
 	}
 	return result
@@ -318,7 +318,7 @@ func (r *registry) getWorkflowDefinition(wt WorkflowType) (workflowDefinition, e
 	}
 	wf, ok := r.getWorkflowFn(lookup)
 	if !ok {
-		supported := strings.Join(r.getRegisteredWorkflowTypes(), ", ")
+		supported := strings.Join(r.GetRegisteredWorkflowTypes(), ", ")
 		return nil, fmt.Errorf(errMsgUnknownWorkflowType+": %v. Supported types: [%v]", lookup, supported)
 	}
 	wd := &workflowExecutor{workflowType: lookup, fn: wf}

--- a/internal/registry_test.go
+++ b/internal/registry_test.go
@@ -105,7 +105,7 @@ func TestWorkflowRegistration(t *testing.T) {
 			tt.register(r)
 
 			// Verify registered workflow type
-			workflowType := r.getRegisteredWorkflowTypes()[0]
+			workflowType := r.GetRegisteredWorkflowTypes()[0]
 			require.Equal(t, tt.workflowType, workflowType)
 
 			// Verify workflow is resolved from workflow type

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -581,6 +581,13 @@ func RegisterWorkflowWithOptions(workflowFunc interface{}, opts RegisterWorkflow
 	registry.RegisterWorkflowWithOptions(workflowFunc, opts)
 }
 
+// GetRegisteredWorkflowTypes returns the registered workflow function/alias names.
+// The public form is: workflow.GetRegisteredWorkflowTypes(...)
+func GetRegisteredWorkflowTypes() []string {
+	registry := getGlobalRegistry()
+	return registry.GetRegisteredWorkflowTypes()
+}
+
 // Await blocks the calling thread until condition() returns true
 // Returns CanceledError if the ctx is canceled.
 func Await(ctx Context, condition func() bool) error {

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -89,6 +89,11 @@ func RegisterWithOptions(workflowFunc interface{}, opts RegisterOptions) {
 	internal.RegisterWorkflowWithOptions(workflowFunc, opts)
 }
 
+// GetRegisteredWorkflowTypes returns the registered workflow function/alias names.
+func GetRegisteredWorkflowTypes() []string {
+	return internal.GetRegisteredWorkflowTypes()
+}
+
 // ExecuteActivity requests activity execution in the context of a workflow.
 // Context can be used to pass the settings for this activity.
 // For example: task list that this need to be routed, timeouts that need to be configured.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Exported the GetRegisteredWorkflowTypes() function for public use.

<!-- Tell your future self why have you made these changes -->
In order to know what function types have been registered and be able to iterate them, and run the
WorkflowShadower on each exported function type.


