### PR TITLE
Adjust startedCount assertion in Test_WorkflowLocalActivityWithMockAndListeners

### DIFF
--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -1856,7 +1856,9 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowLocalActivityWithMockAndListene
 
 	env.ExecuteWorkflow(workflowFn)
 	env.AssertExpectations(s.T())
-	s.Equal(2, startedCount)
+	// the canceled workflow may not have actually started by the time it was canceled
+	s.GreaterOrEqual(startedCount, 1)
+	s.LessOrEqual(startedCount, 2)
 	s.Equal(1, completedCount)
 	s.Equal(1, canceledCount)
 	s.True(env.IsWorkflowCompleted())


### PR DESCRIPTION
Execution of the LocalActivities happens asynchronously from the workflow execution. If the local activity has already been canceled by the time it goes to start the activity then the started listener is never invoked, and the test observes only a single activity being started. This is valid as the Workflow is written so adjust the assertion against it.

This seems to be happening more frequently after we migrated our CI, internal reference CDNC-9656

<!-- Describe what has changed in this PR -->
**What changed?**
- Allow 1 or 2 as valid results for startedCount

<!-- Tell your future self why have you made these changes -->
**Why?**
- Reduce test flakiness

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Running the test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
