### PR TITLE
Bugfix: mock child workflows would complete before they started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Children workflow in tests now always start successfully, before their mock's return value is collected/func is run.
+
 ## [v0.19.0] - 2022-01-05
 ### Added
 - Added JWT Authorization Provider. This change includes a dependency that uses v2+ go modules. They no longer match import paths, meaning that we have to **drop support for dep & glide** in order to use this. [#1116](https://github.com/uber-go/cadence-client/pull/1116)


### PR DESCRIPTION
Encountered and offending code identified by an internal user - thanks very much!
Basically: children workflows in tests would return their mock value / call its
func (which can block) *before* marking the started-future as "ready".

This both violates the obvious order of execution (start then complete), and makes it
unreasonable / possibly deadlocking to use on-start-workflow listeners to control the
execution of the workflow that is being started.

---

Since that's kinda irrational, and returning arbitrary errors from Start is not rational
either (iirc only a few are possible, e.g. schedule to start timeout, as all others are
completion-with-error results), this has now been changed:
- Children workflows now Start before (mocked) Run/Completion.
- Children workflows now *always* successfully start, and failures are reported via the
  normal completion-future rather than both start and completion.

This matches IRL / non-test behavior more accurately, though it does unfortunately mean
some tests that worked before will now fail.

We also do not currently have a way to mock the child-started future's error, so
any tests that actually were correctly checking for start-failures are now unable to
be written.
That's probably not too difficult to add, but it has not been done in this PR.
