### PR TITLE
[cadence/debug] Expose method to get default worker options

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -971,7 +971,7 @@ func newAggregatedWorker(
 	taskList string,
 	options WorkerOptions,
 ) (worker *aggregatedWorker) {
-	wOptions := augmentWorkerOptions(options)
+	wOptions := AugmentWorkerOptions(options)
 	ctx := wOptions.BackgroundActivityContext
 	if ctx == nil {
 		ctx = context.Background()
@@ -1192,7 +1192,7 @@ func getReadOnlyChannel(c chan struct{}) <-chan struct{} {
 	return c
 }
 
-func augmentWorkerOptions(options WorkerOptions) WorkerOptions {
+func AugmentWorkerOptions(options WorkerOptions) WorkerOptions {
 	if options.MaxConcurrentActivityExecutionSize == 0 {
 		options.MaxConcurrentActivityExecutionSize = defaultMaxConcurrentActivityExecutionSize
 	}

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1360,7 +1360,7 @@ func Test_augmentWorkerOptions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, augmentWorkerOptions(tt.args.options), "augmentWorkerOptions(%v)", tt.args.options)
+			assert.Equalf(t, tt.want, AugmentWorkerOptions(tt.args.options), "AugmentWorkerOptions(%v)", tt.args.options)
 		})
 	}
 }

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -169,7 +169,7 @@ func (s *WorkersTestSuite) TestActivityWorkerStop() {
 	ctx, cancel := context.WithCancel(context.Background())
 	executionParameters := workerExecutionParameters{
 		TaskList: "testTaskList",
-		WorkerOptions: augmentWorkerOptions(
+		WorkerOptions: AugmentWorkerOptions(
 			WorkerOptions{
 				MaxConcurrentActivityTaskPollers:   5,
 				MaxConcurrentActivityExecutionSize: 2,

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1175,7 +1175,7 @@ func getRetryBackoffFromThriftRetryPolicy(tp *shared.RetryPolicy, attempt int32,
 
 func (env *testWorkflowEnvironmentImpl) ExecuteLocalActivity(params executeLocalActivityParams, callback laResultHandler) *localActivityInfo {
 	activityID := getStringID(env.nextID())
-	wOptions := augmentWorkerOptions(env.workerOptions)
+	wOptions := AugmentWorkerOptions(env.workerOptions)
 	ae := &activityExecutor{name: getActivityFunctionName(env.registry, params.ActivityFn), fn: params.ActivityFn}
 	if at, _ := getValidatedActivityFunction(params.ActivityFn, params.InputArgs, env.registry); at != nil {
 		// local activity could be registered, if so use the registered name. This name is only used to find a mock.
@@ -1623,7 +1623,7 @@ func (m *mockWrapper) executeMockWithActualArgs(ctx interface{}, inputArgs []int
 }
 
 func (env *testWorkflowEnvironmentImpl) newTestActivityTaskHandler(taskList string, dataConverter DataConverter) ActivityTaskHandler {
-	wOptions := augmentWorkerOptions(env.workerOptions)
+	wOptions := AugmentWorkerOptions(env.workerOptions)
 	wOptions.DataConverter = dataConverter
 	params := workerExecutionParameters{
 		WorkerOptions:     wOptions,

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -356,3 +356,9 @@ func SetBinaryChecksum(checksum string) {
 func NewAdminJwtAuthorizationProvider(privateKey []byte) AuthorizationProvider {
 	return internal.NewAdminJwtAuthorizationProvider(privateKey)
 }
+
+// AugmentWorkerOptions fill all unset worker Options fields with their default values
+// Use as getter for default worker options
+func AugmentWorkerOptions(options Options) Options {
+	return internal.AugmentWorkerOptions(options)
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Exporting an existing function

<!-- Tell your future self why have you made these changes -->
**Why?**
Users may need to get default values for worker options fields (e.g: internal Debug feature at Uber) however they are currently internal and do not have getter methods.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local tests
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Since this is now exposed to users, it might present risks if this API is changed in the future without backward compatibility