### PR TITLE
Rename poller request buffer metric

### DIFF
--- a/internal/common/metrics/constants.go
+++ b/internal/common/metrics/constants.go
@@ -115,6 +115,6 @@ const (
 	MemoryUsedStack = CadenceMetricsPrefix + "memory-used-stack"
 	NumGoRoutines   = CadenceMetricsPrefix + "num-go-routines"
 
-	ConcurrentTaskQuota   = CadenceMetricsPrefix + "concurrent-task-quota"
-	ConcurrentTaskRunning = CadenceMetricsPrefix + "concurrent-task-running"
+	ConcurrentTaskQuota      = CadenceMetricsPrefix + "concurrent-task-quota"
+	PollerRequestBufferUsage = CadenceMetricsPrefix + "poller-request-buffer-usage"
 )

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -253,7 +253,9 @@ func (bw *baseWorker) runPoller() {
 			return
 		case <-bw.pollerRequestCh:
 			bw.metricsScope.Gauge(metrics.ConcurrentTaskQuota).Update(float64(cap(bw.pollerRequestCh)))
-			bw.metricsScope.Gauge(metrics.ConcurrentTaskRunning).Update(float64(cap(bw.pollerRequestCh) - len(bw.pollerRequestCh)))
+			// This metric is used to monitor how many poll requests have been allocated
+			// and can be used to approximate number of concurrent task running (not pinpoint accurate)
+			bw.metricsScope.Gauge(metrics.PollerRequestBufferUsage).Update(float64(cap(bw.pollerRequestCh) - len(bw.pollerRequestCh)))
 			if bw.sessionTokenBucket != nil {
 				bw.sessionTokenBucket.waitForAvailableToken()
 			}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Make the name more accurate.

<!-- Tell your future self why have you made these changes -->
**Why?**
Old name might cause confusion since there might be discrepancy between the metric and the number of concurrent task running

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Only naming change

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
