### PR TITLE
[error] surface more fields in ContinueAsNew error

### DIFF
--- a/internal/error.go
+++ b/internal/error.go
@@ -365,6 +365,16 @@ func (e *ContinueAsNewError) Args() []interface{} {
 	return e.args
 }
 
+// Input return serialized workflow argument
+func (e *ContinueAsNewError) Input() []byte {
+	return e.params.input
+}
+
+// Header return the header to start a workflow
+func (e *ContinueAsNewError) Header() *shared.Header {
+	return e.params.header
+}
+
 // newTerminatedError creates NewTerminatedError instance
 func newTerminatedError() *TerminatedError {
 	return &TerminatedError{}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
To start a new workflow correctly, we actually need more fields:
1. serialized input
2. header info

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
 low risk to add NEW receive methods on public struct