### PR TITLE
Fix coverage metadata commit info

### DIFF
--- a/.buildkite/scripts/gen_coverage_metadata.sh
+++ b/.buildkite/scripts/gen_coverage_metadata.sh
@@ -15,10 +15,10 @@ set -ex
 
 output_path="$1"
 
-# if [ "$BUILDKITE_BRANCH" != "master" ] && [ "$BUILDKITE_BRANCH" != "origin/master" ]; then
-#   echo "Coverage metadata is only generated for master branch. Current branch: $BUILDKITE_BRANCH"
-#   exit 0
-# fi
+if [ "$BUILDKITE_BRANCH" != "master" ] && [ "$BUILDKITE_BRANCH" != "origin/master" ]; then
+  echo "Coverage metadata is only generated for master branch. Current branch: $BUILDKITE_BRANCH"
+  exit 0
+fi
 
 if [ -z "$BUILDKITE_COMMIT" ]; then
   echo "BUILDKITE_COMMIT is not set"

--- a/.buildkite/scripts/gen_coverage_metadata.sh
+++ b/.buildkite/scripts/gen_coverage_metadata.sh
@@ -15,10 +15,10 @@ set -ex
 
 output_path="$1"
 
-if [ "$BUILDKITE_BRANCH" != "master" ]; then
-  echo "Coverage metadata is only generated for master branch. Current branch: $BUILDKITE_BRANCH"
-  exit 0
-fi
+# if [ "$BUILDKITE_BRANCH" != "master" ] && [ "$BUILDKITE_BRANCH" != "origin/master" ]; then
+#   echo "Coverage metadata is only generated for master branch. Current branch: $BUILDKITE_BRANCH"
+#   exit 0
+# fi
 
 if [ -z "$BUILDKITE_COMMIT" ]; then
   echo "BUILDKITE_COMMIT is not set"

--- a/.buildkite/scripts/gen_coverage_metadata.sh
+++ b/.buildkite/scripts/gen_coverage_metadata.sh
@@ -9,9 +9,23 @@ set -ex
 #   commit-sha: 6953daa563e8e44512bc349c9608484cfd4ec4ff
 #   timestamp: 2024-03-04T19:29:16Z
 
+# Required env variables:
+# - BUILDKITE_BRANCH
+# - BUILDKITE_COMMIT
+
 output_path="$1"
 
-echo "commit-sha: $(git rev-parse HEAD)" > "$output_path"
+if [ "$BUILDKITE_BRANCH" != "master" ]; then
+  echo "Coverage metadata is only generated for master branch. Current branch: $BUILDKITE_BRANCH"
+  exit 0
+fi
+
+if [ -z "$BUILDKITE_COMMIT" ]; then
+  echo "BUILDKITE_COMMIT is not set"
+  exit 1
+fi
+
+echo "commit-sha: $BUILDKITE_COMMIT" > "$output_path"
 echo "timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$output_path"
 
 echo "Coverage metadata written to $output_path"

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -81,6 +81,8 @@ services:
       dockerfile: ./docker/buildkite/Dockerfile
     environment:
       - "GO111MODULE=on"
+      - BUILDKITE_BRANCH
+      - BUILDKITE_COMMIT
     volumes:
       - ../../:/go/src/go.uber.org/cadence
     networks:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Coverage metadata file generated by unit-test CI job was missing commit information

```
commit-sha: 
timestamp: 2024-03-15T18:37:21Z
```

Switching to buildkite env vars to retrieve commit information.

<!-- Tell your future self why have you made these changes -->
**Why?**
The `.build/metadata.txt` file contains commit sha and timestamp of the corresponding `.build/cover.out` file. This is used to integrate with 3rd party coverage tools such as Sonarqube.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran the script locally by setting buildkite env vars.
Will check how it does on master CI run after merge.
