### PR TITLE
[code-coverage] Add tests for replayer utils isDecisionMatchEvent

### DIFF
--- a/internal/workflow_replayer_utils_test.go
+++ b/internal/workflow_replayer_utils_test.go
@@ -91,7 +91,7 @@ func TestIsDecisionMatchEvent(t *testing.T) {
 			decision: &shared.Decision{DecisionType: common.DecisionTypePtr(shared.DecisionTypeRequestCancelActivityTask)},
 		},
 		{
-			name: "case DecisionTypeRequestCancelActivityTask - decision activityID != event activityID",
+			name: "case DecisionTypeRequestCancelActivityTask - different activityIDs",
 			decision: &shared.Decision{
 				DecisionType: common.DecisionTypePtr(shared.DecisionTypeRequestCancelActivityTask),
 				RequestCancelActivityTaskDecisionAttributes: &shared.RequestCancelActivityTaskDecisionAttributes{ActivityId: common.StringPtr("ActivityID-1")},
@@ -102,7 +102,7 @@ func TestIsDecisionMatchEvent(t *testing.T) {
 			},
 		},
 		{
-			name: "case DecisionTypeRequestCancelActivityTask - decision activityID == event activityID",
+			name: "case DecisionTypeRequestCancelActivityTask - equal activityIDs",
 			decision: &shared.Decision{
 				DecisionType: common.DecisionTypePtr(shared.DecisionTypeRequestCancelActivityTask),
 				RequestCancelActivityTaskDecisionAttributes: &shared.RequestCancelActivityTaskDecisionAttributes{ActivityId: common.StringPtr(testdata.ActivityID)},
@@ -121,7 +121,7 @@ func TestIsDecisionMatchEvent(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "case DecisionTypeStartTimer - decision timerID != event timerID",
+			name: "case DecisionTypeStartTimer - different timerIDs",
 			decision: &shared.Decision{
 				DecisionType:                 common.DecisionTypePtr(shared.DecisionTypeStartTimer),
 				StartTimerDecisionAttributes: &shared.StartTimerDecisionAttributes{TimerId: common.StringPtr("timerID-1")},
@@ -132,7 +132,7 @@ func TestIsDecisionMatchEvent(t *testing.T) {
 			},
 		},
 		{
-			name: "case DecisionTypeStartTimer - decision timerID == event timerID",
+			name: "case DecisionTypeStartTimer - equal timerIDs",
 			decision: &shared.Decision{
 				DecisionType:                 common.DecisionTypePtr(shared.DecisionTypeStartTimer),
 				StartTimerDecisionAttributes: &shared.StartTimerDecisionAttributes{TimerId: common.StringPtr("timerID")},
@@ -144,7 +144,7 @@ func TestIsDecisionMatchEvent(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "case DecisionTypeCancelTimer - event type != EventTypeTimerCanceled",
+			name: "case DecisionTypeCancelTimer - event not of type EventTypeTimerCanceled",
 			decision: &shared.Decision{
 				DecisionType: common.DecisionTypePtr(shared.DecisionTypeCancelTimer),
 			},
@@ -194,7 +194,7 @@ func TestIsDecisionMatchEvent(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "case DecisionTypeCompleteWorkflowExecution - event type != EventTypeWorkflowExecutionCompleted",
+			name: "case DecisionTypeCompleteWorkflowExecution - event not of type EventTypeWorkflowExecutionCompleted",
 			decision: &shared.Decision{
 				DecisionType: common.DecisionTypePtr(shared.DecisionTypeCompleteWorkflowExecution),
 			},
@@ -222,7 +222,7 @@ func TestIsDecisionMatchEvent(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "case DecisionTypeFailWorkflowExecution - event type != EventTypeWorkflowExecutionFailed",
+			name: "case DecisionTypeFailWorkflowExecution - event not of type EventTypeWorkflowExecutionFailed",
 			decision: &shared.Decision{
 				DecisionType: common.DecisionTypePtr(shared.DecisionTypeFailWorkflowExecution),
 			},
@@ -270,7 +270,7 @@ func TestIsDecisionMatchEvent(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "case DecisionTypeRecordMarker - event type not EventTypeMarkerRecorded",
+			name: "case DecisionTypeRecordMarker - event not of type EventTypeMarkerRecorded",
 			decision: &shared.Decision{
 				DecisionType: common.DecisionTypePtr(shared.DecisionTypeRecordMarker),
 			},
@@ -280,7 +280,7 @@ func TestIsDecisionMatchEvent(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "case DecisionTypeRequestCancelExternalWorkflowExecution - event type not EventTypeRequestCancelExternalWorkflowExecutionInitiated",
+			name: "case DecisionTypeRequestCancelExternalWorkflowExecution - event not of type EventTypeRequestCancelExternalWorkflowExecutionInitiated",
 			decision: &shared.Decision{
 				DecisionType: common.DecisionTypePtr(shared.DecisionTypeRequestCancelExternalWorkflowExecution),
 			},
@@ -320,7 +320,7 @@ func TestIsDecisionMatchEvent(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "case DecisionTypeSignalExternalWorkflowExecution - event type not EventTypeSignalExternalWorkflowExecutionInitiated",
+			name: "case DecisionTypeSignalExternalWorkflowExecution - event not of type EventTypeSignalExternalWorkflowExecutionInitiated",
 			decision: &shared.Decision{
 				DecisionType: common.DecisionTypePtr(shared.DecisionTypeSignalExternalWorkflowExecution),
 			},
@@ -344,7 +344,7 @@ func TestIsDecisionMatchEvent(t *testing.T) {
 			},
 		},
 		{
-			name: "case DecisionTypeCancelWorkflowExecution - event type not EventTypeSignalExternalWorkflowExecutionInitiated",
+			name: "case DecisionTypeCancelWorkflowExecution - event not of type EventTypeSignalExternalWorkflowExecutionInitiated",
 			decision: &shared.Decision{
 				DecisionType: common.DecisionTypePtr(shared.DecisionTypeCancelWorkflowExecution),
 			},
@@ -378,7 +378,7 @@ func TestIsDecisionMatchEvent(t *testing.T) {
 			expected:   true,
 		},
 		{
-			name: "case DecisionTypeContinueAsNewWorkflowExecution - event type not EventTypeWorkflowExecutionContinuedAsNew",
+			name: "case DecisionTypeContinueAsNewWorkflowExecution - event not of type EventTypeWorkflowExecutionContinuedAsNew",
 			decision: &shared.Decision{
 				DecisionType: common.DecisionTypePtr(shared.DecisionTypeContinueAsNewWorkflowExecution),
 			},
@@ -397,7 +397,7 @@ func TestIsDecisionMatchEvent(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "case DecisionTypeStartChildWorkflowExecution - event type not EventTypeStartChildWorkflowExecutionInitiated",
+			name: "case DecisionTypeStartChildWorkflowExecution - event not of type EventTypeStartChildWorkflowExecutionInitiated",
 			decision: &shared.Decision{
 				DecisionType: common.DecisionTypePtr(shared.DecisionTypeStartChildWorkflowExecution),
 			},

--- a/internal/workflow_replayer_utils_test.go
+++ b/internal/workflow_replayer_utils_test.go
@@ -21,6 +21,7 @@
 package internal
 
 import (
+	"go.uber.org/cadence/internal/compatibility/testdata"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,6 +70,376 @@ func TestMatchReplayWithHistory(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestIsDecisionMatchEvent(t *testing.T) {
+	tests := []struct {
+		name       string
+		decision   *shared.Decision
+		event      *shared.HistoryEvent
+		expected   bool
+		strictMode bool
+	}{
+		{
+			name:     "case DecisionTypeScheduleActivityTask - event type not equal EventTypeActivityTaskScheduled",
+			decision: &shared.Decision{DecisionType: common.DecisionTypePtr(shared.DecisionTypeScheduleActivityTask)},
+		},
+		{
+			name:     "case DecisionTypeRequestCancelActivityTask - event type not equal EventTypeActivityTaskCancelRequested",
+			decision: &shared.Decision{DecisionType: common.DecisionTypePtr(shared.DecisionTypeRequestCancelActivityTask)},
+		},
+		{
+			name: "case DecisionTypeRequestCancelActivityTask - decision activityID != event activityID",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeRequestCancelActivityTask),
+				RequestCancelActivityTaskDecisionAttributes: &shared.RequestCancelActivityTaskDecisionAttributes{ActivityId: common.StringPtr("ActivityID-1")},
+			},
+			event: &shared.HistoryEvent{
+				EventType: common.EventTypePtr(shared.EventTypeActivityTaskCancelRequested),
+				ActivityTaskCancelRequestedEventAttributes: &shared.ActivityTaskCancelRequestedEventAttributes{ActivityId: common.StringPtr("ActivityID-2")},
+			},
+		},
+		{
+			name: "case DecisionTypeRequestCancelActivityTask - decision activityID == event activityID",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeRequestCancelActivityTask),
+				RequestCancelActivityTaskDecisionAttributes: &shared.RequestCancelActivityTaskDecisionAttributes{ActivityId: common.StringPtr(testdata.ActivityID)},
+			},
+			event: &shared.HistoryEvent{
+				EventType: common.EventTypePtr(shared.EventTypeActivityTaskCancelRequested),
+				ActivityTaskCancelRequestedEventAttributes: &shared.ActivityTaskCancelRequestedEventAttributes{ActivityId: common.StringPtr(testdata.ActivityID)},
+			},
+			expected: true,
+		},
+		{
+			name: "case DecisionTypeStartTimer - event type != EventTypeTimerStarted",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeStartTimer),
+			},
+			expected: false,
+		},
+		{
+			name: "case DecisionTypeStartTimer - decision timerID != event timerID",
+			decision: &shared.Decision{
+				DecisionType:                 common.DecisionTypePtr(shared.DecisionTypeStartTimer),
+				StartTimerDecisionAttributes: &shared.StartTimerDecisionAttributes{TimerId: common.StringPtr("timerID-1")},
+			},
+			event: &shared.HistoryEvent{
+				EventType:                   common.EventTypePtr(shared.EventTypeTimerStarted),
+				TimerStartedEventAttributes: &shared.TimerStartedEventAttributes{TimerId: common.StringPtr("timerID-2")},
+			},
+		},
+		{
+			name: "case DecisionTypeStartTimer - decision timerID == event timerID",
+			decision: &shared.Decision{
+				DecisionType:                 common.DecisionTypePtr(shared.DecisionTypeStartTimer),
+				StartTimerDecisionAttributes: &shared.StartTimerDecisionAttributes{TimerId: common.StringPtr("timerID")},
+			},
+			event: &shared.HistoryEvent{
+				EventType:                   common.EventTypePtr(shared.EventTypeTimerStarted),
+				TimerStartedEventAttributes: &shared.TimerStartedEventAttributes{TimerId: common.StringPtr("timerID")},
+			},
+			expected: true,
+		},
+		{
+			name: "case DecisionTypeCancelTimer - event type != EventTypeTimerCanceled",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeCancelTimer),
+			},
+		},
+		{
+			name: "case DecisionTypeCancelTimer - event type EventTypeTimerCanceled with different timer IDs",
+			decision: &shared.Decision{
+				DecisionType:                  common.DecisionTypePtr(shared.DecisionTypeCancelTimer),
+				CancelTimerDecisionAttributes: &shared.CancelTimerDecisionAttributes{TimerId: common.StringPtr("timerID-1")},
+			},
+			event: &shared.HistoryEvent{
+				EventType:                    common.EventTypePtr(shared.EventTypeTimerCanceled),
+				TimerCanceledEventAttributes: &shared.TimerCanceledEventAttributes{TimerId: common.StringPtr("timerID-2")},
+			},
+		},
+		{
+			name: "case DecisionTypeCancelTimer - event type EventTypeCancelTimerFailed with different timer IDs",
+			decision: &shared.Decision{
+				DecisionType:                  common.DecisionTypePtr(shared.DecisionTypeCancelTimer),
+				CancelTimerDecisionAttributes: &shared.CancelTimerDecisionAttributes{TimerId: common.StringPtr("timerID-1")},
+			},
+			event: &shared.HistoryEvent{
+				EventType:                        common.EventTypePtr(shared.EventTypeCancelTimerFailed),
+				CancelTimerFailedEventAttributes: &shared.CancelTimerFailedEventAttributes{TimerId: common.StringPtr("timerID-2")},
+			},
+		},
+		{
+			name: "case DecisionTypeCancelTimer - event type EventTypeCancelTimerFailed with equal timer IDs",
+			decision: &shared.Decision{
+				DecisionType:                  common.DecisionTypePtr(shared.DecisionTypeCancelTimer),
+				CancelTimerDecisionAttributes: &shared.CancelTimerDecisionAttributes{TimerId: common.StringPtr("timerID")},
+			},
+			event: &shared.HistoryEvent{
+				EventType:                        common.EventTypePtr(shared.EventTypeCancelTimerFailed),
+				CancelTimerFailedEventAttributes: &shared.CancelTimerFailedEventAttributes{TimerId: common.StringPtr("timerID")},
+			},
+			expected: true,
+		},
+		{
+			name: "case DecisionTypeCompleteWorkflowExecution - match event",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeCompleteWorkflowExecution),
+			},
+			event: &shared.HistoryEvent{
+				EventType: common.EventTypePtr(shared.EventTypeWorkflowExecutionCompleted),
+			},
+			expected: true,
+		},
+		{
+			name: "case DecisionTypeCompleteWorkflowExecution - event type != EventTypeWorkflowExecutionCompleted",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeCompleteWorkflowExecution),
+			},
+		},
+		{
+			name: "case DecisionTypeCompleteWorkflowExecution - event result not equal decision result",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeCompleteWorkflowExecution),
+				CompleteWorkflowExecutionDecisionAttributes: &shared.CompleteWorkflowExecutionDecisionAttributes{Result: []byte("some-result-1")},
+			},
+			event: &shared.HistoryEvent{
+				EventType: common.EventTypePtr(shared.EventTypeWorkflowExecutionCompleted),
+				WorkflowExecutionCompletedEventAttributes: &shared.WorkflowExecutionCompletedEventAttributes{Result: []byte("some-result-2")},
+			},
+			strictMode: true,
+		},
+		{
+			name: "case DecisionTypeFailWorkflowExecution - match event",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeFailWorkflowExecution),
+			},
+			event: &shared.HistoryEvent{
+				EventType: common.EventTypePtr(shared.EventTypeWorkflowExecutionFailed),
+			},
+			expected: true,
+		},
+		{
+			name: "case DecisionTypeFailWorkflowExecution - event type != EventTypeWorkflowExecutionFailed",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeFailWorkflowExecution),
+			},
+		},
+		{
+			name: "case DecisionTypeFailWorkflowExecution - event reason not equal decision reason",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeFailWorkflowExecution),
+				FailWorkflowExecutionDecisionAttributes: &shared.FailWorkflowExecutionDecisionAttributes{
+					Reason:  common.StringPtr("some-reason-1"),
+					Details: []byte("some-details-1"),
+				},
+			},
+			event: &shared.HistoryEvent{
+				EventType: common.EventTypePtr(shared.EventTypeWorkflowExecutionFailed),
+				WorkflowExecutionFailedEventAttributes: &shared.WorkflowExecutionFailedEventAttributes{
+					Reason:  common.StringPtr("some-reason-2"),
+					Details: []byte("some-details-2"),
+				},
+			},
+			strictMode: true,
+		},
+		{
+			name: "case DecisionTypeRecordMarker - equal markerNames",
+			decision: &shared.Decision{
+				DecisionType:                   common.DecisionTypePtr(shared.DecisionTypeRecordMarker),
+				RecordMarkerDecisionAttributes: &shared.RecordMarkerDecisionAttributes{MarkerName: common.StringPtr("some-name")},
+			},
+			event: &shared.HistoryEvent{
+				EventType:                     common.EventTypePtr(shared.EventTypeMarkerRecorded),
+				MarkerRecordedEventAttributes: &shared.MarkerRecordedEventAttributes{MarkerName: common.StringPtr("some-name")},
+			},
+			expected: true,
+		},
+		{
+			name: "case DecisionTypeRecordMarker - different markerNames",
+			decision: &shared.Decision{
+				DecisionType:                   common.DecisionTypePtr(shared.DecisionTypeRecordMarker),
+				RecordMarkerDecisionAttributes: &shared.RecordMarkerDecisionAttributes{MarkerName: common.StringPtr("some-name-1")},
+			},
+			event: &shared.HistoryEvent{
+				EventType:                     common.EventTypePtr(shared.EventTypeMarkerRecorded),
+				MarkerRecordedEventAttributes: &shared.MarkerRecordedEventAttributes{MarkerName: common.StringPtr("some-name-2")},
+			},
+			expected: false,
+		},
+		{
+			name: "case DecisionTypeRecordMarker - event type not EventTypeMarkerRecorded",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeRecordMarker),
+			},
+			event: &shared.HistoryEvent{
+				EventType: common.EventTypePtr(shared.EventType(-24)), // non existent event type
+			},
+			expected: false,
+		},
+		{
+			name: "case DecisionTypeRequestCancelExternalWorkflowExecution - event type not EventTypeRequestCancelExternalWorkflowExecutionInitiated",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeRequestCancelExternalWorkflowExecution),
+			},
+			event: &shared.HistoryEvent{
+				EventType: common.EventTypePtr(shared.EventType(-24)), // non existent event type
+			},
+		},
+		{
+			name: "case DecisionTypeRequestCancelExternalWorkflowExecution - different workflowIDs",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeRequestCancelExternalWorkflowExecution),
+				RequestCancelExternalWorkflowExecutionDecisionAttributes: &shared.RequestCancelExternalWorkflowExecutionDecisionAttributes{
+					WorkflowId: common.StringPtr("some-worklfow-id-1"),
+				},
+			},
+			event: &shared.HistoryEvent{
+				EventType: common.EventTypePtr(shared.EventTypeRequestCancelExternalWorkflowExecutionInitiated),
+				RequestCancelExternalWorkflowExecutionInitiatedEventAttributes: &shared.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes{
+					WorkflowExecution: &shared.WorkflowExecution{WorkflowId: common.StringPtr("some-workflow-id-2")},
+				},
+			},
+		},
+		{
+			name: "case DecisionTypeRequestCancelExternalWorkflowExecution - equal workflowIDs",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeRequestCancelExternalWorkflowExecution),
+				RequestCancelExternalWorkflowExecutionDecisionAttributes: &shared.RequestCancelExternalWorkflowExecutionDecisionAttributes{
+					WorkflowId: common.StringPtr("some-workflow-id"),
+				},
+			},
+			event: &shared.HistoryEvent{
+				EventType: common.EventTypePtr(shared.EventTypeRequestCancelExternalWorkflowExecutionInitiated),
+				RequestCancelExternalWorkflowExecutionInitiatedEventAttributes: &shared.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes{
+					WorkflowExecution: &shared.WorkflowExecution{WorkflowId: common.StringPtr("some-workflow-id")},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "case DecisionTypeSignalExternalWorkflowExecution - event type not EventTypeSignalExternalWorkflowExecutionInitiated",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeSignalExternalWorkflowExecution),
+			},
+			event: &shared.HistoryEvent{
+				EventType: common.EventTypePtr(shared.EventType(-24)), // non existent event type
+			},
+		},
+		{
+			name: "case DecisionTypeSignalExternalWorkflowExecution - different workflowIDs",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeSignalExternalWorkflowExecution),
+				SignalExternalWorkflowExecutionDecisionAttributes: &shared.SignalExternalWorkflowExecutionDecisionAttributes{
+					Execution: &shared.WorkflowExecution{WorkflowId: common.StringPtr("some-workflow-id-1")},
+				},
+			},
+			event: &shared.HistoryEvent{
+				EventType: common.EventTypePtr(shared.EventTypeSignalExternalWorkflowExecutionInitiated),
+				SignalExternalWorkflowExecutionInitiatedEventAttributes: &shared.SignalExternalWorkflowExecutionInitiatedEventAttributes{
+					WorkflowExecution: &shared.WorkflowExecution{WorkflowId: common.StringPtr("some-workflow-id-2")},
+				},
+			},
+		},
+		{
+			name: "case DecisionTypeCancelWorkflowExecution - event type not EventTypeSignalExternalWorkflowExecutionInitiated",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeCancelWorkflowExecution),
+			},
+			event: &shared.HistoryEvent{
+				EventType: common.EventTypePtr(shared.EventType(-24)), // non existent event type
+			},
+		},
+		{
+			name: "case DecisionTypeCancelWorkflowExecution - different attribute details",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeCancelWorkflowExecution),
+				CancelWorkflowExecutionDecisionAttributes: &shared.CancelWorkflowExecutionDecisionAttributes{Details: []byte("some-details-1")},
+			},
+			event: &shared.HistoryEvent{
+				EventType:                                common.EventTypePtr(shared.EventTypeWorkflowExecutionCanceled),
+				WorkflowExecutionCanceledEventAttributes: &shared.WorkflowExecutionCanceledEventAttributes{Details: []byte("some-details-2")},
+			},
+			strictMode: true,
+		},
+		{
+			name: "case DecisionTypeCancelWorkflowExecution - equal attribute details",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeCancelWorkflowExecution),
+				CancelWorkflowExecutionDecisionAttributes: &shared.CancelWorkflowExecutionDecisionAttributes{Details: []byte("some-details")},
+			},
+			event: &shared.HistoryEvent{
+				EventType:                                common.EventTypePtr(shared.EventTypeWorkflowExecutionCanceled),
+				WorkflowExecutionCanceledEventAttributes: &shared.WorkflowExecutionCanceledEventAttributes{Details: []byte("some-details")},
+			},
+			strictMode: true,
+			expected:   true,
+		},
+		{
+			name: "case DecisionTypeContinueAsNewWorkflowExecution - event type not EventTypeWorkflowExecutionContinuedAsNew",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeContinueAsNewWorkflowExecution),
+			},
+			event: &shared.HistoryEvent{
+				EventType: common.EventTypePtr(shared.EventType(-24)), // non existent event type
+			},
+		},
+		{
+			name: "case DecisionTypeContinueAsNewWorkflowExecution - match event",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeContinueAsNewWorkflowExecution),
+			},
+			event: &shared.HistoryEvent{
+				EventType: common.EventTypePtr(shared.EventTypeWorkflowExecutionContinuedAsNew),
+			},
+			expected: true,
+		},
+		{
+			name: "case DecisionTypeStartChildWorkflowExecution - event type not EventTypeStartChildWorkflowExecutionInitiated",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeStartChildWorkflowExecution),
+			},
+			event: &shared.HistoryEvent{
+				EventType: common.EventTypePtr(shared.EventType(-24)), // non existent event type
+			},
+		},
+		{
+			name: "case DecisionTypeStartChildWorkflowExecution - different taskList names",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionTypeStartChildWorkflowExecution),
+				StartChildWorkflowExecutionDecisionAttributes: &shared.StartChildWorkflowExecutionDecisionAttributes{
+					TaskList: &shared.TaskList{Name: common.StringPtr("some-tasklist-1")},
+				},
+			},
+			event: &shared.HistoryEvent{
+				EventType: common.EventTypePtr(shared.EventTypeStartChildWorkflowExecutionInitiated),
+				StartChildWorkflowExecutionInitiatedEventAttributes: &shared.StartChildWorkflowExecutionInitiatedEventAttributes{
+					TaskList: &shared.TaskList{Name: common.StringPtr("some-tasklist-2")},
+				},
+			},
+			strictMode: true,
+		},
+		{
+			name: "default switch case",
+			decision: &shared.Decision{
+				DecisionType: common.DecisionTypePtr(shared.DecisionType(-23)), // some random decision type
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.decision == nil {
+				test.decision = &shared.Decision{}
+			}
+			if test.event == nil {
+				test.event = &shared.HistoryEvent{}
+			}
+			ok := isDecisionMatchEvent(test.decision, test.event, test.strictMode)
+			assert.Equal(t, test.expected, ok)
 		})
 	}
 }

--- a/internal/workflow_replayer_utils_test.go
+++ b/internal/workflow_replayer_utils_test.go
@@ -21,8 +21,9 @@
 package internal
 
 import (
-	"go.uber.org/cadence/internal/compatibility/testdata"
 	"testing"
+
+	"go.uber.org/cadence/internal/compatibility/testdata"
 
 	"github.com/stretchr/testify/assert"
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added tests for isDecisionMatchEvent in internal/workflow_replayer_utils.go

<!-- Tell your future self why have you made these changes -->
**Why?**
Reach 75%+ coverage

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
