### PR TITLE
Add GetActivityTaskList and GetWorkflowTaskList utils to replace WithTaskListMapper utils

### DIFF
--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1413,16 +1413,13 @@ func WithWorkflowTaskList(ctx Context, name string) Context {
 	return ctx1
 }
 
-// WithWorkflowTaskListMapper returns a copy of context and changes workflow tasklist with mapper function.
-func WithWorkflowTaskListMapper(ctx Context, mapper func(string) string) Context {
-	ctx1 := setWorkflowEnvOptionsIfNotExist(ctx)
-	var taskList string
-	if getWorkflowEnvOptions(ctx1).taskListName != nil {
-		taskList = *getWorkflowEnvOptions(ctx1).taskListName
+// GetWorkflowTaskList retrieves current workflow tasklist from context
+func GetWorkflowTaskList(ctx Context) *string {
+	wo := getWorkflowEnvOptions(ctx)
+	if wo == nil {
+		return nil
 	}
-	newTaskList := mapper(taskList)
-	getWorkflowEnvOptions(ctx1).taskListName = &newTaskList
-	return ctx1
+	return wo.taskListName
 }
 
 // WithWorkflowID adds a workflowID to the context.
@@ -1813,12 +1810,14 @@ func WithTaskList(ctx Context, name string) Context {
 	return ctx1
 }
 
-// WithTaskListMapper makes a copy of the context and apply the tasklist mapper function
-// Note this shall not confuse with WithWorkflowTaskListMapper. This is the tasklist for activities.
-func WithTaskListMapper(ctx Context, mapper func(string) string) Context {
-	ctx1 := setActivityParametersIfNotExist(ctx)
-	getActivityOptions(ctx1).TaskListName = mapper(getActivityOptions(ctx1).TaskListName)
-	return ctx1
+// GetActivityTaskList retrieves tasklist info from context
+func GetActivityTaskList(ctx Context) *string {
+	ao := getActivityOptions(ctx)
+	if ao == nil {
+		return nil
+	}
+	tl := ao.TaskListName
+	return &tl
 }
 
 // WithScheduleToCloseTimeout adds a timeout to the copy of the context.

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1416,10 +1416,11 @@ func WithWorkflowTaskList(ctx Context, name string) Context {
 // GetWorkflowTaskList retrieves current workflow tasklist from context
 func GetWorkflowTaskList(ctx Context) *string {
 	wo := getWorkflowEnvOptions(ctx)
-	if wo == nil {
+	if wo == nil || wo.taskListName == nil {
 		return nil
 	}
-	return wo.taskListName
+	tl := *wo.taskListName // copy
+	return common.StringPtr(tl)
 }
 
 // WithWorkflowID adds a workflowID to the context.
@@ -1816,7 +1817,7 @@ func GetActivityTaskList(ctx Context) *string {
 	if ao == nil {
 		return nil
 	}
-	tl := ao.TaskListName
+	tl := ao.TaskListName // copy
 	return &tl
 }
 

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1420,7 +1420,7 @@ func GetWorkflowTaskList(ctx Context) *string {
 		return nil
 	}
 	tl := *wo.taskListName // copy
-	return common.StringPtr(tl)
+	return &tl
 }
 
 // WithWorkflowID adds a workflowID to the context.

--- a/workflow/activity_options.go
+++ b/workflow/activity_options.go
@@ -62,7 +62,7 @@ func WithTaskList(ctx Context, name string) Context {
 // or workflow.GetInfo(ctx).TaskListName if not set or empty
 func GetActivityTaskList(ctx Context) string {
 	tl := internal.GetActivityTaskList(ctx)
-	if tl != nil && len(*tl) > 0 {
+	if tl != nil && *tl != "" {
 		return *tl
 	}
 	return GetInfo(ctx).TaskListName

--- a/workflow/activity_options.go
+++ b/workflow/activity_options.go
@@ -58,10 +58,14 @@ func WithTaskList(ctx Context, name string) Context {
 	return internal.WithTaskList(ctx, name)
 }
 
-// GetActivityTaskList returns tasklist where activity should be started
-// if context is not an activity context then it will return nil
-func GetActivityTaskList(ctx Context) *string {
-	return internal.GetActivityTaskList(ctx)
+// GetActivityTaskList returns tasklist in the Context's current ActivityOptions,
+// or workflow.GetInfo(ctx).TaskListName if not set or empty
+func GetActivityTaskList(ctx Context) string {
+	tl := internal.GetActivityTaskList(ctx)
+	if tl != nil && len(*tl) > 0 {
+		return *tl
+	}
+	return GetInfo(ctx).TaskListName
 }
 
 // WithScheduleToCloseTimeout makes a copy of the current context and update

--- a/workflow/activity_options.go
+++ b/workflow/activity_options.go
@@ -58,10 +58,10 @@ func WithTaskList(ctx Context, name string) Context {
 	return internal.WithTaskList(ctx, name)
 }
 
-// WithTaskListMapper makes a copy of current context and update the tasklist with mapper function.
-// Note this is the tasklist for activity tasklist. For workflow tasklist, use WithWorkflowTaskListMapper
-func WithTaskListMapper(ctx Context, mapper func(string) string) Context {
-	return internal.WithTaskListMapper(ctx, mapper)
+// GetActivityTaskList returns tasklist where activity should be started
+// if context is not an activity context then it will return nil
+func GetActivityTaskList(ctx Context) *string {
+	return internal.GetActivityTaskList(ctx)
 }
 
 // WithScheduleToCloseTimeout makes a copy of the current context and update

--- a/workflow/workflow_options.go
+++ b/workflow/workflow_options.go
@@ -43,10 +43,10 @@ func WithWorkflowTaskList(ctx Context, name string) Context {
 }
 
 // GetWorkflowTaskList returns a copy of Context with changed tasklist.
-// 		1. Activity context returns the current workflow tasklist
-//  	2. Child workflow context returns the child workflow tasklist
-//  	3. Workflow context will return current workflow tasklist
-//  	4. If Context is not a workflow context, it will return nil
+//  1. Activity context returns the current workflow tasklist
+//  2. Child workflow context returns the child workflow tasklist
+//  3. Workflow context will return current workflow tasklist
+//  4. If Context is not a workflow context, it will return nil
 func GetWorkflowTaskList(ctx Context) *string {
 	return internal.GetWorkflowTaskList(ctx)
 }

--- a/workflow/workflow_options.go
+++ b/workflow/workflow_options.go
@@ -43,10 +43,10 @@ func WithWorkflowTaskList(ctx Context, name string) Context {
 }
 
 // GetWorkflowTaskList returns tasklist in the Context's current ChildWorkflowOptions
-// or GetInfo(ctx).TaskListName if not set or empty.
+// or workflow.GetInfo(ctx).TaskListName if not set or empty.
 func GetWorkflowTaskList(ctx Context) string {
 	tl := internal.GetWorkflowTaskList(ctx)
-	if tl != nil && len(*tl) > 0 {
+	if tl != nil && *tl != "" {
 		return *tl
 	}
 	return GetInfo(ctx).TaskListName

--- a/workflow/workflow_options.go
+++ b/workflow/workflow_options.go
@@ -42,9 +42,13 @@ func WithWorkflowTaskList(ctx Context, name string) Context {
 	return internal.WithWorkflowTaskList(ctx, name)
 }
 
-// WithWorkflowTaskListMapper returns a copy of Context with changed tasklist
-func WithWorkflowTaskListMapper(ctx Context, mapper func(name string) string) Context {
-	return internal.WithWorkflowTaskListMapper(ctx, mapper)
+// GetWorkflowTaskList returns a copy of Context with changed tasklist
+// 1. Activity context returns the current workflow tasklist
+// 2. Child workflow context returns the child workflow tasklist
+// 3. Workflow context will return current workflow tasklist
+// 4. If Context is not a workflow context or activity context, it will return nil
+func GetWorkflowTaskList(ctx Context) *string {
+	return internal.GetWorkflowTaskList(ctx)
 }
 
 // WithWorkflowID adds a workflowID to the context.

--- a/workflow/workflow_options.go
+++ b/workflow/workflow_options.go
@@ -42,13 +42,14 @@ func WithWorkflowTaskList(ctx Context, name string) Context {
 	return internal.WithWorkflowTaskList(ctx, name)
 }
 
-// GetWorkflowTaskList returns a copy of Context with changed tasklist.
-//  1. Activity context returns the current workflow tasklist
-//  2. Child workflow context returns the child workflow tasklist
-//  3. Workflow context will return current workflow tasklist
-//  4. If Context is not a workflow context, it will return nil
-func GetWorkflowTaskList(ctx Context) *string {
-	return internal.GetWorkflowTaskList(ctx)
+// GetWorkflowTaskList returns tasklist in the Context's current ChildWorkflowOptions
+// or GetInfo(ctx).TaskListName if not set or empty.
+func GetWorkflowTaskList(ctx Context) string {
+	tl := internal.GetWorkflowTaskList(ctx)
+	if tl != nil && len(*tl) > 0 {
+		return *tl
+	}
+	return GetInfo(ctx).TaskListName
 }
 
 // WithWorkflowID adds a workflowID to the context.

--- a/workflow/workflow_options.go
+++ b/workflow/workflow_options.go
@@ -42,11 +42,11 @@ func WithWorkflowTaskList(ctx Context, name string) Context {
 	return internal.WithWorkflowTaskList(ctx, name)
 }
 
-// GetWorkflowTaskList returns a copy of Context with changed tasklist
-// 1. Activity context returns the current workflow tasklist
-// 2. Child workflow context returns the child workflow tasklist
-// 3. Workflow context will return current workflow tasklist
-// 4. If Context is not a workflow context or activity context, it will return nil
+// GetWorkflowTaskList returns a copy of Context with changed tasklist.
+// 		1. Activity context returns the current workflow tasklist
+//  	2. Child workflow context returns the child workflow tasklist
+//  	3. Workflow context will return current workflow tasklist
+//  	4. If Context is not a workflow context, it will return nil
 func GetWorkflowTaskList(ctx Context) *string {
 	return internal.GetWorkflowTaskList(ctx)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Remove With*Tasklist utils introduced in https://github.com/uber-go/cadence-client/pull/1286 
Instead, users should use the new Get*TaskList and With*TaskList APIs. 

For future as discussed with @Groxx, it's better to have a functional API to replace all "With*".

For example: 
`ExecuteChildWorkflow(ctx, type, child.Args(all, args), child.WorkflowID("asdf'))`

<!-- Tell your future self why have you made these changes -->
**Why?**
With**TaskList APIs are confusing and it's better to remove it

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
