### PR TITLE
Add unit tests for GetVersion

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -623,7 +623,10 @@ func (wc *workflowEnvironmentImpl) GetVersion(changeID string, minSupported, max
 		// Also upsert search attributes to enable ability to search by changeVersion.
 		version = maxSupported
 		wc.decisionsHelper.recordVersionMarker(changeID, version, wc.GetDataConverter())
-		wc.UpsertSearchAttributes(createSearchAttributesForChangeVersion(changeID, version, wc.changeVersions))
+		err := wc.UpsertSearchAttributes(createSearchAttributesForChangeVersion(changeID, version, wc.changeVersions))
+		if err != nil {
+			wc.logger.Warn("UpsertSearchAttributes failed", zap.Error(err))
+		}
 	}
 
 	validateVersion(changeID, version, minSupported, maxSupported)

--- a/internal/internal_event_handlers_test.go
+++ b/internal/internal_event_handlers_test.go
@@ -722,12 +722,12 @@ func TestSideEffect(t *testing.T) {
 
 func TestGetVersion_validation(t *testing.T) {
 	t.Run("version < minSupported", func(t *testing.T) {
-		assert.PanicsWithValue(t, `Workflow code removed support of version 1. for \"test\" changeID. The oldest supported version is 2`, func() {
+		assert.PanicsWithValue(t, `Workflow code removed support of version 1. for "test" changeID. The oldest supported version is 2`, func() {
 			validateVersion("test", 1, 2, 3)
 		})
 	})
 	t.Run("version > maxSupported", func(t *testing.T) {
-		assert.PanicsWithValue(t, `Workflow code is too old to support version 3 for \"test\" changeID. The maximum supported version is 2`, func() {
+		assert.PanicsWithValue(t, `Workflow code is too old to support version 3 for "test" changeID. The maximum supported version is 2`, func() {
 			validateVersion("test", 3, 1, 2)
 		})
 	})

--- a/internal/internal_event_handlers_test.go
+++ b/internal/internal_event_handlers_test.go
@@ -720,6 +720,49 @@ func TestSideEffect(t *testing.T) {
 	})
 }
 
+func TestGetVersion_validation(t *testing.T) {
+	t.Run("version < minSupported", func(t *testing.T) {
+		assert.PanicsWithValue(t, `Workflow code removed support of version 1. for \"test\" changeID. The oldest supported version is 2`, func() {
+			validateVersion("test", 1, 2, 3)
+		})
+	})
+	t.Run("version > maxSupported", func(t *testing.T) {
+		assert.PanicsWithValue(t, `Workflow code is too old to support version 3 for \"test\" changeID. The maximum supported version is 2`, func() {
+			validateVersion("test", 3, 1, 2)
+		})
+	})
+	t.Run("success", func(t *testing.T) {
+		validateVersion("test", 2, 1, 3)
+	})
+}
+
+func TestGetVersion(t *testing.T) {
+	t.Run("version exists", func(t *testing.T) {
+		weh := testWorkflowExecutionEventHandler(t, newRegistry())
+		weh.changeVersions = map[string]Version{
+			"test": 2,
+		}
+		res := weh.GetVersion("test", 1, 3)
+		assert.Equal(t, Version(2), res)
+	})
+	t.Run("version doesn't exist in replay", func(t *testing.T) {
+		weh := testWorkflowExecutionEventHandler(t, newRegistry())
+		weh.isReplay = true
+		res := weh.GetVersion("test", DefaultVersion, 3)
+		assert.Equal(t, DefaultVersion, res)
+		require.Contains(t, weh.changeVersions, "test")
+		assert.Equal(t, DefaultVersion, weh.changeVersions["test"])
+	})
+	t.Run("version doesn't exist without replay", func(t *testing.T) {
+		weh := testWorkflowExecutionEventHandler(t, newRegistry())
+		res := weh.GetVersion("test", DefaultVersion, 3)
+		assert.Equal(t, Version(3), res)
+		require.Contains(t, weh.changeVersions, "test")
+		assert.Equal(t, Version(3), weh.changeVersions["test"])
+		assert.Equal(t, []byte(`["test-3"]`), weh.workflowInfo.SearchAttributes.IndexedFields[CadenceChangeVersion], "ensure search attributes are updated")
+	})
+}
+
 func testWorkflowExecutionEventHandler(t *testing.T, registry *registry) *workflowExecutionEventHandlerImpl {
 	return newWorkflowExecutionEventHandler(
 		testWorkflowInfo,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add unit tests for GetVersion and added a log for error in UpsertSearchAttributes.

The error handling is a noop and happens only if we cannot serialize data. This is not expected to happen with the existing GetVersion API.

<!-- Tell your future self why have you made these changes -->
**Why?**
Improving test coverage.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
