### PR TITLE
Exclude public wrappers from coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -41,3 +41,6 @@ ignore:
   - "mocks/**"
   - "test/**"
   - "testsuite/**"
+  # exclude wrappers around internal functions
+  - "activity/**"
+  - "workflow/**"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Excluding public wrappers from coverage.

<!-- Tell your future self why have you made these changes -->
**Why?**
Cadence-client provides a set of public callable methods, wrappers around actual implementations in the internal folder.

These wrappers are safe to exclude from coverage since they have no logic to test.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
