### PR TITLE
Enforce 85% new line coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,7 +19,10 @@ coverage:
         if_ci_failed: ignore   # require the CI to pass before setting the status
     patch:
       default:
-        informational: true
+        target: 85%            # specify the target coverage for each commit status
+                               #   option: "auto" (compare against parent commit or pull request base)
+                               #   option: "X%" a static target percentage to hit
+        threshold: 0%          # allow the coverage drop by x% before marking as failure
 comment:
   layout: "header, files, footer"
   hide_project_coverage: false


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Updating codecov's `patch` setting to enforce new line coverage is above 85%.
Similar to what we have on Cadence repo: https://github.com/uber/cadence/pull/5805 