### PR TITLE
Add `__query_types` query type

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -43,6 +43,10 @@ const (
 	// QueryTypeOpenSessions is the build in query type for Client.QueryWorkflow() call. Use this query type to get all open
 	// sessions in the workflow. The result will be a list of SessionInfo encoded in the encoded.Value.
 	QueryTypeOpenSessions string = internal.QueryTypeOpenSessions
+
+	// QueryTypeQueryTypes is the build in query type for Client.QueryWorkflow() call. Use this query type to list
+	// all query types of the workflow. The result will be a string encoded in the EncodedValue.
+	QueryTypeQueryTypes string = internal.QueryTypeQueryTypes
 )
 
 type (

--- a/internal/client.go
+++ b/internal/client.go
@@ -45,7 +45,20 @@ const (
 	// QueryTypeOpenSessions is the build in query type for Client.QueryWorkflow() call. Use this query type to get all open
 	// sessions in the workflow. The result will be a list of SessionInfo encoded in the EncodedValue.
 	QueryTypeOpenSessions string = "__open_sessions"
+
+	// QueryTypeQueryTypes is the build in query type for Client.QueryWorkflow() call. Use this query type to list
+	// all query types of the workflow. The result will be a string encoded in the EncodedValue.
+	QueryTypeQueryTypes string = "__query_types"
 )
+
+// BuiltinQueryTypes returns a list of built-in query types
+func BuiltinQueryTypes() []string {
+	return []string{
+		QueryTypeOpenSessions,
+		QueryTypeStackTrace,
+		QueryTypeQueryTypes,
+	}
+}
 
 type Option interface{ private() }
 

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -961,6 +961,8 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessQuery(queryType string, que
 		return weh.encodeArg(weh.StackTrace())
 	case QueryTypeOpenSessions:
 		return weh.encodeArg(weh.getOpenSessions())
+	case QueryTypeQueryTypes:
+		return weh.encodeArg(weh.KnownQueryTypes())
 	default:
 		result, err := weh.queryHandler(queryType, queryArgs)
 		if err != nil {
@@ -978,6 +980,10 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessQuery(queryType string, que
 
 		return result, nil
 	}
+}
+
+func (weh *workflowExecutionEventHandlerImpl) KnownQueryTypes() []string {
+	return weh.workflowDefinition.KnownQueryTypes()
 }
 
 func (weh *workflowExecutionEventHandlerImpl) StackTrace() string {

--- a/internal/internal_event_handlers_test.go
+++ b/internal/internal_event_handlers_test.go
@@ -382,3 +382,22 @@ func TestHistoryEstimationforPackedEvents(t *testing.T) {
 	trueSize := len(testEvents)*historySizeEstimationBuffer + len(byteArray)*2*len(testEvents)
 	assert.Equal(t, trueSize, historySizeSum)
 }
+
+func TestProcessQuery_KnownQueryTypes(t *testing.T) {
+	rootCtx := setWorkflowEnvOptionsIfNotExist(Background())
+	eo := getWorkflowEnvOptions(rootCtx)
+	eo.queryHandlers["a"] = nil
+
+	weh := &workflowExecutionEventHandlerImpl{
+		workflowEnvironmentImpl: &workflowEnvironmentImpl{
+			dataConverter: DefaultDataConverter,
+		},
+		workflowDefinition: &syncWorkflowDefinition{
+			rootCtx: rootCtx,
+		},
+	}
+
+	result, err := weh.ProcessQuery(QueryTypeQueryTypes, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "[\"__open_sessions\",\"__query_types\",\"__stack_trace\",\"a\"]\n", string(result))
+}

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -108,6 +108,9 @@ type (
 		// Executed after all history events since the previous decision are applied to workflowDefinition
 		OnDecisionTaskStarted()
 		StackTrace() string // Stack trace of all coroutines owned by the Dispatcher instance
+
+		// KnownQueryTypes returns a list of known query types of the workflowOptions with BuiltinQueryTypes
+		KnownQueryTypes() []string
 		Close()
 	}
 

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -1308,3 +1308,39 @@ func (t *tracingInterceptor) ExecuteWorkflow(ctx Context, workflowType string, a
 	t.trace = append(t.trace, "ExecuteWorkflow "+workflowType+" end")
 	return result
 }
+
+type WorkflowOptionTest struct {
+	suite.Suite
+}
+
+func TestWorkflowOption(t *testing.T) {
+	suite.Run(t, new(WorkflowOptionTest))
+}
+
+func (t *WorkflowOptionTest) TestKnowQueryType_NoHandlers() {
+	wo := workflowOptions{queryHandlers: make(map[string]func([]byte) ([]byte, error))}
+	t.ElementsMatch(
+		[]string{
+			QueryTypeStackTrace,
+			QueryTypeOpenSessions,
+			QueryTypeQueryTypes,
+		},
+		wo.KnownQueryTypes())
+}
+
+func (t *WorkflowOptionTest) TestKnowQueryType_WithHandlers() {
+	wo := workflowOptions{queryHandlers: map[string]func([]byte) ([]byte, error){
+		"a": nil,
+		"b": nil,
+	}}
+
+	t.ElementsMatch(
+		[]string{
+			QueryTypeStackTrace,
+			QueryTypeOpenSessions,
+			QueryTypeQueryTypes,
+			"a",
+			"b",
+		},
+		wo.KnownQueryTypes())
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

A new built-in query type `__query_type` has been added. A result of the processing of the query type must be an array of strings. The list must contain all built-in query types (included this one) and all custom query types of the workflow.


<!-- Tell your future self why have you made these changes -->
**Why?**
The changes are required to implement [the task](https://github.com/uber/cadence/issues/382), so it allows users to retrieve the list of available query types. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
The changes were tested locally. TestProcessQuery_KnownQueryTypes was added. 


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
There are no expected risks. The worst potential risk is the query functionality will not work. 
