### PR TITLE
[activity/logging] produce a log when activities time out

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -35,7 +35,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/opentracing/opentracing-go"
 	"go.uber.org/zap"
 
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
@@ -1947,6 +1946,11 @@ func (ath *activityTaskHandlerImpl) Execute(taskList string, t *s.PollForActivit
 
 	dlCancelFunc()
 	if <-ctx.Done(); ctx.Err() == context.DeadlineExceeded {
+		ath.logger.Warn("Activity timeout.",
+			zap.String(tagWorkflowID, t.WorkflowExecution.GetWorkflowId()),
+			zap.String(tagRunID, t.WorkflowExecution.GetRunId()),
+			zap.String(tagActivityType, activityType),
+		)
 		return nil, ctx.Err()
 	}
 	if err != nil && err != ErrActivityResultPending {

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -35,6 +35,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
 	"go.uber.org/zap"
 
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"


### PR DESCRIPTION
logging when activities time out will help with debugging

<!-- Describe what has changed in this PR -->
added a log when activity times out


<!-- Tell your future self why have you made these changes -->
log will help in debugging


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
local testing


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
no risk
