### PR TITLE
Improve retrieval of binaryChecksum

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -889,11 +889,6 @@ func initBinaryChecksum() error {
 	binaryChecksumLock.Lock()
 	defer binaryChecksumLock.Unlock()
 
-	return initBinaryChecksumLocked()
-}
-
-// callers MUST hold binaryChecksumLock before calling
-func initBinaryChecksumLocked() error {
 	if len(binaryChecksum) > 0 {
 		return nil
 	}
@@ -924,18 +919,14 @@ func initBinaryChecksumLocked() error {
 
 func getBinaryChecksum() string {
 	binaryChecksumLock.RLock()
-	if len(binaryChecksum) != 0 {
-		// already initialized. release the Read lock and return it.
-		binaryChecksumLock.RUnlock()
-		return binaryChecksum
+	val := binaryChecksum
+	binaryChecksumLock.RUnlock()
+
+	if len(val) != 0 { // already initialized.
+		return val
 	}
 
-	// not initialized yet so release the Read lock and acquire Write lock
-	binaryChecksumLock.RUnlock()
-	binaryChecksumLock.Lock()
-	defer binaryChecksumLock.Unlock()
-
-	if err := initBinaryChecksumLocked(); err != nil {
+	if err := initBinaryChecksum(); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`binaryChecksum` gets initialized somewhere early on in worker's lifecycle and then read many times. It was protected by a `sync.Mutex` for both reads and writes. Typically `sync.Once` is used for such scenarios but there is a `SetBinaryChecksum()` function exposed so it wouldn't work here. 
Changing the implementation to avoid mutex locks for reads once `binaryChecksum` is initialized/set.

<!-- Tell your future self why have you made these changes -->
**Why?**
This change might not have visible performance improvements but still better to use atomic instead of a mutex each time `binaryChecksum` is read.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
`make test`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

