### PR TITLE
Adding WorkflowType to "Workflow panic" log-message

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1240,6 +1240,7 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 		// Workflow panic
 		metricsScope.Counter(metrics.DecisionTaskPanicCounter).Inc(1)
 		wth.logger.Error("Workflow panic.",
+			zap.String(tagWorkflowType, task.WorkflowType.GetName()),
 			zap.String(tagWorkflowID, task.WorkflowExecution.GetWorkflowId()),
 			zap.String(tagRunID, task.WorkflowExecution.GetRunId()),
 			zap.String(tagPanicError, panicErr.Error()),

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -297,6 +297,15 @@ func createTestEventTimerFired(eventID int64, id int) *s.HistoryEvent {
 		TimerFiredEventAttributes: attr}
 }
 
+func findLogField(entry observer.LoggedEntry, fieldName string) *zapcore.Field {
+	for _, field := range entry.Context {
+		if field.Key == fieldName {
+			return &field
+		}
+	}
+	return nil
+}
+
 var testWorkflowTaskTasklist = "tl1"
 
 func (t *TaskHandlersTestSuite) testWorkflowTaskWorkflowExecutionStartedHelper(params workerExecutionParameters) {
@@ -875,13 +884,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicLogNonexistingI
 	require.Len(t.T(), ignoredWorkflowLogs.All(), 1)
 
 	// Find the ReplayError field
-	withField := ignoredWorkflowLogs.All()[0]
-	var replayErrorField *zapcore.Field
-	for _, field := range withField.Context {
-		if field.Key == "ReplayError" {
-			replayErrorField = &field
-		}
-	}
+	replayErrorField := findLogField(ignoredWorkflowLogs.All()[0], "ReplayError")
 	require.NotNil(t.T(), replayErrorField)
 	require.Equal(t.T(), zapcore.ErrorType, replayErrorField.Type)
 	require.ErrorContains(t.T(), replayErrorField.Interface.(error),
@@ -928,12 +931,16 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowPanics() {
 		createTestEventDecisionTaskScheduled(2, &s.DecisionTaskScheduledEventAttributes{TaskList: &s.TaskList{Name: &taskList}}),
 		createTestEventDecisionTaskStarted(3),
 	}
+
+	obs, logs := observer.New(zap.ErrorLevel)
+	logger := zap.New(obs)
+
 	task := createWorkflowTask(testEvents, 3, "PanicWorkflow")
 	params := workerExecutionParameters{
 		TaskList: taskList,
 		WorkerOptions: WorkerOptions{
 			Identity:                       "test-id-1",
-			Logger:                         zap.NewNop(),
+			Logger:                         logger,
 			NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
 		},
 	}
@@ -946,6 +953,14 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowPanics() {
 	t.True(ok)
 	t.EqualValues("WORKFLOW_WORKER_UNHANDLED_FAILURE", r.Cause.String())
 	t.EqualValues("panicError", string(r.Details))
+
+	// Check that the error was logged
+	panicLogs := logs.FilterMessage("Workflow panic.")
+	require.Len(t.T(), panicLogs.All(), 1)
+
+	wfTypeField := findLogField(panicLogs.All()[0], tagWorkflowType)
+	require.NotNil(t.T(), wfTypeField)
+	require.Equal(t.T(), "PanicWorkflow", wfTypeField.String)
 }
 
 func (t *TaskHandlersTestSuite) TestGetWorkflowInfo() {


### PR DESCRIPTION
It is very expected to have this field, but customers have to walk
through the stack trace, which is not always convinient especially with
wrappers.

<!-- Describe what has changed in this PR -->
**What changed?**
WorkflowType is logged among other fields in "Workflow panic" log-message.

<!-- Tell your future self why have you made these changes -->
**Why?**
Seeing this field makes debugging easier.
Especially when you have a log-view (Like Kibana or uMonitor) - you can add WorkflowType field as a column.



<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Verified by writing a workflow that panics + with the unit-test


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks - retrieving workflow-name is lock-free, and at least returns an empty string.
