### PR TITLE
Documentation fix in MinConcurrentDecisionTaskPollers

### DIFF
--- a/internal/worker.go
+++ b/internal/worker.go
@@ -104,7 +104,7 @@ type (
 		MaxConcurrentDecisionTaskPollers int
 
 		// optional: Sets the minimum number of goroutines that will concurrently poll the
-		// cadence-server to retrieve decision tasks. If FeatureFlags.PollerAutoScalerEnabled is set to true,
+		// cadence-server to retrieve decision tasks. Unless FeatureFlags.PollerAutoScalerEnabled is set to true,
 		// changing this value will NOT affect the rate at which the worker is able to consume tasks from a task list.
 		// Default value is 1
 		MinConcurrentDecisionTaskPollers int


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Have changed the description of MinConcurrentDecisionTaskPollers.

<!-- Tell your future self why have you made these changes -->
**Why?**
It was giving the opposite meaning of what it was supposed to give. It was depicted that changing this value would not take effect if PollerAutoScaler is set to true, but it was supposed to be the opposite.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Just a documentation change

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None
