### PR TITLE
docs: Convert slack links to CNCF, add link to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 This doc is intended for contributors to `cadence-client` (hopefully that's you!)
 
+> 📚 **New to contributing to Cadence?** Check out our [Contributing Guide](https://cadenceworkflow.io/community/how-to-contribute/getting-started) for an overview of the contribution process across all Cadence repositories. This document contains cadence-client specific setup and development instructions.
+
+Once you go through the rest of this doc and get familiar with local development setup, feel free to start contributing!
+
+Join our community on the CNCF Slack workspace at [cloud-native.slack.com](https://communityinviter.com/apps/cloud-native/cncf) in the **#cadence-users** channel to reach out and discuss issues with the team.
+
 **Note:** All contributors also need to fill out the [Uber Contributor License Agreement](http://t.uber.com/cla) before we can merge in any of your changes
 
 ## Development Environment

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Go framework for Cadence
 [![CI Checks](https://github.com/cadence-workflow/cadence-go-client/actions/workflows/ci-checks.yml/badge.svg)](https://github.com/cadence-workflow/cadence-go-client/actions/workflows/ci-checks.yml)
 [![Coverage](https://codecov.io/gh/uber-go/cadence-client/graph/badge.svg?token=iEpqo5HbDe)](https://codecov.io/gh/uber-go/cadence-client)
+[![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://communityinviter.com/apps/cloud-native/cncf)
 [![GoDoc](https://godoc.org/go.uber.org/cadence?status.svg)](https://godoc.org/go.uber.org/cadence)
 
 [Cadence](https://github.com/uber/cadence) is a distributed, scalable, durable, and highly available orchestration engine we developed at Uber Engineering to execute asynchronous long-running business logic in a scalable and resilient way.
@@ -28,6 +29,8 @@ You can also find the API documentation [here](https://godoc.org/go.uber.org/cad
 
 ## Contributing
 We'd love your help in making the Cadence Go client great. Please review our [contribution guidelines](CONTRIBUTING.md).
+
+If you'd like to propose a new feature or discuss issues, join the [CNCF Slack workspace](https://communityinviter.com/apps/cloud-native/cncf) in the **#cadence-users** channel to start a discussion.
 
 ## License
 Apache 2.0 License, please see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
**What changed?**

Converts links from our old slack instance to the CNCF community inviter.
Adds a link to our shared contributing guide to the contributing readme.

**Why?**

The goal of the contribution guide is to move all common guides and processes between our repositories to a shared place – reducing conflicting information and streamlining the process to contribute to cadence.

**How did you test it?**

N/A