### PR TITLE
Added minor adjustments in the shadow status options

### DIFF
--- a/internal/query_builder.go
+++ b/internal/query_builder.go
@@ -50,8 +50,6 @@ var (
 	WorkflowStatusFailed = WorkflowStatus(shared.WorkflowExecutionCloseStatusFailed.String())
 	// WorkflowStatusCanceled is the WorkflowStatus for canceled workflows
 	WorkflowStatusCanceled = WorkflowStatus(shared.WorkflowExecutionCloseStatusCanceled.String())
-	// WorkflowStatusTerminated is the WorkflowStatus for terminated workflows
-	WorkflowStatusTerminated = WorkflowStatus(shared.WorkflowExecutionCloseStatusTerminated.String())
 	// WorkflowStatusContinuedAsNew is the WorkflowStatus for continuedAsNew workflows
 	WorkflowStatusContinuedAsNew = WorkflowStatus(shared.WorkflowExecutionCloseStatusContinuedAsNew.String())
 	// WorkflowStatusTimedOut is the WorkflowStatus for timedout workflows
@@ -183,7 +181,7 @@ func ToWorkflowStatus(statusString string) (WorkflowStatus, error) {
 	status := WorkflowStatus(strings.ToUpper(statusString))
 	switch status {
 	case WorkflowStatusOpen, WorkflowStatusClosed, WorkflowStatusCompleted,
-		WorkflowStatusFailed, WorkflowStatusCanceled, WorkflowStatusTerminated,
+		WorkflowStatusFailed, WorkflowStatusCanceled,
 		WorkflowStatusContinuedAsNew, WorkflowStatusTimedOut, WorkflowStatusALL:
 		return status, nil
 	default:

--- a/internal/query_builder_test.go
+++ b/internal/query_builder_test.go
@@ -103,7 +103,7 @@ func (s *queryBuilderSuite) TestWorkflowStatusQuery() {
 		},
 		{
 			msg:              "all workflows",
-			workflowStatuses: []WorkflowStatus{WorkflowStatusTerminated, WorkflowStatusALL},
+			workflowStatuses: []WorkflowStatus{WorkflowStatusALL},
 			expectedQuery:    "",
 		},
 	}
@@ -224,12 +224,6 @@ func (s *queryBuilderSuite) TestToWorkflowStatus() {
 			statusString:   "Timed_Out",
 			expectErr:      false,
 			expectedStatus: WorkflowStatusTimedOut,
-		},
-		{
-			msg:            "upper case status string",
-			statusString:   "TERMINATED",
-			expectErr:      false,
-			expectedStatus: WorkflowStatusTerminated,
 		},
 		{
 			msg:            "all",

--- a/internal/workflow_shadower.go
+++ b/internal/workflow_shadower.go
@@ -338,10 +338,9 @@ func (o *ShadowOptions) validateAndPopulateFields() error {
 			}
 			statuses = append(statuses, status)
 		}
-		//All the open statuses are taken by default. This list seems to not work as expected.
-		//TODO: verify that the status list works as expected. currently all wfs of all types get picked up.
+		//This filter doesn't seem to be working as expected.
 		if len(statuses) == 0 {
-			statuses = []WorkflowStatus{WorkflowStatusOpen}
+			statuses = []WorkflowStatus{WorkflowStatusOpen, WorkflowStatusClosed}
 		}
 		queryBuilder.WorkflowStatus(statuses)
 

--- a/internal/workflow_shadower_test.go
+++ b/internal/workflow_shadower_test.go
@@ -203,7 +203,7 @@ func (s *workflowShadowerSuite) TestShadowOptionsValidation() {
 			options:   ShadowOptions{},
 			expectErr: false,
 			validationFn: func(options *ShadowOptions) {
-				s.Equal("(CloseTime = missing)", options.WorkflowQuery)
+				s.Equal("(CloseTime = missing or CloseTime != missing)", options.WorkflowQuery)
 				s.Equal(1.0, options.SamplingRate)
 				s.Equal(1, options.Concurrency)
 			},
@@ -255,7 +255,7 @@ func (s *workflowShadowerSuite) TestShadowOptionsWithExcludeTypes() {
 		Mode:          ShadowModeNormal,
 	}
 	expectedQuery := fmt.Sprintf(
-		`(WorkflowType = "includedType1" or WorkflowType = "includedType2") and (WorkflowType != "excludedType1" and WorkflowType != "excludedType2") and (CloseTime = missing)`,
+		`(WorkflowType = "includedType1" or WorkflowType = "includedType2") and (WorkflowType != "excludedType1" and WorkflowType != "excludedType2") and (CloseTime = missing or CloseTime != missing)`,
 	)
 	shadower, err := NewWorkflowShadower(s.mockService, "testDomain", options, ReplayOptions{}, nil)
 	s.NoError(err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added minor adjustments in the shadow status options so that Terminated workflows are never replayed.
Removed the terminated workflow status from the All option as well. 
Added default option for replaying only closed and open workflows and no other workflows if workflow status filter is not passed.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is to ensure that the terminated workflows are not replayed. We also have bugs associated with continue as new workflows that need to be fixed before those wfs can be replayed.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
test cases.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
shadower accuracy may get affected.