### PR TITLE
Introduce DisableStrictNonDeterminismCheck worker option

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -131,7 +131,7 @@ type (
 		contextPropagators             []ContextPropagator
 		tracer                         opentracing.Tracer
 		workflowInterceptorFactories   []WorkflowInterceptorFactory
-		enableStrictNonDeterminism     bool
+		disableStrictNonDeterminism    bool
 	}
 
 	activityProvider func(name string) activity
@@ -403,13 +403,13 @@ func newWorkflowTaskHandler(
 		contextPropagators:             params.ContextPropagators,
 		tracer:                         params.Tracer,
 		workflowInterceptorFactories:   params.WorkflowInterceptorChainFactories,
-		enableStrictNonDeterminism:     params.WorkerBugPorts.EnableStrictNonDeterminismCheck,
+		disableStrictNonDeterminism:    params.WorkerBugPorts.DisableStrictNonDeterminismCheck,
 	}
 
 	traceLog(func() {
 		wth.logger.Debug("Workflow task handler is created.",
 			zap.String(tagDomain, wth.domain),
-			zap.Bool("EnableStrictNonDeterminism", wth.enableStrictNonDeterminism))
+			zap.Bool("disableStrictNonDeterminism", wth.disableStrictNonDeterminism))
 	})
 
 	return wth

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1041,7 +1041,7 @@ func newAggregatedWorker(
 	var workflowWorker *workflowWorker
 	if !wOptions.DisableWorkflowWorker {
 		testTags := getTestTags(wOptions.BackgroundActivityContext)
-		if testTags != nil && len(testTags) > 0 {
+		if len(testTags) > 0 {
 			workflowWorker = newWorkflowWorkerWithPressurePoints(
 				service,
 				domain,

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -228,7 +228,7 @@ func (s *internalWorkerTestSuite) TestCreateWorker_WithAutoScaler() {
 }
 
 func (s *internalWorkerTestSuite) TestCreateWorker_WithStrictNonDeterminism() {
-	worker := createWorkerWithStrictNonDeterminismOption(s.T(), s.service)
+	worker := createWorkerWithStrictNonDeterminismDisabled(s.T(), s.service)
 	err := worker.Start()
 	require.NoError(s.T(), err)
 	time.Sleep(time.Millisecond * 200)
@@ -433,11 +433,11 @@ func createWorkerWithAutoscaler(
 	return createWorkerWithThrottle(t, service, 0, WorkerOptions{FeatureFlags: FeatureFlags{PollerAutoScalerEnabled: true}})
 }
 
-func createWorkerWithStrictNonDeterminismOption(
+func createWorkerWithStrictNonDeterminismDisabled(
 	t *testing.T,
 	service *workflowservicetest.MockClient,
 ) *aggregatedWorker {
-	return createWorkerWithThrottle(t, service, 0, WorkerOptions{WorkerBugPorts: WorkerBugPorts{EnableStrictNonDeterminismCheck: true}})
+	return createWorkerWithThrottle(t, service, 0, WorkerOptions{WorkerBugPorts: WorkerBugPorts{DisableStrictNonDeterminismCheck: true}})
 }
 
 func createWorkerWithHost(

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -227,6 +227,14 @@ func (s *internalWorkerTestSuite) TestCreateWorker_WithAutoScaler() {
 	worker.Stop()
 }
 
+func (s *internalWorkerTestSuite) TestCreateWorker_WithStrictNonDeterminism() {
+	worker := createWorkerWithStrictNonDeterminismOption(s.T(), s.service)
+	err := worker.Start()
+	require.NoError(s.T(), err)
+	time.Sleep(time.Millisecond * 200)
+	worker.Stop()
+}
+
 func (s *internalWorkerTestSuite) TestCreateWorker_WithHost() {
 	worker := createWorkerWithHost(s.T(), s.service)
 	err := worker.Start()
@@ -423,6 +431,13 @@ func createWorkerWithAutoscaler(
 	service *workflowservicetest.MockClient,
 ) *aggregatedWorker {
 	return createWorkerWithThrottle(t, service, float64(0), WorkerOptions{FeatureFlags: FeatureFlags{PollerAutoScalerEnabled: true}})
+}
+
+func createWorkerWithStrictNonDeterminismOption(
+	t *testing.T,
+	service *workflowservicetest.MockClient,
+) *aggregatedWorker {
+	return createWorkerWithThrottle(t, service, float64(0), WorkerOptions{WorkerBugPorts: WorkerBugPorts{EnableStrictNonDeterminismCheck: true}})
 }
 
 func createWorkerWithHost(

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -196,7 +196,7 @@ func testActivityMultipleArgsWithStruct(ctx context.Context, i int, s testActivi
 }
 
 func (s *internalWorkerTestSuite) TestCreateWorker() {
-	worker := createWorkerWithThrottle(s.T(), s.service, float64(500.0), WorkerOptions{})
+	worker := createWorkerWithThrottle(s.T(), s.service, 500, WorkerOptions{})
 	err := worker.Start()
 	require.NoError(s.T(), err)
 	time.Sleep(time.Millisecond * 200)
@@ -356,7 +356,7 @@ func createWorker(
 	t *testing.T,
 	service *workflowservicetest.MockClient,
 ) *aggregatedWorker {
-	return createWorkerWithThrottle(t, service, float64(0.0), WorkerOptions{})
+	return createWorkerWithThrottle(t, service, 0, WorkerOptions{})
 }
 
 func createShadowWorker(
@@ -364,7 +364,7 @@ func createShadowWorker(
 	service *workflowservicetest.MockClient,
 	shadowOptions *ShadowOptions,
 ) *aggregatedWorker {
-	return createWorkerWithThrottle(t, service, float64(0.0), WorkerOptions{
+	return createWorkerWithThrottle(t, service, 0, WorkerOptions{
 		EnableShadowWorker: true,
 		ShadowOptions:      *shadowOptions,
 	})
@@ -423,28 +423,28 @@ func createWorkerWithDataConverter(
 	t *testing.T,
 	service *workflowservicetest.MockClient,
 ) *aggregatedWorker {
-	return createWorkerWithThrottle(t, service, float64(0.0), WorkerOptions{DataConverter: newTestDataConverter()})
+	return createWorkerWithThrottle(t, service, 0, WorkerOptions{DataConverter: newTestDataConverter()})
 }
 
 func createWorkerWithAutoscaler(
 	t *testing.T,
 	service *workflowservicetest.MockClient,
 ) *aggregatedWorker {
-	return createWorkerWithThrottle(t, service, float64(0), WorkerOptions{FeatureFlags: FeatureFlags{PollerAutoScalerEnabled: true}})
+	return createWorkerWithThrottle(t, service, 0, WorkerOptions{FeatureFlags: FeatureFlags{PollerAutoScalerEnabled: true}})
 }
 
 func createWorkerWithStrictNonDeterminismOption(
 	t *testing.T,
 	service *workflowservicetest.MockClient,
 ) *aggregatedWorker {
-	return createWorkerWithThrottle(t, service, float64(0), WorkerOptions{WorkerBugPorts: WorkerBugPorts{EnableStrictNonDeterminismCheck: true}})
+	return createWorkerWithThrottle(t, service, 0, WorkerOptions{WorkerBugPorts: WorkerBugPorts{EnableStrictNonDeterminismCheck: true}})
 }
 
 func createWorkerWithHost(
 	t *testing.T,
 	service *workflowservicetest.MockClient,
 ) *aggregatedWorker {
-	return createWorkerWithThrottle(t, service, float64(0), WorkerOptions{Host: "test_host"})
+	return createWorkerWithThrottle(t, service, 0, WorkerOptions{Host: "test_host"})
 }
 
 func (s *internalWorkerTestSuite) testCompleteActivityHelper(opt *ClientOptions) {

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -283,14 +283,13 @@ type (
 	// allow cleaning up the additional code complexity that they cause.
 	// Deprecated: All bugports are always deprecated and may be removed at any time
 	WorkerBugPorts struct {
-		// Optional: Enable strict non-determinism checks for workflow.
+		// Optional: Disable strict non-determinism checks for workflow.
 		// There are some non-determinism cases which are missed by original implementation and a fix is on the way.
-		// The fix will be activated by this option which basicakky accuracy of the non-determinism checks.
-		// Exposing this as bugport for now to avoid breaking existing workflows which are actually non-deterministic but users depend on this.
-		// Once we identify such cases and notify users, we can enable this by default.
+		// The fix will be toggleable by this parameter.
+		// Default: false, which means strict non-determinism checks are enabled.
 		//
 		// Deprecated: All bugports are always deprecated and may be removed at any time
-		EnableStrictNonDeterminismCheck bool
+		DisableStrictNonDeterminismCheck bool
 	}
 )
 

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -268,6 +268,8 @@ type (
 		Host string
 
 		// Optional: See WorkerBugPorts for more details
+		//
+		// Deprecated: This field is deprecated and will be removed in the future.
 		WorkerBugPorts WorkerBugPorts
 	}
 
@@ -279,13 +281,16 @@ type (
 	// Bugports are always deprecated and may be removed in future versions.
 	// Generally speaking they will *likely* remain in place for one minor version, and then they may be removed to
 	// allow cleaning up the additional code complexity that they cause.
+	// Deprecated: This is deprecated and will be removed in the future.
+	//
 	WorkerBugPorts struct {
 		// Optional: Enable strict non-determinism checks for workflow.
 		// There are some non-determinism cases which are missed by original implementation and a fix is on the way.
 		// The fix will be activated by this option which basicakky accuracy of the non-determinism checks.
 		// Exposing this as bugport for now to avoid breaking existing workflows which are actually non-deterministic but users depend on this.
 		// Once we identify such cases and notify users, we can enable this by default.
-		// default: false
+		//
+		// Deprecated: This field is deprecated and will be removed in the future.
 		EnableStrictNonDeterminismCheck bool
 	}
 )

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -266,6 +266,27 @@ type (
 		// Optional: Host is just string on the machine running the client
 		// default: empty string
 		Host string
+
+		// Optional: See WorkerBugPorts for more details
+		WorkerBugPorts WorkerBugPorts
+	}
+
+	// WorkerBugPorts allows opt-in enabling of older, possibly buggy behavior, primarily intended to allow temporarily
+	// emulating old behavior until a fix is deployed.
+	// By default, bugs (especially rarely-occurring ones) are fixed and all users are opted into the new behavior.
+	// Back-ported buggy behavior *may* be available via these flags.
+	//
+	// Bugports are always deprecated and may be removed in future versions.
+	// Generally speaking they will *likely* remain in place for one minor version, and then they may be removed to
+	// allow cleaning up the additional code complexity that they cause.
+	WorkerBugPorts struct {
+		// Optional: Enable strict non-determinism checks for workflow.
+		// There are some non-determinism cases which are missed by original implementation and a fix is on the way.
+		// The fix will be activated by this option which basicakky accuracy of the non-determinism checks.
+		// Exposing this as bugport for now to avoid breaking existing workflows which are actually non-deterministic but users depend on this.
+		// Once we identify such cases and notify users, we can enable this by default.
+		// default: false
+		EnableStrictNonDeterminismCheck bool
 	}
 )
 

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -269,7 +269,7 @@ type (
 
 		// Optional: See WorkerBugPorts for more details
 		//
-		// Deprecated: This field is deprecated and will be removed in the future.
+		// Deprecated: All bugports are always deprecated and may be removed at any time.
 		WorkerBugPorts WorkerBugPorts
 	}
 
@@ -281,8 +281,7 @@ type (
 	// Bugports are always deprecated and may be removed in future versions.
 	// Generally speaking they will *likely* remain in place for one minor version, and then they may be removed to
 	// allow cleaning up the additional code complexity that they cause.
-	// Deprecated: This is deprecated and will be removed in the future.
-	//
+	// Deprecated: All bugports are always deprecated and may be removed at any time
 	WorkerBugPorts struct {
 		// Optional: Enable strict non-determinism checks for workflow.
 		// There are some non-determinism cases which are missed by original implementation and a fix is on the way.
@@ -290,7 +289,7 @@ type (
 		// Exposing this as bugport for now to avoid breaking existing workflows which are actually non-deterministic but users depend on this.
 		// Once we identify such cases and notify users, we can enable this by default.
 		//
-		// Deprecated: This field is deprecated and will be removed in the future.
+		// Deprecated: All bugports are always deprecated and may be removed at any time
 		EnableStrictNonDeterminismCheck bool
 	}
 )

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -481,7 +481,7 @@ type (
 		// Generally speaking they will *likely* remain in place for one minor version, and then they may be removed to
 		// allow cleaning up the additional code complexity that they cause.
 		//
-		// deprecated
+		// Deprecated: This field is deprecated and will be removed in the future.
 		Bugports Bugports
 	}
 
@@ -500,7 +500,7 @@ type (
 	// Generally speaking they will *likely* remain in place for one minor version, and then they may be removed to
 	// allow cleaning up the additional code complexity that they cause.
 	//
-	// deprecated
+	// DEPRECATED: This is deprecated and will be removed in the future.
 	Bugports struct {
 		// StartChildWorkflowsOnCanceledContext allows emulating older, buggy behavior that existed prior to v0.18.4.
 		//
@@ -530,7 +530,7 @@ type (
 		//
 		// Added in 0.18.4, this may be removed in or after v0.19.0, so please migrate off of it ASAP.
 		//
-		// deprecated
+		// Deprecated: This field is deprecated and will be removed in the future.
 		StartChildWorkflowsOnCanceledContext bool
 	}
 )

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -481,7 +481,7 @@ type (
 		// Generally speaking they will *likely* remain in place for one minor version, and then they may be removed to
 		// allow cleaning up the additional code complexity that they cause.
 		//
-		// Deprecated: This field is deprecated and will be removed in the future.
+		// Deprecated: All bugports are always deprecated and may be removed at any time.
 		Bugports Bugports
 	}
 
@@ -500,7 +500,7 @@ type (
 	// Generally speaking they will *likely* remain in place for one minor version, and then they may be removed to
 	// allow cleaning up the additional code complexity that they cause.
 	//
-	// DEPRECATED: This is deprecated and will be removed in the future.
+	// DEPRECATED: All bugports are always deprecated and may be removed at any time.
 	Bugports struct {
 		// StartChildWorkflowsOnCanceledContext allows emulating older, buggy behavior that existed prior to v0.18.4.
 		//
@@ -530,7 +530,7 @@ type (
 		//
 		// Added in 0.18.4, this may be removed in or after v0.19.0, so please migrate off of it ASAP.
 		//
-		// Deprecated: This field is deprecated and will be removed in the future.
+		// Deprecated: All bugports are always deprecated and may be removed at any time.
 		StartChildWorkflowsOnCanceledContext bool
 	}
 )


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding a new option to be able to toggle non-determinism false positives fix in #1281. 

<!-- Tell your future self why have you made these changes -->
**Why?**
The strict non-determinism checks in #1281 may cause some existing workflows to fail due to the existing buggy non-determinism checks in task handling loop. So exposing this option to disable the strict non-determinism if needed.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
 #1281 will be rebased with this change and testing will be done there.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A