### PR TITLE
Partial fix for Continue as new case

### DIFF
--- a/internal/workflow_replayer.go
+++ b/internal/workflow_replayer.go
@@ -339,10 +339,13 @@ func (r *WorkflowReplayer) replayWorkflowHistory(
 		return err
 	}
 
-	if last.GetEventType() != shared.EventTypeWorkflowExecutionCompleted && last.GetEventType() != shared.EventTypeWorkflowExecutionContinuedAsNew {
+	//if last.GetEventType() != shared.EventTypeWorkflowExecutionCompleted && last.GetEventType() != shared.EventTypeWorkflowExecutionContinuedAsNew {
+	//	return nil
+	//}
+	//Technically speaking we do not need extra validations for the continue as new cases as they are equivalent to that case getting completed.
+	if last.GetEventType() != shared.EventTypeWorkflowExecutionCompleted {
 		return nil
 	}
-
 	// TODO: the following result will not be executed if nextPageToken is not nil, which is probably fine as the actual workflow task
 	// processing logic does not have such check. If we want to always execute this check for closed workflows, we need to dump the
 	// entire history before starting the replay as otherwise we can't get the last event here.
@@ -351,14 +354,14 @@ func (r *WorkflowReplayer) replayWorkflowHistory(
 		completeReq, ok := resp.(*shared.RespondDecisionTaskCompletedRequest)
 		if ok {
 			for _, d := range completeReq.Decisions {
-				if d.GetDecisionType() == shared.DecisionTypeContinueAsNewWorkflowExecution &&
-					last.GetEventType() == shared.EventTypeWorkflowExecutionContinuedAsNew {
-					inputA := d.ContinueAsNewWorkflowExecutionDecisionAttributes.Input
-					inputB := last.WorkflowExecutionContinuedAsNewEventAttributes.Input
-					if bytes.Compare(inputA, inputB) == 0 {
-						return nil
-					}
-				}
+				//if d.GetDecisionType() == shared.DecisionTypeContinueAsNewWorkflowExecution &&
+				//	last.GetEventType() == shared.EventTypeWorkflowExecutionContinuedAsNew {
+				//	inputA := d.ContinueAsNewWorkflowExecutionDecisionAttributes.Input
+				//	inputB := last.WorkflowExecutionContinuedAsNewEventAttributes.Input
+				//	if bytes.Compare(inputA, inputB) == 0 {
+				//		return nil
+				//	}
+				//}
 				if d.GetDecisionType() == shared.DecisionTypeCompleteWorkflowExecution &&
 					last.GetEventType() == shared.EventTypeWorkflowExecutionCompleted {
 					resultA := last.WorkflowExecutionCompletedEventAttributes.Result
@@ -366,13 +369,6 @@ func (r *WorkflowReplayer) replayWorkflowHistory(
 					if bytes.Compare(resultA, resultB) == 0 {
 						return nil
 					}
-				}
-				if d.GetDecisionType() == shared.DecisionTypeCompleteWorkflowExecution &&
-					last.GetEventType() == shared.EventTypeWorkflowExecutionContinuedAsNew {
-					// for cron and retry workflow, decision will be completed workflow and
-					// and server side will convert it to a continue as new event.
-					// there's nothing to compare here
-					return nil
 				}
 			}
 		}

--- a/internal/workflow_replayer.go
+++ b/internal/workflow_replayer.go
@@ -339,9 +339,6 @@ func (r *WorkflowReplayer) replayWorkflowHistory(
 		return err
 	}
 
-	//if last.GetEventType() != shared.EventTypeWorkflowExecutionCompleted && last.GetEventType() != shared.EventTypeWorkflowExecutionContinuedAsNew {
-	//	return nil
-	//}
 	//Technically speaking we do not need extra validations for the continue as new cases as they are equivalent to that case getting completed.
 	if last.GetEventType() != shared.EventTypeWorkflowExecutionCompleted {
 		return nil
@@ -354,14 +351,6 @@ func (r *WorkflowReplayer) replayWorkflowHistory(
 		completeReq, ok := resp.(*shared.RespondDecisionTaskCompletedRequest)
 		if ok {
 			for _, d := range completeReq.Decisions {
-				//if d.GetDecisionType() == shared.DecisionTypeContinueAsNewWorkflowExecution &&
-				//	last.GetEventType() == shared.EventTypeWorkflowExecutionContinuedAsNew {
-				//	inputA := d.ContinueAsNewWorkflowExecutionDecisionAttributes.Input
-				//	inputB := last.WorkflowExecutionContinuedAsNewEventAttributes.Input
-				//	if bytes.Compare(inputA, inputB) == 0 {
-				//		return nil
-				//	}
-				//}
 				if d.GetDecisionType() == shared.DecisionTypeCompleteWorkflowExecution &&
 					last.GetEventType() == shared.EventTypeWorkflowExecutionCompleted {
 					resultA := last.WorkflowExecutionCompletedEventAttributes.Result


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Removed the additional checks for the cases where the workflows continued as new. The check sometimes clashes with the completed status and there is no point in matching the inputs to this granularity if a wf continues as new and a workflows completed are almost similar. If there was a  timeout failure in the workflow it would be before it continued as new and it makes no sense to match it.

In another scenario, the identification of the last event is not reliable. `last := events[len(events)-1]`
So in case of an early return or when the events have something else going on you don't actually get the real last event. if this is not reliable then we would be doing the checks unnecessarily.

<!-- Tell your future self why have you made these changes -->
**Why?**
In an attempt to fix the false negtaives thrown by the replayer in continue as new cases.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
more false negatives.