### PR TITLE
Write coverage output to a static path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,6 +365,7 @@ unit_test: $(ALL_SRC) ## run all unit tests
 		go test "$$dir" $(TEST_ARG) -coverprofile=$(COVER_ROOT)/"$$dir"/cover.out || failed=1; \
 		cat $(COVER_ROOT)/"$$dir"/cover.out | grep -v "mode: atomic" >> $(UT_COVER_FILE); \
 	done; \
+	cat $(UT_COVER_FILE) > .build/cover.out;
 	exit $$failed
 
 integ_test_sticky_off: $(ALL_SRC)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Unit test coverage output is currently written to a file with potentially non-static path. e.g. `.build/go1.21.2_darwin_arm64/coverage/unit_test_cover.out`
Some 3rd party coverage reporting tools expects a static path to integrate. 
The change is to also write the coverage results to a predictable path `.build/cover.out`

<!-- Tell your future self why have you made these changes -->
**Why?**
To easily integrate with 3rd party coverage reporting tools.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
`make unit_test`
