### PR TITLE
downgrade thrift to backend compatible version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,3 +111,6 @@ retract (
 	v0.3.0 // Published accidentally
 	v0.2.0 // Published accidentally
 )
+
+// Cadence backend depends on older version of thrift, so we cannot use the latest version.
+replace github.com/apache/thrift => github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7

--- a/go.sum
+++ b/go.sum
@@ -11,9 +11,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
+github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7 h1:Fv9bK1Q+ly/ROk4aJsVMeuIwPel4bEnD8EPiI91nZMg=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/apache/thrift v0.16.0 h1:qEy6UW60iVOlUy+b9ZR0d5WzUWYGOo4HfopoyBaNmoY=
-github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/internal/common/thrift_util.go
+++ b/internal/common/thrift_util.go
@@ -29,7 +29,7 @@ import (
 
 // TSerialize is used to serialize thrift TStruct to []byte
 func TSerialize(ctx context.Context, t thrift.TStruct) (b []byte, err error) {
-	return thrift.NewTSerializer().Write(ctx, t)
+	return thrift.NewTSerializer().Write(t)
 }
 
 // TListSerialize is used to serialize list of thrift TStruct to []byte
@@ -43,21 +43,19 @@ func TListSerialize(ts []thrift.TStruct) (b []byte, err error) {
 
 	// NOTE: we don't write any markers as thrift by design being a streaming protocol doesn't
 	// recommend writing length.
-
-	// TODO populate context from argument
-	ctx := context.Background()
+	
 	for _, v := range ts {
-		if e := v.Write(ctx, t.Protocol); e != nil {
+		if e := v.Write(t.Protocol); e != nil {
 			err = thrift.PrependError("error writing TStruct: ", e)
 			return
 		}
 	}
 
-	if err = t.Protocol.Flush(ctx); err != nil {
+	if err = t.Protocol.Flush(); err != nil {
 		return
 	}
 
-	if err = t.Transport.Flush(ctx); err != nil {
+	if err = t.Transport.Flush(); err != nil {
 		return
 	}
 
@@ -67,7 +65,7 @@ func TListSerialize(ts []thrift.TStruct) (b []byte, err error) {
 
 // TDeserialize is used to deserialize []byte to thrift TStruct
 func TDeserialize(ctx context.Context, t thrift.TStruct, b []byte) (err error) {
-	return thrift.NewTDeserializer().Read(ctx, t, b)
+	return thrift.NewTDeserializer().Read(t, b)
 }
 
 // TListDeserialize is used to deserialize []byte to list of thrift TStruct
@@ -78,10 +76,8 @@ func TListDeserialize(ts []thrift.TStruct, b []byte) (err error) {
 		return
 	}
 
-	// TODO populate context from argument
-	ctx := context.Background()
 	for i := 0; i < len(ts); i++ {
-		if e := ts[i].Read(ctx, t.Protocol); e != nil {
+		if e := ts[i].Read(t.Protocol); e != nil {
 			err = thrift.PrependError("error reading TStruct: ", e)
 			return
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I downgraded apache/thrfit version to the version compatible on the Cadence backend.

<!-- Tell your future self why have you made these changes -->
**Why?**
Cadence backend uses client to run internal operations, so client should be compatible with the backend.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests/integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Potential failures for customers using up to date thrift version.
