### PR TITLE
Fixing unit_test failure detection, and tests for data converters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,14 +375,13 @@ test: unit_test integ_test_sticky_off integ_test_sticky_on ## run all tests (req
 unit_test: $(ALL_SRC) ## run all unit tests
 	$Q mkdir -p $(COVER_ROOT)
 	$Q echo "mode: atomic" > $(UT_COVER_FILE)
-	$Q failed=0; \
+	$Q FAIL=""; \
 	for dir in $(UT_DIRS); do \
 		mkdir -p $(COVER_ROOT)/"$$dir"; \
-		go test "$$dir" $(TEST_ARG) -coverprofile=$(COVER_ROOT)/"$$dir"/cover.out || failed=1; \
+		go test "$$dir" $(TEST_ARG) -coverprofile=$(COVER_ROOT)/"$$dir"/cover.out || FAIL="$$FAIL $$dir"; \
 		cat $(COVER_ROOT)/"$$dir"/cover.out | grep -v "mode: atomic" >> $(UT_COVER_FILE); \
-	done; \
+	done; test -z "$$FAIL" || (echo "Failed packages; $$FAIL"; exit 1)
 	cat $(UT_COVER_FILE) > .build/cover.out;
-	exit $$failed
 
 integ_test_sticky_off: $(ALL_SRC)
 	$Q mkdir -p $(COVER_ROOT)


### PR DESCRIPTION
Apparently these also failed on the original PR, but due to missing a `\` in #1303 it wasn't failing in CI because the env var was gone by the time `exit` ran.
I should really take that as a hint to finally rewrite that chunk of the makefile, so it just does a normal `go test ./...` :\  but not today.

Thankfully this seems to be the only set of tests that snuck past, and they were just incorrect.
I'm not sure why I apparently didn't run them or something while writing them in #1331 but it seems pretty clear I didn't since the old pre-merge SHA fails too.  Bleh.

---

To correct the tests' original flaws:
1. memos *are* supposed to be encoded by custom dataconverters, and they are.  we don't search them so they're not JSON like search attrs are, they're just blobs we expose in list APIs (and in workflow metadata).
2. `Equal(string, []byte)` just doesn't work, and the default dataconverter adds a trailing newline to separate args.
3. the `[]byte`-heavy copypasta meant the Input-checking tests were odd, so I changed them, and fixed the args to the dataconverter.  Internally we splat the args in here, so it's not `[]interface{..}`-packed: https://github.com/uber-go/cadence-client/blob/6decfc78571a9d91d943815ae3a445a3bc115fa8/internal/internal_worker.go#L573-L579