### PR TITLE
Fix TestActivityWorkerStop: it times out with go 1.20

### DIFF
--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -168,10 +168,13 @@ func (s *WorkersTestSuite) TestActivityWorkerStop() {
 	ctx, cancel := context.WithCancel(context.Background())
 	executionParameters := workerExecutionParameters{
 		TaskList: "testTaskList",
-		WorkerOptions: WorkerOptions{
-			MaxConcurrentActivityTaskPollers:   5,
-			MaxConcurrentActivityExecutionSize: 2,
-			Logger:                             zaptest.NewLogger(s.T())},
+		WorkerOptions: augmentWorkerOptions(
+			WorkerOptions{
+				MaxConcurrentActivityTaskPollers:   5,
+				MaxConcurrentActivityExecutionSize: 2,
+				Logger:                             zaptest.NewLogger(s.T()),
+			},
+		),
 		UserContext:       ctx,
 		UserContextCancel: cancel,
 		WorkerStopTimeout: time.Second * 2,


### PR DESCRIPTION
The only test that fails with go 1.20 is this one. The reason is workerOptions.WorkerActivitiesPerSecond == 0, and it is not augmented in newActivityWorker() - this supposed to be done in callers. This breaks task-dispatching: polled tasks are never executed since it is always above the limit(0).

<!-- Describe what has changed in this PR -->
**What changed?**
TestActivityWorkerStop now works with default MaxActivity

<!-- Tell your future self why have you made these changes -->
**Why?**
`make unit_test` was hanging on TestActivityWorkerStop for 10 minutes (timeout), and failed afterwards.
I believe it because of the new go version:
```
$ go version
go version go1.20.1 darwin/arm64
```

The reason is, an activity which supposed to drive the test is never executed because of rate-limiting; workerOptions.WorkerActivitiesPerSecond is *zero*. `newActivityWorker` expects this already be augmented to default (100k) by callers.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
`make unit_test` succeeds after this patch.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks, it is only a test-file changed.