### PR TITLE
Adding WorkflowType to "Workflow panic" log-message

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1240,6 +1240,7 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 		// Workflow panic
 		metricsScope.Counter(metrics.DecisionTaskPanicCounter).Inc(1)
 		wth.logger.Error("Workflow panic.",
+			zap.String(tagWorkflowType, task.WorkflowType.GetName()),
 			zap.String(tagWorkflowID, task.WorkflowExecution.GetWorkflowId()),
 			zap.String(tagRunID, task.WorkflowExecution.GetRunId()),
 			zap.String(tagPanicError, panicErr.Error()),


### PR DESCRIPTION
It is very expected to have this field, but customers have to walk
through the stack trace, which is not always convinient especially with
wrappers.

<!-- Describe what has changed in this PR -->
**What changed?**
WorkflowType is logged among other fields in "Workflow panic" log-message.

<!-- Tell your future self why have you made these changes -->
**Why?**
Seeing this field makes debugging easier.
Especially when you have a log-view (Like Kibana or uMonitor) - you can add WorkflowType field as a column.



<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Verified by writing a workflow that panics + with the unit-test


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks - retrieving workflow-name is lock-free, and at least returns an empty string.
