### PR TITLE
Test-suite bugfix: local activity errors were not encoded correctly

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -1159,10 +1159,10 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessLocalActivityResult(lar *lo
 	if lar.err != nil {
 		errReason, errDetails := getErrorDetails(lar.err, weh.GetDataConverter())
 		lamd.ErrReason = errReason
-		lamd.ErrJSON = string(errDetails)
+		lamd.ErrJSON = string(errDetails) // TODO: this is not json, nor is it necessarily a valid string
 		lamd.Backoff = lar.backoff
 	} else {
-		lamd.ResultJSON = string(lar.result)
+		lamd.ResultJSON = string(lar.result) // TODO: same, not json nor a string
 	}
 
 	// encode marker data

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -140,7 +140,7 @@ type (
 
 	localActivityResult struct {
 		result  []byte
-		err     error
+		err     error // original error type, possibly an un-encoded user error
 		task    *localActivityTask
 		backoff time.Duration
 	}

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -60,7 +60,7 @@ type (
 	laResultHandler func(lar *localActivityResultWrapper)
 
 	localActivityResultWrapper struct {
-		err     error
+		err     error // internal error type, possibly containing encoded user-error data
 		result  []byte
 		attempt int32
 		backoff time.Duration


### PR DESCRIPTION
The added test hopefully reveals the issue - prior to this fix,
that `err := f.Get(...)` -> `errors.Is(err, ...)` check passed, because
the error value was not ever encoded into a `*GenericError`.

Thankfully this was only a test environment bug, and a user discovered
it due to writing tests.

---

The non-test behavior can be seen split between these two locations:
- encoding error reason / data: https://github.com/uber-go/cadence-client/blob/ad91fc718330cb40ff26627fa1d1a6c78c2ceaca/internal/internal_event_handlers.go#L1159-L1163
- constructing the generic error in handleLocalActivityMarker: https://github.com/uber-go/cadence-client/blob/ad91fc718330cb40ff26627fa1d1a6c78c2ceaca/internal/internal_event_handlers.go#L1132-L1135

... which also show incorrect / pointless string/byte conversions.
I've left comments there just to prevent confusion, but these fields are
probably worth changing at some point.