### PR TITLE
Add debugger interface to allow extracting the workerStats from Worker

### DIFF
--- a/debug/types.go
+++ b/debug/types.go
@@ -51,4 +51,8 @@ type (
 	// Activities is a list of executing activities on the worker
 	// Deprecated: in development and very likely to change
 	Activities = internal.Activities
+
+	// Debugger exposes stats collected on a running Worker
+	// Deprecated: in development and very likely to change
+	Debugger = internal.Debugger
 )

--- a/internal/common/debug/types.go
+++ b/internal/common/debug/types.go
@@ -69,4 +69,10 @@ type (
 		Info  ActivityInfo
 		Count int64
 	}
+
+	// Debugger exposes stats collected on a running Worker
+	// Deprecated: in development and very likely to change
+	Debugger interface {
+		GetWorkerStats() WorkerStats
+	}
 )

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -804,7 +804,10 @@ type aggregatedWorker struct {
 	shadowWorker                    *shadowWorker
 	logger                          *zap.Logger
 	registry                        *registry
+	workerstats                     debug.WorkerStats
 }
+
+var _ debug.Debugger = &aggregatedWorker{}
 
 func (aw *aggregatedWorker) GetRegisteredWorkflows() []RegistryWorkflowInfo {
 	workflows := aw.registry.GetRegisteredWorkflows()
@@ -1010,6 +1013,10 @@ func (aw *aggregatedWorker) Stop() {
 	aw.logger.Info("Stopped Worker")
 }
 
+func (aw *aggregatedWorker) GetWorkerStats() debug.WorkerStats {
+	return aw.workerstats
+}
+
 // AggregatedWorker returns an instance to manage the workers. Use defaultConcurrentPollRoutineSize (which is 2) as
 // poller size. The typical RTT (round-trip time) is below 1ms within data center. And the poll API latency is about 5ms.
 // With 2 poller, we could achieve around 300~400 RPS.
@@ -1148,6 +1155,7 @@ func newAggregatedWorker(
 		shadowWorker:                    shadowWorker,
 		logger:                          logger,
 		registry:                        registry,
+		workerstats:                     workerParams.WorkerStats,
 	}
 }
 

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1116,6 +1116,7 @@ func TestWorkerOptionDefaults(t *testing.T) {
 	require.NotNil(t, activityWorker.executionParameters.MetricsScope)
 	require.Nil(t, activityWorker.executionParameters.ContextPropagators)
 	assertWorkerExecutionParamsEqual(t, expected, activityWorker.executionParameters)
+	assert.Equal(t, expected.WorkerStats, aggWorker.GetWorkerStats())
 }
 
 func TestWorkerOptionNonDefaults(t *testing.T) {
@@ -1176,6 +1177,7 @@ func TestWorkerOptionNonDefaults(t *testing.T) {
 	activityWorker := aggWorker.activityWorker
 	require.True(t, len(activityWorker.executionParameters.ContextPropagators) > 0)
 	assertWorkerExecutionParamsEqual(t, expected, activityWorker.executionParameters)
+	assert.Equal(t, expected.WorkerStats, aggWorker.GetWorkerStats())
 }
 
 func assertWorkerExecutionParamsEqual(t *testing.T, paramsA workerExecutionParameters, paramsB workerExecutionParameters) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This PR adds a debugger interface to the debug package

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently the WorkerStats struct is injected in the client by passing it as a worker options however there is no way of retrieving the WorkerStats or its fields from a Worker instance unless we keep track of Trackers instances that were constructed and passed as options seperately. In this PR, we make improvement to the design by adding a debugger interface. The internal worker implementation implements Debugger and allow consumers to retrieve the WorkerStats

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests
Local Test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
