### PR TITLE
Lower "Failed to send heartbeat" log level

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1496,7 +1496,7 @@ func (i *cadenceInvoker) heartbeatAndScheduleNextRun(details []byte) error {
 
 			// Log the error outside the lock.
 			if err != nil {
-				i.logger.Error("Failed to send heartbeat", zap.Error(err), zap.String(tagWorkflowType, i.workflowType), zap.String(tagActivityType, i.activityType))
+				i.logger.Info("Failed to send heartbeat", zap.Error(err), zap.String(tagWorkflowType, i.workflowType), zap.String(tagActivityType, i.activityType))
 			}
 		}()
 	}


### PR DESCRIPTION
We now log when the automatic heartbeating fails introduced in #1263

<!-- Describe what has changed in this PR -->
**What changed?**
We introduced this log to help stakeholders debug, however now stakeholders are being flooded with this log, so lowering the log level.

<!-- Tell your future self why have you made these changes -->
**Why?**
Lowered to avoid stakeholders who cancel workflows being flooded with error logs

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk