### PR TITLE
Migrate CI from AWS queues to Google Kubernetes Engine queues

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,4 @@
+# `yq 'explode(.)' .buildkite/pipeline.yml` to view expanded anchors/aliases
 container:
   kubernetes: &kubernetes
     gitEnvFrom:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,81 +1,137 @@
+container:
+  kubernetes: &kubernetes
+    gitEnvFrom:
+      - secretRef:
+          name: oss-github-ssh-credentials
+    sidecars:
+    - image: us-west1-docker.pkg.dev/ci-compute/buildkite-images/buildkite-dind:v1
+      volumeMounts:
+        - mountPath: /var/run/
+          name: docker-sock
+      securityContext:
+        privileged: true
+        allowPrivilegeEscalation: true
+    mirrorVolumeMounts: true # CRITICAL: this must be at the same indentation level as sidecars
+    podSpec: &podSpec
+      containers:
+        - &commandContainer
+          image: us-west1-docker.pkg.dev/ci-compute/buildkite-images/buildkite-command-container:v2
+          command:
+          - |-
+            echo "Command step was not overridden."
+            exit 1
+          volumeMounts:
+            - mountPath: /var/run/
+              name: docker-sock
+          resources:
+            requests:
+              cpu: 7500m
+              memory: 28G
+      volumes:
+      - name: docker-sock
+        emptyDir: {}
+
+agents:
+  queue: "buildkite-gcp"
 steps:
   - label: "fossa analyze"
-    agents:
-      queue: "init"
-      docker: "*"
     command: ".buildkite/scripts/fossa.sh"
 
   - label: ":golang: unit-test"
-    agents:
-      queue: "workers"
-      docker: "*"
-    commands:
-      - "make unit_test"
-      - ".buildkite/scripts/gen_coverage_metadata.sh .build/metadata.txt"
     artifact_paths:
       - ".build/*/coverage/*.out"
       - ".build/cover.out"
       - ".build/metadata.txt"
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  make unit_test
+                  .buildkite/scripts/gen_coverage_metadata.sh .build/metadata.txt
       - docker-compose#v3.0.0:
           run: unit-test
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golangci-lint: validate code is clean"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "./scripts/golint.sh"
     artifact_paths: [ ]
     retry:
       automatic:
-        limit: 1
+        limit: 2
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  ./scripts/golint.sh
       - docker-compose#v3.0.0:
           run: unit-test
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golang: integration-test-sticky-off"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "make integ_test_sticky_off"
     artifact_paths:
       - ".build/*/coverage/*.out"
     retry:
       automatic:
-        limit: 1
+        limit: 2
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  make integ_test_sticky_off
       - docker-compose#v3.0.0:
           run: integ-test
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golang: integration-test-sticky-on"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "make integ_test_sticky_on"
     artifact_paths:
       - ".build/*/coverage/*.out"
     retry:
       automatic:
-        limit: 1
+        limit: 2
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  make integ_test_sticky_on
       - docker-compose#v3.0.0:
           run: integ-test
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golang: integration-test-grpc-adapter"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "make integ_test_grpc"
     artifact_paths:
       - ".build/*/coverage/*.out"
     retry:
       automatic:
-        limit: 1
+        limit: 2
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  make integ_test_grpc
       - docker-compose#v3.0.0:
           run: integ-test-grpc
           config: docker/buildkite/docker-compose.yml
@@ -83,11 +139,16 @@ steps:
   - wait
 
   - label: ":golang: code-coverage"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: ".buildkite/scripts/gocov.sh"
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  .buildkite/scripts/gocov.sh
       - docker-compose#v3.0.0:
           run: coverage-report
           config: docker/buildkite/docker-compose.yml

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -9,17 +9,12 @@ ADD go.mod go.sum /go/src/go.uber.org/cadence/
 RUN git config --global --add safe.directory /go/src/go.uber.org/cadence
 RUN GO111MODULE=on go mod download
 
-# Install dependencies needed to install buildkite-agent
+# Install Buildkite agent
+# https://buildkite.com/docs/agent/v3/ubuntu
 RUN apt-get install -y apt-transport-https dirmngr curl
-
-# Add Buildkite's GPG key
 RUN curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | \
   gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
-
-# Add the repository to Apt sources
 RUN echo \
   "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | \
   tee /etc/apt/sources.list.d/buildkite-agent.list
-
-# Install Buildkite agent
 RUN apt-get update && apt-get install -yy --no-install-recommends buildkite-agent

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -8,3 +8,18 @@ ADD go.mod go.sum /go/src/go.uber.org/cadence/
 # allow git-status and similar to work
 RUN git config --global --add safe.directory /go/src/go.uber.org/cadence
 RUN GO111MODULE=on go mod download
+
+# Install dependencies needed to install buildkite-agent
+RUN apt-get install -y apt-transport-https dirmngr curl
+
+# Add Buildkite's GPG key
+RUN curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | \
+  gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
+
+# Add the repository to Apt sources
+RUN echo \
+  "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | \
+  tee /etc/apt/sources.list.d/buildkite-agent.list
+
+# Install Buildkite agent
+RUN apt-get update && apt-get install -yy --no-install-recommends buildkite-agent

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -116,7 +116,6 @@ services:
       - "GO111MODULE=on"
     volumes:
       - ../../:/go/src/go.uber.org/cadence
-      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
 
 networks:
   services-network:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Update Buildkite pipeline yaml to work with the newly provisioned queues in Google Kubernetes Engine
- Use [agent-stack-k8s v0.8.0 helm chart](https://github.com/buildkite/agent-stack-k8s/tree/v0.8.0?tab=readme-ov-file#cloning-repos-via-ssh) which has its own expected pipeline yaml syntax in order to successfully onboard. 
- Install buildkite-agent in Dockerfile for use in the code coverage step
  - The mount that previously worked in AWS's VM based infra doesn't work in Kubernete's container based set up. Install the cli directly for simplicity. 

<!-- Tell your future self why have you made these changes -->
**Why?**
- There is a company mandate to evacuate Uber's AWS CI footprint. The go forward decision is to use Google Cloud. Buildkite Enterprise recommends GKE (as opposed to GCP) as the way to have a queue with autoscaling compute. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- https://buildkite.com/uberopensource/cadence-go-client/builds/2175

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- CI builds will be broken or flaky
- Can be mitigated by a git revert
