### PR TITLE
Fix go-generate calling, do more before running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,8 @@ $(THRIFT_GEN): $(THRIFT_FILES) $(BIN)/thriftrw $(BIN)/thriftrw-plugin-yarpc
 	$Q touch $@
 
 # mockery is quite noisy so it's worth being kinda precise with the files.
-# this needs to be both the files defining the generate command, AND the files that define the interfaces.
+# as long as the //go:generate line is in the file that defines the thing to mock, this will auto-discover it.
+# if we build any fancier generators, like the server's wrappers, this might need adjusting / switch to completely manual.
 $(BUILD)/generate: $(shell grep --files-with-matches -E '^//go:generate' $(ALL_SRC)) $(BIN)/mockery
 	$Q $(BIN_PATH) go generate ./...
 	$Q touch $@

--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ errcheck: $(BIN)/errcheck $(BUILD)/fmt ## (re)run errcheck
 	$(BIN)/errcheck ./...
 
 .PHONY: generate
-generate: ## run go-generate (build, lint, fmt all do this for you if needed)
+generate: ## run go-generate (build, lint, fmt, tests all do this for you if needed)
 	$(call remake,generate)
 
 .PHONY: tidy

--- a/client/client.go
+++ b/client/client.go
@@ -21,8 +21,6 @@
 // when adding any, make sure you update the files that it checks in the makefile
 //go:generate mockery --srcpkg . --name Client --output ../mocks --boilerplate-file ../LICENSE
 //go:generate mockery --srcpkg . --name DomainClient --output ../mocks --boilerplate-file ../LICENSE
-//go:generate mockery --srcpkg go.uber.org/cadence/internal --name HistoryEventIterator --output ../mocks --boilerplate-file ../LICENSE
-//go:generate mockery --srcpkg go.uber.org/cadence/internal --name WorkflowRun --output ../mocks --boilerplate-file ../LICENSE
 
 // Package client contains functions to create Cadence clients used to communicate to Cadence service.
 //

--- a/encoded/encoded.go
+++ b/encoded/encoded.go
@@ -18,8 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-//go:generate mockery --srcpkg go.uber.org/cadence/internal --name Value --output ../mocks --boilerplate-file ../LICENSE
-
 // Package encoded contains wrappers that are used for binary payloads deserialization.
 package encoded
 

--- a/internal/encoded.go
+++ b/internal/encoded.go
@@ -27,6 +27,8 @@ import (
 	"go.uber.org/cadence/internal/common/util"
 )
 
+//go:generate mockery --name Value --output ../mocks --boilerplate-file ../LICENSE
+
 type (
 	// Value is used to encapsulate/extract encoded value from workflow/activity.
 	Value interface {

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -41,6 +41,9 @@ import (
 	"go.uber.org/cadence/internal/common/metrics"
 )
 
+//go:generate mockery --name HistoryEventIterator --output ../mocks --boilerplate-file ../LICENSE
+//go:generate mockery --name WorkflowRun --output ../mocks --boilerplate-file ../LICENSE
+
 // Assert that structs do indeed implement the interfaces
 var _ Client = (*workflowClient)(nil)
 


### PR DESCRIPTION
Does a couple things:
- `make $(BUILD)/generate` now infers files that might affect generation.  This should work as long as we keep simple codegen (the server has moved beyond this, sadly).
- `make generate` now forces re-generation regardless of need, because it's a nice workaround for dependency issues like happened in #1373
- `make test` and related targets now go-generate and fmt before running tests.  Slower, but you can't forget to re-generate, and they're slow already so it's probably fine.
