### PR TITLE
Adding go version check when building locally.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BIN := .bin
 #
 # this can _likely_ remain a major version, as fmt output does not tend to change in minor versions,
 # which will allow findstring to match any minor version.
-EXPECTED_GO_VERSION := go1.16.3
+EXPECTED_GO_VERSION := go1.16
 CURRENT_GO_VERSION := $(shell go version)
 ifeq (,$(findstring $(EXPECTED_GO_VERSION),$(CURRENT_GO_VERSION)))
 # if you are seeing this warning: consider using https://github.com/travis-ci/gimme to pin your version

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,19 @@ BUILD := .build
 # usually unnecessary to clean, and may require downloads to restore, so this folder is not automatically cleaned.
 BIN := .bin
 
+# current (when committed) version of Go used in CI, and ideally also our docker images.
+# this generally does not matter, but can impact goimports or formatting output.
+# for maximum stability, make sure you use the same version as CI uses.
+#
+# this can _likely_ remain a major version, as fmt output does not tend to change in minor versions,
+# which will allow findstring to match any minor version.
+EXPECTED_GO_VERSION := go1.16.3
+CURRENT_GO_VERSION := $(shell go version)
+ifeq (,$(findstring $(EXPECTED_GO_VERSION),$(CURRENT_GO_VERSION)))
+# if you are seeing this warning: consider using https://github.com/travis-ci/gimme to pin your version
+$(warning Caution: you are not using CI's go version. Expected: $(EXPECTED_GO_VERSION), current: $(CURRENT_GO_VERSION))
+endif
+
 # ====================================
 # book-keeping files that are used to control sequencing.
 #


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Adding check to print a warning when building with a different go version locally.


<!-- Tell your future self why have you made these changes -->
**Why?**
For example, when building locally formatting changes happen with go1.19 version


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Tested locally.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
