### PR TITLE
Revert breaking changes in v1.2.8

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -362,7 +362,6 @@ func (env *testWorkflowEnvironmentImpl) newTestWorkflowEnvironmentForChild(param
 	childEnv.startedHandler = startedHandler
 	childEnv.testWorkflowEnvironmentShared = env.testWorkflowEnvironmentShared
 	childEnv.workerOptions = env.workerOptions
-	childEnv.workflowInterceptors = env.workflowInterceptors
 	childEnv.workerOptions.DataConverter = params.dataConverter
 	childEnv.workflowInterceptors = env.workflowInterceptors
 	childEnv.registry = env.registry

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -240,8 +240,8 @@ func (t *TestWorkflowEnvironment) OnActivity(activity interface{}, args ...inter
 			panic(err)
 		}
 		fnName := getActivityFunctionName(t.impl.registry, activity)
-		t.impl.registry.RegisterActivityWithOptions(activity, RegisterActivityOptions{DisableAlreadyRegisteredCheck: true})
 		call = t.Mock.On(fnName, args...)
+
 	case reflect.String:
 		call = t.Mock.On(activity.(string), args...)
 	default:
@@ -289,12 +289,11 @@ func (t *TestWorkflowEnvironment) OnWorkflow(workflow interface{}, args ...inter
 		if alias, ok := t.impl.registry.getWorkflowAlias(fnName); ok {
 			fnName = alias
 		}
-		t.impl.registry.RegisterWorkflowWithOptions(workflow, RegisterWorkflowOptions{DisableAlreadyRegisteredCheck: true})
 		call = t.Mock.On(fnName, args...)
 	case reflect.String:
 		call = t.Mock.On(workflow.(string), args...)
 	default:
-		panic("workflow must be function or string")
+		panic("activity must be function or string")
 	}
 
 	return t.wrapCall(call)

--- a/internal/workflow_testsuite_test.go
+++ b/internal/workflow_testsuite_test.go
@@ -23,7 +23,6 @@ package internal
 
 import (
 	"context"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"strings"
 	"testing"
@@ -130,53 +129,6 @@ func TestWorkflowReturnNil(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func HelloWorkflow(ctx Context, name string) (string, error) {
-	ctx = WithActivityOptions(ctx, ActivityOptions{
-		ScheduleToCloseTimeout: time.Hour,
-		StartToCloseTimeout:    time.Hour,
-		ScheduleToStartTimeout: time.Hour,
-	})
-	var result string
-	err := ExecuteActivity(ctx, HelloActivity, name).Get(ctx, &result)
-	return result, err
-}
-
-func HelloActivity(ctx context.Context, name string) (string, error) {
-	return "Hello " + name + "!", nil
-}
-
-func TestWorkflowMockingWithoutRegistration(t *testing.T) {
-	testSuite := &WorkflowTestSuite{}
-	env := testSuite.NewTestWorkflowEnvironment()
-	env.OnWorkflow(HelloWorkflow, mock.Anything, mock.Anything).Return(
-		func(ctx Context, person string) (string, error) {
-			return "Hello " + person + "!", nil
-		})
-	// Workflow is mocked, no activity registration required
-	env.ExecuteWorkflow(HelloWorkflow, "Cadence")
-	require.NoError(t, env.GetWorkflowError())
-	var result string
-	err := env.GetWorkflowResult(&result)
-	require.NoError(t, err)
-	require.Equal(t, "Hello Cadence!", result)
-}
-
-func TestActivityMockingWithoutRegistration(t *testing.T) {
-	testSuite := &WorkflowTestSuite{}
-	env := testSuite.NewTestWorkflowEnvironment()
-	env.OnActivity(HelloActivity, mock.Anything, mock.Anything).Return(
-		func(ctx context.Context, person string) (string, error) {
-			return "Goodbye " + person + "!", nil
-		})
-	// Registration of activity not required
-	env.RegisterWorkflow(HelloWorkflow)
-	env.ExecuteWorkflow(HelloWorkflow, "Cadence")
-	require.NoError(t, env.GetWorkflowError())
-	var result string
-	err := env.GetWorkflowResult(&result)
-	require.NoError(t, err)
-	require.Equal(t, "Goodbye Cadence!", result)
-  
 type InterceptorTestSuite struct {
 	suite.Suite
 	WorkflowTestSuite


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Reverting the 2 commits below in this order:
https://github.com/uber-go/cadence-client/pull/1256
https://github.com/uber-go/cadence-client/pull/1257

<!-- Tell your future self why have you made these changes -->
**Why?**
At least one of these commits caused unit test failures for Uber internal cadence users

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
