### PR TITLE
Ensure PR description follows a template when potential breaking changes are made

### DIFF
--- a/.github/workflows/breaking_change_pr_template.md
+++ b/.github/workflows/breaking_change_pr_template.md
@@ -1,0 +1,18 @@
+**Detailed Description**
+[In-depth description of the changes made to the interfaces, specifying new fields, removed fields, or modified data structures]
+
+**Impact Analysis**
+- **Backward Compatibility**: [Analysis of backward compatibility]
+- **Forward Compatibility**: [Analysis of forward compatibility]
+
+**Testing Plan**
+- **Unit Tests**: [Do we have unit test covering the change?]
+- **Persistence Tests**: [If the change is related to a data type which is persisted, do we have persistence tests covering the change?]
+- **Integration Tests**: [Do we have integration test covering the change?]
+- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?]
+
+**Rollout Plan**
+- What is the rollout plan?
+- Does the order of deployment matter?
+- Is it safe to rollback? Does the order of rollback matter?
+- Is there a kill switch to mitigate the impact immediately?

--- a/.github/workflows/breaking_change_reminder.yml
+++ b/.github/workflows/breaking_change_reminder.yml
@@ -45,10 +45,10 @@ jobs:
             if [[ "$BODY" == *"$i"* ]]; then
                 continue
             else
-                echo "\n\nPotential breaking changes detected! Please update the PR description to include following template:\n"
+                echo "Potential breaking changes detected! Please update the PR description to include following template:"
                 echo "---"
                 echo "$TEMPLATE"
-                echo "---\n"
+                echo "---"
                 exit 1
             fi
         done

--- a/.github/workflows/breaking_change_reminder.yml
+++ b/.github/workflows/breaking_change_reminder.yml
@@ -1,0 +1,54 @@
+name: Workflow for Breaking Change Reminder
+on:
+  pull_request:
+    paths:
+      # below files do not cover all the exposed types/funcs, but it's a good start to detect potentially breaking changes
+      - activity/activity.go
+      - client/client.go
+      - encoded/encoded.go
+      - interceptors/workflow_interceptor.go
+      - internal/activity.go
+      - internal/client.go
+      - internal/encoded.go
+      - internal/workflow.go
+      - internal/interceptors.go
+      - internal/worker.go
+      - internal/workflow.go
+      - worker/worker.go
+      - workflow/*.go
+
+jobs:
+  breaking-change-pr-template-reminder:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Fail if PR description is missing breaking change template
+      if: steps.pr-changes.outputs.changes != '[]'
+      run: |
+        PR_NUMBER=${{ github.event.pull_request.number }}
+        PR_URL="https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUMBER}"
+        BODY=$(curl $PR_URL | jq '.body')
+        CHECKLIST=(
+          "Detailed Description"
+          "Impact Analysis"
+          "Testing Plan"
+          "Rollout Plan"
+        )
+        TEMPLATE=$(cat .github/workflows/breaking_change_pr_template.md)
+
+        for i in "${CHECKLIST[@]}"; do
+            if [[ "$BODY" == *"$i"* ]]; then
+                continue
+            else
+                echo "\n\nPotential breaking changes detected! Please update the PR description to include following template:\n"
+                echo "---"
+                echo "$TEMPLATE"
+                echo "---\n"
+                exit 1
+            fi
+        done

--- a/activity/activity.go
+++ b/activity/activity.go
@@ -31,7 +31,6 @@ import (
 
 type (
 	// Type identifies an activity type.
-	// TODO: remove
 	Type = internal.ActivityType
 
 	// Info contains information about a currently executing activity.

--- a/activity/activity.go
+++ b/activity/activity.go
@@ -31,6 +31,7 @@ import (
 
 type (
 	// Type identifies an activity type.
+	// TODO: remove
 	Type = internal.ActivityType
 
 	// Info contains information about a currently executing activity.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding a new github workflow to run on schema changes and fails if the PR template is missing critical information.


<!-- Tell your future self why have you made these changes -->
**Why?**
To warn the developer about potential breaking changes.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Made some changes on activity.go and validated the workflow is [failing as expected](https://github.com/uber-go/cadence-client/actions/runs/9751434460/job/26912996577?pr=1351) when PR description is missing required sections.
