### PR TITLE
Revert "Handle panics while polling for tasks (#1352)"

### DIFF
--- a/internal/common/metrics/constants.go
+++ b/internal/common/metrics/constants.go
@@ -85,7 +85,6 @@ const (
 	ActivityLocalDispatchFailedCounter          = CadenceMetricsPrefix + "activity-local-dispatch-failed"
 	ActivityLocalDispatchSucceedCounter         = CadenceMetricsPrefix + "activity-local-dispatch-succeed"
 	WorkerPanicCounter                          = CadenceMetricsPrefix + "worker-panic"
-	InternalPanicCounter                        = CadenceMetricsPrefix + "internal-panic"
 
 	UnhandledSignalsCounter = CadenceMetricsPrefix + "unhandled-signals"
 	CorruptedSignalsCounter = CadenceMetricsPrefix + "corrupted-signals"

--- a/internal/internal_logging_tags.go
+++ b/internal/internal_logging_tags.go
@@ -41,7 +41,6 @@ const (
 	tagVisibilityQuery             = "VisibilityQuery"
 	tagPanicError                  = "PanicError"
 	tagPanicStack                  = "PanicStack"
-	tagPollerType                  = "PollerType"
 	causeTag                       = "pollerrorcause"
 	tagWorkflowRuntimeLength       = "workflowruntimelength"
 	tagNonDeterminismDetectionType = "NonDeterminismDetectionType"

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -26,14 +26,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/yarpc"
 	"go.uber.org/zap/zaptest"
-
-	"go.uber.org/cadence/.gen/go/cadence/workflowservicetest"
-	"go.uber.org/cadence/.gen/go/shared"
 )
 
 func TestLocalActivityPanic(t *testing.T) {
@@ -58,81 +53,4 @@ func TestLocalActivityPanic(t *testing.T) {
 	require.True(t, errors.As(err, &perr), "error should be a panic error")
 	assert.Contains(t, perr.StackTrace(), "panic")
 	assert.Contains(t, perr.StackTrace(), t.Name(), "should mention the source location of the local activity that panicked")
-}
-
-func TestActivityTaskPollerHandlesPanics(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	service := workflowservicetest.NewMockClient(ctrl)
-	service.EXPECT().PollForActivityTask(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ *shared.PollForActivityTaskRequest, opts ...yarpc.CallOption) (*shared.PollForActivityTaskResponse, error) {
-		panic("oh no")
-	})
-	workerStopChannel := make(chan struct{}, 1)
-	activityPoller := newActivityTaskPoller(nil, service, "test", workerExecutionParameters{
-		TaskList: "tasklist",
-
-		WorkerStopChannel: workerStopChannel,
-		WorkerOptions: WorkerOptions{
-			Identity: "identity",
-			Logger:   zaptest.NewLogger(t),
-		},
-	})
-
-	result, err := activityPoller.PollTask()
-
-	assert.Nil(t, result)
-	var panicErr *PanicError
-	assert.ErrorAs(t, err, &panicErr)
-	assert.Equal(t, "oh no", panicErr.value)
-}
-
-func TestActivityTaskPollerHandlesCancel(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	service := workflowservicetest.NewMockClient(ctrl)
-	workerStopChannel := make(chan struct{}, 1)
-	pollBlockingChannel := make(chan struct{}, 1)
-	defer close(pollBlockingChannel)
-	activityPoller := newActivityTaskPoller(nil, service, "test", workerExecutionParameters{
-		TaskList: "tasklist",
-
-		WorkerStopChannel: workerStopChannel,
-		WorkerOptions: WorkerOptions{
-			Identity: "identity",
-			Logger:   zaptest.NewLogger(t),
-		},
-	})
-	service.EXPECT().PollForActivityTask(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ *shared.PollForActivityTaskRequest, opts ...yarpc.CallOption) (*shared.PollForActivityTaskResponse, error) {
-		workerStopChannel <- struct{}{}
-		<-pollBlockingChannel
-		return nil, nil
-	})
-
-	result, err := activityPoller.PollTask()
-
-	assert.Nil(t, result)
-	assert.ErrorIs(t, err, errShutdown)
-}
-
-func TestWorkflowTaskPollerHandlesPanics(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	service := workflowservicetest.NewMockClient(ctrl)
-	service.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ *shared.PollForDecisionTaskRequest, opts ...yarpc.CallOption) (*shared.PollForDecisionTaskResponse, error) {
-		panic("oh no")
-	})
-	workerStopChannel := make(chan struct{}, 1)
-	workflowTaskPoller := newWorkflowTaskPoller(nil, nil, service, "test", workerExecutionParameters{
-		TaskList: "tasklist",
-
-		WorkerStopChannel: workerStopChannel,
-		WorkerOptions: WorkerOptions{
-			Identity: "identity",
-			Logger:   zaptest.NewLogger(t),
-		},
-	})
-
-	result, err := workflowTaskPoller.PollTask()
-
-	assert.Nil(t, result)
-	var panicErr *PanicError
-	assert.ErrorAs(t, err, &panicErr)
-	assert.Equal(t, "oh no", panicErr.value)
 }


### PR DESCRIPTION
This reverts commit 20dd93841ca7e8d145394978bb5c5dc99e519993.

<!-- Describe what has changed in this PR -->
**What changed?**
Reverting #1352 

<!-- Tell your future self why have you made these changes -->
**Why?**
Unsure why at the moment but observing activity timeouts on some edge cases

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
deployed in docstore-staging

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
