### PR TITLE
Remove deprecated fossa

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,9 +35,6 @@ container:
 agents:
   queue: "buildkite-gcp"
 steps:
-  - label: "fossa analyze"
-    command: ".buildkite/scripts/fossa.sh"
-
   - label: ":golang: unit-test"
     artifact_paths:
       - ".build/*/coverage/*.out"


### PR DESCRIPTION
Fossa's being removed / decomm'd. Removing for now until we move to a replacement

<!-- Describe what has changed in this PR -->
Fossa's being removed / decomm'd. Removing for now until we move to a replacement

<!-- Tell your future self why have you made these changes -->
We're blocked because of this in builds.
It seems to emit wrong warnings.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
