### PR TITLE
Fixing panics in test activities

### DIFF
--- a/internal/internal_poller_autoscaler.go
+++ b/internal/internal_poller_autoscaler.go
@@ -83,11 +83,10 @@ func newPollerScaler(
 	options pollerAutoScalerOptions,
 	logger *zap.Logger,
 	hooks ...func()) *pollerAutoScaler {
-	ctx, cancel := context.WithCancel(context.Background())
 	if !options.Enabled {
 		return nil
 	}
-
+	ctx, cancel := context.WithCancel(context.Background())
 	return &pollerAutoScaler{
 		isDryRun:             options.DryRun,
 		cooldownTime:         options.Cooldown,

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1406,6 +1406,12 @@ func newActivityTaskHandlerWithCustomProvider(
 	registry *registry,
 	activityProvider activityProvider,
 ) ActivityTaskHandler {
+	if params.Tracer == nil {
+		params.Tracer = opentracing.NoopTracer{}
+	}
+	if params.WorkerStats.ActivityTracker == nil {
+		params.WorkerStats.ActivityTracker = debug.NewNoopActivityTracker()
+	}
 	return &activityTaskHandlerImpl{
 		taskListName:       params.TaskList,
 		identity:           params.Identity,

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -1248,7 +1248,6 @@ func (t *TaskHandlersTestSuite) TestLocalActivityRetry_DecisionHeartbeatFail() {
 		WorkerOptions: WorkerOptions{
 			Identity: "test-id-1",
 			Logger:   t.logger,
-			Tracer:   opentracing.NoopTracer{},
 		},
 		WorkerStopChannel: stopCh,
 	}

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -525,6 +525,12 @@ func (wtp *workflowTaskPoller) RespondTaskCompleted(completedRequest interface{}
 }
 
 func newLocalActivityPoller(params workerExecutionParameters, laTunnel *localActivityTunnel) *localActivityTaskPoller {
+	if params.Tracer == nil {
+		params.Tracer = opentracing.NoopTracer{}
+	}
+	if params.WorkerStats.ActivityTracker == nil {
+		params.WorkerStats.ActivityTracker = debug.NewNoopActivityTracker()
+	}
 	handler := &localActivityTaskHandler{
 		userContext:        params.UserContext,
 		metricsScope:       metrics.NewTaggedScope(params.MetricsScope),

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -281,6 +281,12 @@ func newWorkflowTaskPoller(
 	domain string,
 	params workerExecutionParameters,
 ) *workflowTaskPoller {
+	if params.Tracer == nil {
+		params.Tracer = opentracing.NoopTracer{}
+	}
+	if params.WorkerStats.PollerTracker == nil {
+		params.WorkerStats.PollerTracker = debug.NewNoopPollerTracker()
+	}
 	return &workflowTaskPoller{
 		basePoller:                   basePoller{shutdownC: params.WorkerStopChannel},
 		service:                      service,

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -281,12 +281,6 @@ func newWorkflowTaskPoller(
 	domain string,
 	params workerExecutionParameters,
 ) *workflowTaskPoller {
-	if params.Tracer == nil {
-		params.Tracer = opentracing.NoopTracer{}
-	}
-	if params.WorkerStats.PollerTracker == nil {
-		params.WorkerStats.PollerTracker = debug.NewNoopPollerTracker()
-	}
 	return &workflowTaskPoller{
 		basePoller:                   basePoller{shutdownC: params.WorkerStopChannel},
 		service:                      service,

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -165,6 +165,9 @@ func newWorkflowWorker(
 }
 
 func ensureRequiredParams(params *workerExecutionParameters) {
+	if params.Tracer == nil {
+		params.Tracer = opentracing.NoopTracer{}
+	}
 	if params.Identity == "" {
 		params.Identity = getWorkerIdentity(params.TaskList)
 	}

--- a/internal/internal_worker_interfaces_test.go
+++ b/internal/internal_worker_interfaces_test.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap/zaptest"
 
@@ -216,7 +215,7 @@ func (s *InterfacesTestSuite) TestInterface() {
 			MaxConcurrentActivityTaskPollers: 10,
 			MaxConcurrentDecisionTaskPollers: 10,
 			Logger:                           zaptest.NewLogger(s.T()),
-		}
+		},
 	}
 
 	// Register activity instances and launch the worker.

--- a/internal/internal_worker_interfaces_test.go
+++ b/internal/internal_worker_interfaces_test.go
@@ -184,7 +184,7 @@ func (s *InterfacesTestSuite) TestInterface() {
 			MaxConcurrentActivityTaskPollers: 4,
 			MaxConcurrentDecisionTaskPollers: 4,
 			Logger:                           zaptest.NewLogger(s.T()),
-			Tracer:                           opentracing.NoopTracer{}},
+		},
 	}
 
 	domainStatus := m.DomainStatusRegistered
@@ -216,7 +216,7 @@ func (s *InterfacesTestSuite) TestInterface() {
 			MaxConcurrentActivityTaskPollers: 10,
 			MaxConcurrentDecisionTaskPollers: 10,
 			Logger:                           zaptest.NewLogger(s.T()),
-			Tracer:                           opentracing.NoopTracer{}},
+		}
 	}
 
 	// Register activity instances and launch the worker.

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1142,8 +1142,8 @@ func TestWorkerOptionNonDefaults(t *testing.T) {
 		DataConverter:                           &defaultDataConverter{},
 		BackgroundActivityContext:               context.Background(),
 		Logger:                                  zap.NewNop(),
-		MetricsScope:                            tally.NoopScope,
-		Tracer:                                  opentracing.NoopTracer{},
+		MetricsScope:                            tally.NewTestScope("", nil),
+		Tracer:                                  opentracing.GlobalTracer(),
 	}
 
 	aggWorker, err := newAggregatedWorker(nil, domain, taskList, options)

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -274,6 +274,7 @@ func (s *internalWorkerTestSuite) TestNoActivitiesOrWorkflows() {
 	assert.Empty(t, w.registry.getRegisteredActivities())
 	assert.Empty(t, w.registry.GetRegisteredWorkflowTypes())
 	assert.NoError(t, w.Start())
+	w.Stop()
 }
 
 func (s *internalWorkerTestSuite) TestWorkerStartFailsWithInvalidDomain() {

--- a/internal/worker_test.go
+++ b/internal/worker_test.go
@@ -26,6 +26,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestMain(m *testing.M) {
+	EnableVerboseLogging(true)
+	m.Run()
+}
+
 func Test_NewWorker(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I've fixed missing arguments in test worker implementations that caused tests to be flaky.
1. Centralized additional params initialization and ensured that everything was initialized before use.
2. Set Enable Logging to be true so tests will get all trace log messages covered.

<!-- Tell your future self why have you made these changes -->
**Why?**
Improve stability of tests

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
