### PR TITLE
Create a new poller thread pool usage metric

### DIFF
--- a/internal/common/metrics/constants.go
+++ b/internal/common/metrics/constants.go
@@ -114,4 +114,6 @@ const (
 	MemoryUsedHeap  = CadenceMetricsPrefix + "memory-used-heap"
 	MemoryUsedStack = CadenceMetricsPrefix + "memory-used-stack"
 	NumGoRoutines   = CadenceMetricsPrefix + "num-go-routines"
+
+	PollerRemainingBuffer = CadenceMetricsPrefix + "poller-remaining-buffer"
 )


### PR DESCRIPTION
Create a new poller thread pool usage metric for the amount of buffer left in the poller channel. If there are non-remaining, then polling will halt.

<!-- Describe what has changed in this PR -->
**What changed?**
Added a new metric regarding the usage and remaining capacity of the poller channel

<!-- Tell your future self why have you made these changes -->
**Why?**
We are aiming to understand current poller utilizations and improve the overall utilization as a result. This metric allows us to determine whether there exists a need to tune the amount of buffer of the channel for high traffic customers.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested on development environment

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks considering that is only a new metric
