### PR TITLE
test: add Maybe() to MockCallWrapper

### DIFF
--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -404,6 +404,13 @@ func (c *MockCallWrapper) Times(i int) *MockCallWrapper {
 	return c
 }
 
+// Maybe indicates that the mock is optional.
+// Not calling an optional mock will not cause an error while asserting expectations.
+func (c *MockCallWrapper) Maybe() *MockCallWrapper {
+	c.call.Maybe()
+	return c
+}
+
 // Run sets a handler to be called before returning. It can be used when mocking a method such as unmarshalers that
 // takes a pointer to a struct and sets properties in such struct.
 func (c *MockCallWrapper) Run(fn func(args mock.Arguments)) *MockCallWrapper {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added a new `Maybe()` assertion on mock calls.

<!-- Tell your future self why have you made these changes -->
**Why?**
This allows for asserting calls that are optional (i.e., fire-and-forget calls that are sometimes racey and are not scheduled) and are not core to the functions that are tested.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
`Maybe()` is [supported](https://pkg.go.dev/github.com/stretchr/testify/mock#Call.Maybe) by the underlying `mock.Call` used in `MockCallWrapper`, so we simply wrapped over it.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A, for testing use cases