### PR TITLE
Change registry Apis signature to return info interface

### DIFF
--- a/activity/activity.go
+++ b/activity/activity.go
@@ -38,6 +38,9 @@ type (
 
 	// RegisterOptions consists of options for registering an activity
 	RegisterOptions = internal.RegisterActivityOptions
+
+	// RegistryInfo
+	RegistryInfo = internal.RegistryActivityInfo
 )
 
 // ErrResultPending is returned from activity's implementation to indicate the activity is not completed when

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -35,9 +35,16 @@ import (
 )
 
 type (
+	// RegistryActivityInfo
+	RegistryActivityInfo interface {
+		ActivityType() ActivityType
+		GetFunction() interface{}
+	}
+
 	// ActivityType identifies a activity type.
 	ActivityType struct {
 		Name string
+		Path string
 	}
 
 	// ActivityInfo contains information about currently executing activity.

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -249,7 +249,7 @@ func createWorkflowTaskWithQueries(
 	copy(eventsCopy, events)
 	return &s.PollForDecisionTaskResponse{
 		PreviousStartedEventId: common.Int64Ptr(previousStartEventID),
-		WorkflowType:           workflowTypePtr(WorkflowType{workflowName}),
+		WorkflowType:           workflowTypePtr(WorkflowType{Name: workflowName}),
 		History:                &s.History{Events: eventsCopy},
 		WorkflowExecution: &s.WorkflowExecution{
 			WorkflowId: common.StringPtr("fake-workflow-id"),

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -732,9 +732,7 @@ func (ae *activityExecutor) Execute(ctx context.Context, input []byte) ([]byte, 
 	}
 
 	fnValue := reflect.ValueOf(ae.fn)
-	//
 	retValues := fnValue.Call(args)
-	//
 	return validateFunctionAndGetResults(ae.fn, retValues, dataConverter)
 }
 

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -653,6 +653,7 @@ func decodeAndAssignValue(dc DataConverter, from interface{}, toValuePtr interfa
 type workflowExecutor struct {
 	workflowType string
 	fn           interface{}
+	path         string
 }
 
 func (we *workflowExecutor) Execute(ctx Context, input []byte) ([]byte, error) {
@@ -677,15 +678,27 @@ func (we *workflowExecutor) Execute(ctx Context, input []byte) ([]byte, error) {
 	return serializeResults(we.fn, results, dataConverter)
 }
 
+func (we *workflowExecutor) WorkflowType() WorkflowType {
+	return WorkflowType{
+		Name: we.workflowType,
+		Path: we.path,
+	}
+}
+
+func (we *workflowExecutor) GetFunction() interface{} {
+	return we.fn
+}
+
 // Wrapper to execute activity functions.
 type activityExecutor struct {
 	name    string
 	fn      interface{}
 	options RegisterActivityOptions
+	path    string
 }
 
 func (ae *activityExecutor) ActivityType() ActivityType {
-	return ActivityType{Name: ae.name}
+	return ActivityType{Name: ae.name, Path: ae.path}
 }
 
 func (ae *activityExecutor) GetFunction() interface{} {
@@ -719,7 +732,9 @@ func (ae *activityExecutor) Execute(ctx context.Context, input []byte) ([]byte, 
 	}
 
 	fnValue := reflect.ValueOf(ae.fn)
+	//
 	retValues := fnValue.Call(args)
+	//
 	return validateFunctionAndGetResults(ae.fn, retValues, dataConverter)
 }
 
@@ -776,20 +791,22 @@ type aggregatedWorker struct {
 	registry                        *registry
 }
 
-func (aw *aggregatedWorker) GetRegisteredWorkflows() []string {
-	return aw.registry.GetRegisteredWorkflows()
+func (aw *aggregatedWorker) GetRegisteredWorkflows() []RegistryWorkflowInfo {
+	workflows := aw.registry.GetRegisteredWorkflows()
+	var result []RegistryWorkflowInfo
+	for _, wf := range workflows {
+		result = append(result, wf)
+	}
+	return result
 }
 
-func (aw *aggregatedWorker) GetWorkflowFunc(registerName string) (interface{}, bool) {
-	return aw.registry.GetWorkflowFunc(registerName)
-}
-
-func (aw *aggregatedWorker) GetRegisteredActivities() []string {
-	return aw.registry.GetRegisteredActivities()
-}
-
-func (aw *aggregatedWorker) GetActivityFunc(registerName string) (interface{}, bool) {
-	return aw.registry.GetActivityFunc(registerName)
+func (aw *aggregatedWorker) GetRegisteredActivities() []RegistryActivityInfo {
+	activities := aw.registry.getRegisteredActivities()
+	var result []RegistryActivityInfo
+	for _, a := range activities {
+		result = append(result, a)
+	}
+	return result
 }
 
 func (aw *aggregatedWorker) RegisterWorkflow(w interface{}) {

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -843,21 +843,29 @@ func TestRegisterVariousWorkflowTypes(t *testing.T) {
 	w.RegisterWorkflowWithOptions(testWorkflowReturnStructPtrPtr, RegisterWorkflowOptions{EnableShortName: true})
 
 	wfs := w.GetRegisteredWorkflows()
+	var wfNames []string
+	for _, wf := range wfs {
+		wfNames = append(wfNames, wf.WorkflowType().Name)
+	}
 	assert.Equal(t, 8, len(wfs))
-	assert.Contains(t, wfs, "testWorkflowSample")
-	assert.Contains(t, wfs, "testWorkflowMultipleArgs")
-	assert.Contains(t, wfs, "testWorkflowNoArgs")
-	assert.Contains(t, wfs, "testWorkflowReturnInt")
-	assert.Contains(t, wfs, "testWorkflowReturnString")
-	assert.Contains(t, wfs, "testWorkflowReturnString")
-	assert.Contains(t, wfs, "testWorkflowReturnStructPtr")
-	assert.Contains(t, wfs, "testWorkflowReturnStructPtrPtr")
+	assert.Contains(t, wfNames, "testWorkflowSample")
+	assert.Contains(t, wfNames, "testWorkflowMultipleArgs")
+	assert.Contains(t, wfNames, "testWorkflowNoArgs")
+	assert.Contains(t, wfNames, "testWorkflowReturnInt")
+	assert.Contains(t, wfNames, "testWorkflowReturnString")
+	assert.Contains(t, wfNames, "testWorkflowReturnString")
+	assert.Contains(t, wfNames, "testWorkflowReturnStructPtr")
+	assert.Contains(t, wfNames, "testWorkflowReturnStructPtrPtr")
 
 	// sample assertion on workflow func
-	fn, ok := w.GetWorkflowFunc("testWorkflowSample")
-	assert.True(t, ok)
-	assert.Equal(t, reflect.Func, reflect.ValueOf(fn).Kind())
-	assert.Equal(t, getFunctionName(testWorkflowSample), runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name())
+	var sampleFunc interface{}
+	for _, wf := range wfs {
+		if wf.WorkflowType().Name == "testWorkflowSample" {
+			sampleFunc = wf.GetFunction()
+			break
+		}
+	}
+	assert.Equal(t, getFunctionName(testWorkflowSample), runtime.FuncForPC(reflect.ValueOf(sampleFunc).Pointer()).Name())
 }
 
 func TestRegisterActivityWithOptions(t *testing.T) {
@@ -865,13 +873,12 @@ func TestRegisterActivityWithOptions(t *testing.T) {
 	w := &aggregatedWorker{registry: r}
 	w.RegisterActivityWithOptions(testActivityMultipleArgs, RegisterActivityOptions{EnableShortName: true})
 
-	wfs := w.GetRegisteredActivities()
-	assert.Equal(t, 1, len(wfs))
-	assert.Contains(t, wfs, "testActivityMultipleArgs")
+	a := w.GetRegisteredActivities()
+	assert.Equal(t, 1, len(a))
+	assert.Contains(t, a[0].ActivityType().Name, "testActivityMultipleArgs")
 
 	// assert activity function
-	fn, ok := w.GetActivityFunc("testActivityMultipleArgs")
-	assert.True(t, ok)
+	fn := a[0].GetFunction()
 	assert.Equal(t, reflect.Func, reflect.ValueOf(fn).Kind())
 	assert.Equal(t, getFunctionName(testActivityMultipleArgs), runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name())
 }

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -98,6 +98,8 @@ type (
 	// Note that workflow.Context is used instead of context.Context to avoid use of raw channels.
 	workflow interface {
 		Execute(ctx Context, input []byte) (result []byte, err error)
+		WorkflowType() WorkflowType
+		GetFunction() interface{}
 	}
 
 	sendCallback struct {

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1884,20 +1884,22 @@ func (env *testWorkflowEnvironmentImpl) ExecuteChildWorkflow(params executeWorkf
 	return env.executeChildWorkflowWithDelay(0, params, callback, startedHandler)
 }
 
-func (env *testWorkflowEnvironmentImpl) GetRegisteredWorkflows() []string {
-	return env.registry.GetRegisteredWorkflows()
+func (env *testWorkflowEnvironmentImpl) GetRegisteredWorkflows() []RegistryWorkflowInfo {
+	workflows := env.registry.GetRegisteredWorkflows()
+	var result []RegistryWorkflowInfo
+	for _, wf := range workflows {
+		result = append(result, wf)
+	}
+	return result
 }
 
-func (env *testWorkflowEnvironmentImpl) GetWorkflowFunc(registerName string) (interface{}, bool) {
-	return env.registry.GetWorkflowFunc(registerName)
-}
-
-func (env *testWorkflowEnvironmentImpl) GetRegisteredActivities() []string {
-	return env.registry.GetRegisteredActivities()
-}
-
-func (env *testWorkflowEnvironmentImpl) GetActivityFunc(registerName string) (interface{}, bool) {
-	return env.registry.GetActivityFunc(registerName)
+func (env *testWorkflowEnvironmentImpl) GetRegisteredActivities() []RegistryActivityInfo {
+	activities := env.registry.getRegisteredActivities()
+	var result []RegistryActivityInfo
+	for _, a := range activities {
+		result = append(result, a)
+	}
+	return result
 }
 
 func (env *testWorkflowEnvironmentImpl) executeChildWorkflowWithDelay(delayStart time.Duration, params executeWorkflowParams, callback resultHandler, startedHandler func(r WorkflowExecution, e error)) error {

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -260,7 +260,7 @@ func (r *registry) getWorkflowNoLock(registerName string) (interface{}, bool) {
 	if ok {
 		return a.GetFunction(), ok
 	}
-	return a, ok
+	return nil, ok
 }
 
 func (r *registry) GetRegisteredWorkflowTypes() []string {

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -39,7 +39,7 @@ var globalRegistry *registry
 
 func newRegistry() *registry {
 	return &registry{
-		workflowFuncMap:  make(map[string]interface{}),
+		workflowFuncMap:  make(map[string]workflow),
 		workflowAliasMap: make(map[string]string),
 		activityFuncMap:  make(map[string]activity),
 		activityAliasMap: make(map[string]string),
@@ -50,7 +50,7 @@ func newRegistry() *registry {
 func getGlobalRegistry() *registry {
 	once.Do(func() {
 		globalRegistry = &registry{
-			workflowFuncMap:  make(map[string]interface{}),
+			workflowFuncMap:  make(map[string]workflow),
 			workflowAliasMap: make(map[string]string),
 			activityFuncMap:  make(map[string]activity),
 			activityAliasMap: make(map[string]string),
@@ -61,7 +61,7 @@ func getGlobalRegistry() *registry {
 
 type registry struct {
 	sync.Mutex
-	workflowFuncMap  map[string]interface{}
+	workflowFuncMap  map[string]workflow
 	workflowAliasMap map[string]string
 	activityFuncMap  map[string]activity
 	activityAliasMap map[string]string
@@ -100,7 +100,7 @@ func (r *registry) RegisterWorkflowWithOptions(
 			panic(fmt.Sprintf("workflow name \"%v\" is already registered", registerName))
 		}
 	}
-	r.workflowFuncMap[registerName] = wf
+	r.workflowFuncMap[registerName] = &workflowExecutor{registerName, wf, fnName}
 	if len(alias) > 0 || options.EnableShortName {
 		r.workflowAliasMap[fnName] = registerName
 	}
@@ -124,29 +124,18 @@ func (r *registry) RegisterActivityWithOptions(af interface{}, options RegisterA
 	}
 }
 
-func (r *registry) GetRegisteredWorkflows() []string {
-	return r.GetRegisteredWorkflowTypes()
-}
-
-func (r *registry) GetWorkflowFunc(registerName string) (interface{}, bool) {
-	return r.getWorkflowFn(registerName)
-}
-
-func (r *registry) GetRegisteredActivities() []string {
-	activities := r.getRegisteredActivities()
-	activityNames := make([]string, 0, len(activities))
-	for _, a := range activities {
-		activityNames = append(activityNames, a.ActivityType().Name)
+func (r *registry) GetRegisteredWorkflows() []workflow {
+	r.Lock()
+	var result []workflow
+	for _, wf := range r.workflowFuncMap {
+		result = append(result, wf)
 	}
-	return activityNames
-}
-
-func (r *registry) GetActivityFunc(registerName string) (interface{}, bool) {
-	a, ok := r.GetActivity(registerName)
-	if !ok {
-		return nil, false
+	r.Unlock()
+	if r.next != nil {
+		nextWFs := r.next.GetRegisteredWorkflows()
+		result = append(result, nextWFs...)
 	}
-	return a.GetFunction(), ok
+	return result
 }
 
 func (r *registry) registerActivityFunction(af interface{}, options RegisterActivityOptions) error {
@@ -174,7 +163,7 @@ func (r *registry) registerActivityFunction(af interface{}, options RegisterActi
 			return fmt.Errorf("activity type \"%v\" is already registered", registerName)
 		}
 	}
-	r.activityFuncMap[registerName] = &activityExecutor{registerName, af, options}
+	r.activityFuncMap[registerName] = &activityExecutor{registerName, af, options, fnName}
 	if len(alias) > 0 || options.EnableShortName {
 		r.activityAliasMap[fnName] = registerName
 	}
@@ -216,7 +205,7 @@ func (r *registry) registerActivityStruct(aStruct interface{}, options RegisterA
 				return fmt.Errorf("activity type \"%v\" is already registered", registerName)
 			}
 		}
-		r.activityFuncMap[registerName] = &activityExecutor{registerName, methodValue.Interface(), options}
+		r.activityFuncMap[registerName] = &activityExecutor{registerName, methodValue.Interface(), options, methodName}
 		if len(structPrefix) > 0 || options.EnableShortName {
 			r.activityAliasMap[methodName] = registerName
 		}
@@ -248,22 +237,28 @@ func (r *registry) getWorkflowAlias(fnName string) (string, bool) {
 
 func (r *registry) getWorkflowFn(fnName string) (interface{}, bool) {
 	r.Lock() // do not defer for Unlock to call next.getWorkflowFn without lock
-	fn, ok := r.workflowFuncMap[fnName]
+	wf, ok := r.workflowFuncMap[fnName]
 	if !ok { // if exact match is not found, check for backwards compatible name without -fm suffix
-		fn, ok = r.workflowFuncMap[strings.TrimSuffix(fnName, "-fm")]
+		wf, ok = r.workflowFuncMap[strings.TrimSuffix(fnName, "-fm")]
 	}
 	if !ok && r.next != nil {
 		r.Unlock()
 		return r.next.getWorkflowFn(fnName)
 	}
 	r.Unlock()
-	return fn, ok
+	if ok {
+		return wf.GetFunction(), ok
+	}
+	return nil, ok
 }
 
 func (r *registry) getWorkflowNoLock(registerName string) (interface{}, bool) {
 	a, ok := r.workflowFuncMap[registerName]
 	if !ok && r.next != nil {
 		return r.next.getWorkflowNoLock(registerName)
+	}
+	if ok {
+		return a.GetFunction(), ok
 	}
 	return a, ok
 }

--- a/internal/registry_test.go
+++ b/internal/registry_test.go
@@ -105,16 +105,16 @@ func TestWorkflowRegistration(t *testing.T) {
 			tt.register(r)
 
 			// Verify registered workflow type
-			workflowType := r.GetRegisteredWorkflows()[0]
+			workflowType := r.GetRegisteredWorkflows()[0].WorkflowType().Name
 			require.Equal(t, tt.workflowType, workflowType)
 
 			// Verify workflow is resolved from workflow type
-			_, ok := r.GetWorkflowFunc(tt.workflowType)
+			_, ok := r.getWorkflowFn(tt.workflowType)
 			require.True(t, ok)
 
 			// Verify workflow is resolved from alternative (backwards compatible) workflow type
 			if len(tt.altWorkflowType) > 0 {
-				_, ok = r.GetWorkflowFunc(tt.altWorkflowType)
+				_, ok := r.getWorkflowFn(tt.workflowType)
 				require.True(t, ok)
 			}
 
@@ -228,12 +228,9 @@ func TestActivityRegistration(t *testing.T) {
 			// Verify registered activity type
 			activityType := r.getRegisteredActivities()[0].ActivityType().Name
 			require.Equal(t, tt.activityType, activityType, "activity type")
-			require.Equal(t, tt.activityType, r.GetRegisteredActivities()[0])
 
 			// Verify activity is resolved from activity type
 			_, ok := r.GetActivity(tt.activityType)
-			require.True(t, ok)
-			_, ok = r.GetActivityFunc(tt.activityType)
 			require.True(t, ok)
 
 			// Verify activity is resolved from alternative (backwards compatible) activity type

--- a/internal/registry_test.go
+++ b/internal/registry_test.go
@@ -114,7 +114,7 @@ func TestWorkflowRegistration(t *testing.T) {
 
 			// Verify workflow is resolved from alternative (backwards compatible) workflow type
 			if len(tt.altWorkflowType) > 0 {
-				_, ok := r.getWorkflowFn(tt.workflowType)
+				_, ok := r.getWorkflowFn(tt.altWorkflowType)
 				require.True(t, ok)
 			}
 

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -389,9 +389,16 @@ type (
 		SignalChildWorkflow(ctx Context, signalName string, data interface{}) Future
 	}
 
+	// RegistryWorkflowInfo
+	RegistryWorkflowInfo interface {
+		WorkflowType() WorkflowType
+		GetFunction() interface{}
+	}
+
 	// WorkflowType identifies a workflow type.
 	WorkflowType struct {
 		Name string
+		Path string
 	}
 
 	// WorkflowExecution Details.

--- a/internal/workflow_replayer.go
+++ b/internal/workflow_replayer.go
@@ -131,20 +131,24 @@ func (r *WorkflowReplayer) RegisterActivityWithOptions(a interface{}, options Re
 	r.registry.RegisterActivityWithOptions(a, options)
 }
 
-func (r *WorkflowReplayer) GetRegisteredWorkflows() []string {
-	return r.registry.GetRegisteredWorkflows()
+// GetRegisteredWorkflows retrieves the registered workflows on the replayer
+func (r *WorkflowReplayer) GetRegisteredWorkflows() []RegistryWorkflowInfo {
+	workflows := r.registry.GetRegisteredWorkflows()
+	var result []RegistryWorkflowInfo
+	for _, wf := range workflows {
+		result = append(result, wf)
+	}
+	return result
 }
 
-func (r *WorkflowReplayer) GetWorkflowFunc(registerName string) (interface{}, bool) {
-	return r.registry.GetWorkflowFunc(registerName)
-}
-
-func (r *WorkflowReplayer) GetRegisteredActivities() []string {
-	return r.registry.GetRegisteredActivities()
-}
-
-func (r *WorkflowReplayer) GetActivityFunc(registerName string) (interface{}, bool) {
-	return r.registry.GetActivityFunc(registerName)
+// GetRegisteredActivities retrieves the registered activities on the replayer
+func (r *WorkflowReplayer) GetRegisteredActivities() []RegistryActivityInfo {
+	activities := r.registry.getRegisteredActivities()
+	var result []RegistryActivityInfo
+	for _, a := range activities {
+		result = append(result, a)
+	}
+	return result
 }
 
 // ReplayWorkflowHistory executes a single decision task for the given history.

--- a/internal/workflow_replayer_test.go
+++ b/internal/workflow_replayer_test.go
@@ -144,11 +144,10 @@ func (s *workflowReplayerSuite) TestReplayWorkflowHistoryFromFile() {
 func (s *workflowReplayerSuite) TestActivityRegistration() {
 	name := "test-Activity"
 	s.replayer.RegisterActivityWithOptions(testActivityFunction, RegisterActivityOptions{Name: name})
-	a := s.replayer.GetRegisteredActivities()[0]
+	a := s.replayer.GetRegisteredActivities()[0].ActivityType().Name
 	s.Equal(name, a)
 
-	fn, ok := s.replayer.GetActivityFunc(a)
-	s.True(ok)
+	fn := s.replayer.GetRegisteredActivities()[0].GetFunction()
 	s.Equal(reflect.Func, reflect.ValueOf(fn).Kind())
 	s.Equal(getFunctionName(testActivityFunction), runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name())
 }

--- a/internal/workflow_shadower.go
+++ b/internal/workflow_shadower.go
@@ -229,13 +229,8 @@ func (s *WorkflowShadower) Stop() {
 }
 
 // GetRegisteredWorkflows retrieves the list of workflows registered on the worker
-func (s *WorkflowShadower) GetRegisteredWorkflows() []string {
+func (s *WorkflowShadower) GetRegisteredWorkflows() []RegistryWorkflowInfo {
 	return s.replayer.GetRegisteredWorkflows()
-}
-
-// GetWorkflowFn returns the workflow function corresponding to the provided registerName
-func (s *WorkflowShadower) GetWorkflowFunc(registerName string) (interface{}, bool) {
-	return s.replayer.GetWorkflowFunc(registerName)
 }
 
 func (s *WorkflowShadower) shadowWorker() error {

--- a/internal/workflow_shadower_test.go
+++ b/internal/workflow_shadower_test.go
@@ -440,12 +440,11 @@ func (s *workflowShadowerSuite) TestShadowWorker_ExpectedReplayError() {
 }
 
 func (s *workflowShadowerSuite) TestWorkflowRegistration() {
-	wfName := s.testShadower.GetRegisteredWorkflows()[0]
+	wfName := s.testShadower.GetRegisteredWorkflows()[0].WorkflowType().Name
 	fnName := getFunctionName(testReplayWorkflow)
 	s.Equal(fnName, wfName)
 
-	fn, ok := s.testShadower.GetWorkflowFunc(wfName)
-	s.True(ok)
+	fn := s.testShadower.GetRegisteredWorkflows()[0].GetFunction()
 	s.Equal(fnName, runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name())
 }
 

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -141,12 +141,8 @@ func (t *TestActivityEnvironment) RegisterActivityWithOptions(a interface{}, opt
 	t.impl.RegisterActivityWithOptions(a, options)
 }
 
-func (t *TestActivityEnvironment) GetRegisteredActivities() []string {
+func (t *TestActivityEnvironment) GetRegisteredActivities() []RegistryActivityInfo {
 	return t.impl.GetRegisteredActivities()
-}
-
-func (t *TestActivityEnvironment) GetActivityFunc(registerName string) (interface{}, bool) {
-	return t.impl.GetActivityFunc(registerName)
 }
 
 // ExecuteActivity executes an activity. The tested activity will be executed synchronously in the calling goroutinue.
@@ -214,20 +210,12 @@ func (t *TestWorkflowEnvironment) RegisterActivityWithOptions(a interface{}, opt
 	t.impl.RegisterActivityWithOptions(a, options)
 }
 
-func (t *TestWorkflowEnvironment) GetRegisteredWorkflows() []string {
+func (t *TestWorkflowEnvironment) GetRegisteredWorkflows() []RegistryWorkflowInfo {
 	return t.impl.GetRegisteredWorkflows()
 }
 
-func (t *TestWorkflowEnvironment) GetWorkflowFunc(registerName string) (interface{}, bool) {
-	return t.impl.GetWorkflowFunc(registerName)
-}
-
-func (t *TestWorkflowEnvironment) GetRegisteredActivities() []string {
+func (t *TestWorkflowEnvironment) GetRegisteredActivities() []RegistryActivityInfo {
 	return t.impl.GetRegisteredActivities()
-}
-
-func (t *TestWorkflowEnvironment) GetActivityFunc(registerName string) (interface{}, bool) {
-	return t.impl.GetActivityFunc(registerName)
 }
 
 // SetStartTime sets the start time of the workflow. This is optional, default start time will be the wall clock time when

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -80,19 +80,13 @@ type (
 		// type name twice. Use workflow.RegisterOptions.DisableAlreadyRegisteredCheck to allow multiple registrations.
 		RegisterWorkflowWithOptions(w interface{}, options workflow.RegisterOptions)
 
-		// GetRegisteredWorkflows returns a list of all workflows registered on the worker.
-		// The returned workflow name is by default the method name. However, if the workflow was registered
+		// GetRegisteredWorkflows returns information on all workflows registered on the worker.
+		// the RegistryInfo interface can be used to read workflow names, paths or retrieve the workflow functions.
+		// The workflow name is by default the method name. However, if the workflow was registered
 		// with options (see Worker.RegisterWorkflowWithOptions), the workflow may have customized name.
-		// For chained registries, this returns a combined list of all registered activities from the current
-		// instance to the global registry. In this case, the list may contain duplicate names.
-		GetRegisteredWorkflows() []string
-
-		// GetWorkflowFunc takes a name and returns the corresponding workflow
-		// function and a boolean value indicating whether the activity was found.
-		// It returns nil, false when no workflow was registered with the provided name.
-		// The registerName is the resolved name recorded on the registry after all options
-		// from workflow.RegisterOptions{} are applied.
-		GetWorkflowFunc(registerName string) (interface{}, bool)
+		// For chained registries, this returns a combined list of all registered workflows from the
+		// worker instance that calls this method to the global registry. In this case, the list may contain duplicate names.
+		GetRegisteredWorkflows() []workflow.RegistryInfo
 	}
 
 	// ActivityRegistry exposes activity registration functions to consumers.
@@ -146,21 +140,13 @@ type (
 		// worker.RegisterActivityWithOptions(barActivity, RegisterActivityOptions{DisableAlreadyRegisteredCheck: true})
 		RegisterActivityWithOptions(a interface{}, options activity.RegisterOptions)
 
-		// GetRegisteredActivities returns the names of all activities registered on the worker.
-		// The activity name is by default the method name. However, if the activity was registered
-		// with options (see Worker.RegisterActivityWithOptions), the activity may have customized name.
-		// For example, struct pointer activities that were registered with the Name option activity.RegisterOptions{Name: ...}
-		// will have their method names prepended with the provided name option.
-		// For chained registries, this returns a combined list of all registered activities from the current
-		// instance to the global registry. In this case, the list may contain duplicate names.
-		GetRegisteredActivities() []string
-
-		// GetActivityFunc takes a name and returns the corresponding activity
-		// function and a boolean value indicating whether the activity was found.
-		// It returns nil, false when no activity was registered with the provided name.
-		// The registerName is the resolved name recorded on the registry after all options
-		// from activity.RegisterOptions{} are applied.
-		GetActivityFunc(registerName string) (interface{}, bool)
+		// GetRegisteredActivities returns information on all activities registered on the worker.
+		// the RegistryInfo interface can be used to read activity names, paths or retrieve the activity functions.
+		// The activity name is by default the method name. However, if the workflow was registered
+		// with options (see Worker.RegisterWorkflowWithOptions), the workflow may have customized name.
+		// For chained registries, this returns a combined list of all registered activities from the
+		// worker instance that calls this method to the global registry. In this case, the list may contain duplicate names.
+		GetRegisteredActivities() []activity.RegistryInfo
 	}
 
 	// WorkflowReplayer supports replaying a workflow from its event history.

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -57,6 +57,8 @@ type (
 
 	// Info information about currently executing workflow
 	Info = internal.WorkflowInfo
+
+	RegistryInfo = internal.RegistryWorkflowInfo
 )
 
 // Register - registers a workflow function with the framework.


### PR DESCRIPTION
**Detailed Description**
[In-depth description of the changes made to the interfaces, specifying new fields, removed fields, or modified data structures]

Change in signature on the following WorkflowRegistry methods:
GetWorkflowFunc
GetRegisteredWorkflows

the two methods are combined into one where GetRegisteredWorkflows now returns an RegistryInfo interface. The info interface exposes methods to retrieve the function and workflow info.

 The same goes for the ActivityRegistry methods:
GetActivityFunc
GetRegisteredActivities

**Impact Analysis**
- **Backward Compatibility**: [Analysis of backward compatibility]
- **Forward Compatibility**: [Analysis of forward compatibility]

**Testing Plan**
- **Unit Tests**: [Do we have unit test covering the change?] Yes
- **Persistence Tests**: [If the change is related to a data type which is persisted, do we have persistence tests covering the change?]
- **Integration Tests**: [Do we have integration test covering the change?]
- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?]

**Rollout Plan**
- What is the rollout plan?
- Does the order of deployment matter?
- Is it safe to rollback? Does the order of rollback matter? Safe to roll back. No required order
- Is there a kill switch to mitigate the impact immediately?
