### PR TITLE
Handle panics while polling for tasks

### DIFF
--- a/internal/common/metrics/constants.go
+++ b/internal/common/metrics/constants.go
@@ -85,6 +85,7 @@ const (
 	ActivityLocalDispatchFailedCounter          = CadenceMetricsPrefix + "activity-local-dispatch-failed"
 	ActivityLocalDispatchSucceedCounter         = CadenceMetricsPrefix + "activity-local-dispatch-succeed"
 	WorkerPanicCounter                          = CadenceMetricsPrefix + "worker-panic"
+	InternalPanicCounter                        = CadenceMetricsPrefix + "internal-panic"
 
 	UnhandledSignalsCounter = CadenceMetricsPrefix + "unhandled-signals"
 	CorruptedSignalsCounter = CadenceMetricsPrefix + "corrupted-signals"

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -63,7 +63,9 @@ type (
 
 	// basePoller is the base class for all poller implementations
 	basePoller struct {
-		shutdownC <-chan struct{}
+		shutdownC    <-chan struct{}
+		metricsScope *metrics.TaggedScope
+		logger       *zap.Logger
 	}
 
 	// workflowTaskPoller implements polling/processing a workflow task
@@ -75,8 +77,6 @@ type (
 		service      workflowserviceclient.Interface
 		taskHandler  WorkflowTaskHandler
 		ldaTunnel    *locallyDispatchedActivityTunnel
-		metricsScope *metrics.TaggedScope
-		logger       *zap.Logger
 
 		stickyUUID                   string
 		disableStickyExecution       bool
@@ -97,8 +97,6 @@ type (
 		identity            string
 		service             workflowserviceclient.Interface
 		taskHandler         ActivityTaskHandler
-		metricsScope        *metrics.TaggedScope
-		logger              *zap.Logger
 		activitiesPerSecond float64
 		featureFlags        FeatureFlags
 	}
@@ -123,10 +121,8 @@ type (
 
 	localActivityTaskPoller struct {
 		basePoller
-		handler      *localActivityTaskHandler
-		metricsScope tally.Scope
-		logger       *zap.Logger
-		laTunnel     *localActivityTunnel
+		handler  *localActivityTaskHandler
+		laTunnel *localActivityTunnel
 	}
 
 	localActivityTaskHandler struct {
@@ -256,9 +252,19 @@ func (bp *basePoller) doPoll(
 	ctx, cancel, _ := newChannelContext(context.Background(), featureFlags, chanTimeout(pollTaskServiceTimeOut))
 
 	go func() {
+		defer close(doneC)
+		defer func() {
+			if p := recover(); p != nil {
+				bp.metricsScope.Counter(metrics.InternalPanicCounter).Inc(1)
+				st := getStackTraceRaw("base poller [panic]:", 7, 0)
+				bp.logger.Error("Unhandled panic.",
+					zap.String(tagPanicError, fmt.Sprintf("%v", p)),
+					zap.String(tagPanicStack, st))
+				err = newPanicError(p, st)
+			}
+		}()
+		defer cancel()
 		result, err = pollFunc(ctx)
-		cancel()
-		close(doneC)
 	}()
 
 	select {
@@ -279,15 +285,17 @@ func newWorkflowTaskPoller(
 	params workerExecutionParameters,
 ) *workflowTaskPoller {
 	return &workflowTaskPoller{
-		basePoller:                   basePoller{shutdownC: params.WorkerStopChannel},
+		basePoller: basePoller{
+			shutdownC:    params.WorkerStopChannel,
+			metricsScope: metrics.NewTaggedScope(params.MetricsScope),
+			logger:       params.Logger,
+		},
 		service:                      service,
 		domain:                       domain,
 		taskListName:                 params.TaskList,
 		identity:                     params.Identity,
 		taskHandler:                  taskHandler,
 		ldaTunnel:                    ldaTunnel,
-		metricsScope:                 metrics.NewTaggedScope(params.MetricsScope),
-		logger:                       params.Logger,
 		stickyUUID:                   uuid.New(),
 		disableStickyExecution:       params.DisableStickyExecution,
 		StickyScheduleToStartTimeout: params.StickyScheduleToStartTimeout,
@@ -531,11 +539,13 @@ func newLocalActivityPoller(params workerExecutionParameters, laTunnel *localAct
 		tracer:             params.Tracer,
 	}
 	return &localActivityTaskPoller{
-		basePoller:   basePoller{shutdownC: params.WorkerStopChannel},
-		handler:      handler,
-		metricsScope: params.MetricsScope,
-		logger:       params.Logger,
-		laTunnel:     laTunnel,
+		basePoller: basePoller{
+			shutdownC:    params.WorkerStopChannel,
+			metricsScope: metrics.NewTaggedScope(params.MetricsScope),
+			logger:       params.Logger,
+		},
+		handler:  handler,
+		laTunnel: laTunnel,
 	}
 }
 
@@ -990,14 +1000,16 @@ func newActivityTaskPoller(taskHandler ActivityTaskHandler, service workflowserv
 	domain string, params workerExecutionParameters) *activityTaskPoller {
 
 	activityTaskPoller := &activityTaskPoller{
-		basePoller:          basePoller{shutdownC: params.WorkerStopChannel},
+		basePoller: basePoller{
+			shutdownC:    params.WorkerStopChannel,
+			logger:       params.Logger,
+			metricsScope: metrics.NewTaggedScope(params.MetricsScope),
+		},
 		taskHandler:         taskHandler,
 		service:             service,
 		domain:              domain,
 		taskListName:        params.TaskList,
 		identity:            params.Identity,
-		logger:              params.Logger,
-		metricsScope:        metrics.NewTaggedScope(params.MetricsScope),
 		activitiesPerSecond: params.TaskListActivitiesPerSecond,
 		featureFlags:        params.FeatureFlags,
 	}

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -26,9 +26,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc"
 	"go.uber.org/zap/zaptest"
+
+	"go.uber.org/cadence/.gen/go/cadence/workflowservicetest"
+	"go.uber.org/cadence/.gen/go/shared"
 )
 
 func TestLocalActivityPanic(t *testing.T) {
@@ -53,4 +58,54 @@ func TestLocalActivityPanic(t *testing.T) {
 	require.True(t, errors.As(err, &perr), "error should be a panic error")
 	assert.Contains(t, perr.StackTrace(), "panic")
 	assert.Contains(t, perr.StackTrace(), t.Name(), "should mention the source location of the local activity that panicked")
+}
+
+func TestActivityTaskPollerHandlesPanics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	service := workflowservicetest.NewMockClient(ctrl)
+	service.EXPECT().PollForActivityTask(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ *shared.PollForActivityTaskRequest, opts ...yarpc.CallOption) (*shared.PollForActivityTaskResponse, error) {
+		panic("oh no")
+	})
+	workerStopChannel := make(chan struct{}, 1)
+	activityPoller := newActivityTaskPoller(nil, service, "test", workerExecutionParameters{
+		TaskList: "tasklist",
+
+		WorkerStopChannel: workerStopChannel,
+		WorkerOptions: WorkerOptions{
+			Identity: "identity",
+			Logger:   zaptest.NewLogger(t),
+		},
+	})
+
+	result, err := activityPoller.PollTask()
+
+	assert.Nil(t, result)
+	var panicErr *PanicError
+	assert.ErrorAs(t, err, &panicErr)
+	assert.Equal(t, "oh no", panicErr.value)
+}
+
+func TestWorkflowTaskPollerHandlesPanics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	service := workflowservicetest.NewMockClient(ctrl)
+	service.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ *shared.PollForDecisionTaskRequest, opts ...yarpc.CallOption) (*shared.PollForDecisionTaskResponse, error) {
+		panic("oh no")
+	})
+	workerStopChannel := make(chan struct{}, 1)
+	workflowTaskPoller := newWorkflowTaskPoller(nil, nil, service, "test", workerExecutionParameters{
+		TaskList: "tasklist",
+
+		WorkerStopChannel: workerStopChannel,
+		WorkerOptions: WorkerOptions{
+			Identity: "identity",
+			Logger:   zaptest.NewLogger(t),
+		},
+	})
+
+	result, err := workflowTaskPoller.PollTask()
+
+	assert.Nil(t, result)
+	var panicErr *PanicError
+	assert.ErrorAs(t, err, &panicErr)
+	assert.Equal(t, "oh no", panicErr.value)
 }


### PR DESCRIPTION
The goroutines started in doPoll execute the logic for actually making the poll RPCs, as well as any wrapping layers around them. Notably the proto conversion logic contains panics if there are unexpected values, and if we fail to handle these panics the application crashes.

<!-- Describe what has changed in this PR -->
**What changed?**
- Add handling for panics while polling

<!-- Tell your future self why have you made these changes -->
**Why?**
- Prevent services from crashing due to unexpected behavior

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Tested via unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

These panics indicate a pretty core disconnect between the client and the server state, and if encountered it's unlikely that the situation will resolve without a change to the server or the client. It seems safer to indefinitely retry these panicking requests and hope that a server-side change will resolve the issue than crashing the worker, but workers in this state will likely have a higher RPS than they would otherwise. Cadence's rate limiting support should be able to mitigate risk from that.