### PR TITLE
fix: missing fields for FailoverDomain API call 

### DIFF
--- a/internal/compatibility/proto/request.go
+++ b/internal/compatibility/proto/request.go
@@ -698,10 +698,16 @@ func FailoverDomainRequest(t *shared.FailoverDomainRequest) *apiv1.FailoverDomai
 	if t == nil {
 		return nil
 	}
-	return &apiv1.FailoverDomainRequest{
-		DomainName:              t.GetDomainName(),
-		DomainActiveClusterName: *t.DomainActiveClusterName,
+	request := &apiv1.FailoverDomainRequest{
+		DomainName: t.GetDomainName(),
 	}
+	if t.DomainActiveClusterName != nil {
+		request.DomainActiveClusterName = *t.DomainActiveClusterName
+	}
+	if t.ActiveClusters != nil {
+		request.ActiveClusters = ActiveClusters(t.ActiveClusters)
+	}
+	return request
 }
 
 func ListFailoverHistoryRequest(t *shared.ListFailoverHistoryRequest) *apiv1.ListFailoverHistoryRequest {

--- a/internal/compatibility/proto/response.go
+++ b/internal/compatibility/proto/response.go
@@ -350,6 +350,38 @@ func UpdateDomainResponse(t *shared.UpdateDomainResponse) *apiv1.UpdateDomainRes
 	}
 }
 
+func FailoverDomainResponse(t *shared.FailoverDomainResponse) *apiv1.FailoverDomainResponse {
+	if t == nil {
+		return nil
+	}
+	domain := apiv1.Domain{
+		FailoverVersion: t.GetFailoverVersion(),
+		IsGlobalDomain:  t.GetIsGlobalDomain(),
+	}
+	if info := t.DomainInfo; info != nil {
+		domain.Id = info.GetUUID()
+		domain.Name = info.GetName()
+		domain.Status = DomainStatus(info.Status)
+		domain.Description = info.GetDescription()
+		domain.OwnerEmail = info.GetOwnerEmail()
+		domain.Data = info.Data
+	}
+	if config := t.Configuration; config != nil {
+		domain.WorkflowExecutionRetentionPeriod = daysToDuration(config.WorkflowExecutionRetentionPeriodInDays)
+		domain.BadBinaries = BadBinaries(config.BadBinaries)
+		domain.HistoryArchivalStatus = ArchivalStatus(config.HistoryArchivalStatus)
+		domain.HistoryArchivalUri = config.GetHistoryArchivalURI()
+		domain.VisibilityArchivalStatus = ArchivalStatus(config.VisibilityArchivalStatus)
+		domain.VisibilityArchivalUri = config.GetVisibilityArchivalURI()
+	}
+	if repl := t.ReplicationConfiguration; repl != nil {
+		domain.ActiveClusterName = repl.GetActiveClusterName()
+		domain.Clusters = ClusterReplicationConfigurationArray(repl.Clusters)
+		domain.ActiveClusters = ActiveClusters(repl.ActiveClusters)
+	}
+	return &apiv1.FailoverDomainResponse{Domain: &domain}
+}
+
 func ListFailoverHistoryResponse(t *shared.ListFailoverHistoryResponse) *apiv1.ListFailoverHistoryResponse {
 	if t == nil {
 		return nil

--- a/internal/compatibility/testdata/service.go
+++ b/internal/compatibility/testdata/service.go
@@ -107,6 +107,14 @@ var (
 		Name:          DomainName,
 		SecurityToken: SecurityToken,
 	}
+	FailoverDomainRequest = apiv1.FailoverDomainRequest{
+		DomainName:              DomainName,
+		DomainActiveClusterName: ClusterName1,
+		ActiveClusters:          ActiveClusters,
+	}
+	FailoverDomainResponse = apiv1.FailoverDomainResponse{
+		Domain: &Domain,
+	}
 	ListWorkflowExecutionsRequest = apiv1.ListWorkflowExecutionsRequest{
 		Domain:        DomainName,
 		PageSize:      PageSize,

--- a/internal/compatibility/thrift/request.go
+++ b/internal/compatibility/thrift/request.go
@@ -604,6 +604,22 @@ func ListOpenWorkflowExecutionsRequest(r *apiv1.ListOpenWorkflowExecutionsReques
 	}
 }
 
+func FailoverDomainRequest(t *apiv1.FailoverDomainRequest) *shared.FailoverDomainRequest {
+	if t == nil {
+		return nil
+	}
+	request := &shared.FailoverDomainRequest{
+		DomainName: &t.DomainName,
+	}
+	if t.DomainActiveClusterName != "" {
+		request.DomainActiveClusterName = &t.DomainActiveClusterName
+	}
+	if t.ActiveClusters != nil {
+		request.ActiveClusters = ActiveClusters(t.ActiveClusters)
+	}
+	return request
+}
+
 func ListFailoverHistoryRequest(t *apiv1.ListFailoverHistoryRequest) *shared.ListFailoverHistoryRequest {
 	if t == nil {
 		return nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
The FailoverDomain endpoint is missing a few fields for cluster attributes. This maps them and adds a few tests to cover this. More problematic, is the response struct which, to be honest, I didn't realise was returning the entire domain data. So this also updates / maps that. 

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
