### PR TITLE
Extracting domain client to a separate file

### DIFF
--- a/internal/internal_domain_client.go
+++ b/internal/internal_domain_client.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Portions of the Software are attributed to Copyright (c) 2020 Temporal Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"context"
+
+	"github.com/uber-go/tally"
+
+	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
+	s "go.uber.org/cadence/.gen/go/shared"
+	"go.uber.org/cadence/internal/common"
+)
+
+// Assert that structs do indeed implement the interfaces
+var _ DomainClient = (*domainClient)(nil)
+
+// domainClient is the client for managing domains.
+type domainClient struct {
+	workflowService workflowserviceclient.Interface
+	metricsScope    tally.Scope
+	identity        string
+	featureFlags    FeatureFlags
+}
+
+// Register a domain with cadence server
+// The errors it can throw:
+//   - DomainAlreadyExistsError
+//   - BadRequestError
+//   - InternalServiceError
+func (dc *domainClient) Register(ctx context.Context, request *s.RegisterDomainRequest) error {
+	return retryWhileTransientError(
+		ctx,
+		func() error {
+			tchCtx, cancel, opt := newChannelContext(ctx, dc.featureFlags)
+			defer cancel()
+			return dc.workflowService.RegisterDomain(tchCtx, request, opt...)
+		},
+	)
+}
+
+// Describe a domain. The domain has 3 part of information
+// DomainInfo - Which has Name, Status, Description, Owner Email
+// DomainConfiguration - Configuration like Workflow Execution Retention Period In Days, Whether to emit metrics.
+// ReplicationConfiguration - replication config like clusters and active cluster name
+// The errors it can throw:
+//   - EntityNotExistsError
+//   - BadRequestError
+//   - InternalServiceError
+func (dc *domainClient) Describe(ctx context.Context, name string) (*s.DescribeDomainResponse, error) {
+	request := &s.DescribeDomainRequest{
+		Name: common.StringPtr(name),
+	}
+
+	var response *s.DescribeDomainResponse
+	err := retryWhileTransientError(
+		ctx,
+		func() error {
+			tchCtx, cancel, opt := newChannelContext(ctx, dc.featureFlags)
+			defer cancel()
+			var err error
+			response, err = dc.workflowService.DescribeDomain(tchCtx, request, opt...)
+			return err
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// Update a domain.
+// The errors it can throw:
+//   - EntityNotExistsError
+//   - BadRequestError
+//   - InternalServiceError
+func (dc *domainClient) Update(ctx context.Context, request *s.UpdateDomainRequest) error {
+	return retryWhileTransientError(
+		ctx,
+		func() error {
+			tchCtx, cancel, opt := newChannelContext(ctx, dc.featureFlags)
+			defer cancel()
+			_, err := dc.workflowService.UpdateDomain(tchCtx, request, opt...)
+			return err
+		},
+	)
+}

--- a/internal/internal_domain_client_test.go
+++ b/internal/internal_domain_client_test.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Portions of the Software are attributed to Copyright (c) 2020 Temporal Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc"
+
+	"go.uber.org/cadence/.gen/go/cadence/workflowservicetest"
+	s "go.uber.org/cadence/.gen/go/shared"
+	"go.uber.org/cadence/internal/common"
+	"go.uber.org/cadence/internal/common/metrics"
+)
+
+type domainClientTestData struct {
+	dc                  DomainClient
+	mockWorkflowService *workflowservicetest.MockClient
+}
+
+func newDomainClientTestData(t *testing.T) *domainClientTestData {
+	var td domainClientTestData
+	ctrl := gomock.NewController(t)
+
+	metricsScope := metrics.NewTaggedScope(nil)
+
+	td.mockWorkflowService = workflowservicetest.NewMockClient(ctrl)
+	td.dc = NewDomainClient(
+		td.mockWorkflowService,
+		&ClientOptions{
+			MetricsScope: metricsScope,
+			Identity:     identity,
+		},
+	)
+
+	return &td
+}
+
+func TestRegisterDomain(t *testing.T) {
+	testcases := []struct {
+		name     string
+		rpcError error
+	}{
+		{
+			name:     "success",
+			rpcError: nil,
+		},
+		{
+			name:     "failure",
+			rpcError: &s.AccessDeniedError{},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			td := newDomainClientTestData(t)
+			request := &s.RegisterDomainRequest{
+				Name: common.StringPtr(testDomain),
+			}
+
+			td.mockWorkflowService.EXPECT().
+				RegisterDomain(gomock.Any(), request, gomock.Any()).
+				Return(tt.rpcError)
+
+			err := td.dc.Register(context.Background(), request)
+			assert.Equal(t, tt.rpcError, err, "error should be returned as-is")
+		})
+	}
+}
+
+func TestDescribeDomain(t *testing.T) {
+	testcases := []struct {
+		name     string
+		rpcError error
+		response *s.DescribeDomainResponse
+	}{
+		{
+			name:     "success",
+			rpcError: nil,
+			response: &s.DescribeDomainResponse{},
+		},
+		{
+			name:     "failure",
+			rpcError: &s.AccessDeniedError{},
+			response: nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			td := newDomainClientTestData(t)
+
+			td.mockWorkflowService.EXPECT().
+				DescribeDomain(gomock.Any(), gomock.Any(), gomock.Any()).
+				Do(
+					func(ctx context.Context, req *s.DescribeDomainRequest, opts ...yarpc.CallOption) {
+						// request also can contain other fields like UUID
+						//   so compare a single, most important field explicitly
+						assert.Equal(t, testDomain, *req.Name)
+					},
+				).
+				Return(tt.response, tt.rpcError)
+
+			r, err := td.dc.Describe(context.Background(), testDomain)
+			assert.Equal(t, tt.rpcError, err, "error should be returned as-is")
+			assert.Equal(t, tt.response, r)
+		})
+	}
+}
+
+func TestUpdateDomain(t *testing.T) {
+	testcases := []struct {
+		name     string
+		rpcError error
+	}{
+		{
+			name:     "success",
+			rpcError: nil,
+		},
+		{
+			name:     "failure",
+			rpcError: &s.AccessDeniedError{},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			td := newDomainClientTestData(t)
+			request := &s.UpdateDomainRequest{
+				Name: common.StringPtr(testDomain),
+				UpdatedInfo: &s.UpdateDomainInfo{
+					Description: common.StringPtr("domain for unit test"),
+				},
+			}
+
+			td.mockWorkflowService.EXPECT().
+				UpdateDomain(gomock.Any(), request, gomock.Any()).
+				Return(nil, tt.rpcError)
+
+			err := td.dc.Update(context.Background(), request)
+			assert.Equal(t, tt.rpcError, err, "error should be returned as-is")
+		})
+	}
+}

--- a/internal/internal_retry.go
+++ b/internal/internal_retry.go
@@ -123,3 +123,7 @@ func isServiceTransientError(err error) bool {
 	// and all other `error` types
 	return true
 }
+
+func retryWhileTransientError(ctx context.Context, fn func() error) error {
+	return backoff.Retry(ctx, fn, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
+}


### PR DESCRIPTION
Also extract retryWhileTransientError as the same code-block used
everywhere in internal package. // gonna replace it later

<!-- Describe what has changed in this PR -->
Extracting domain client to a separate file as it has 
nothing to do with workflow client - they don't depend on each other.

<!-- Tell your future self why have you made these changes -->
Increasing code coverage + more structure
Less huge files incl. test files.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
unit tests


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
no risks
