### PR TITLE
fix: update WorkflowInfo ExecutionStartToCloseTimeoutSeconds to match TestWorkflowEnvironment timeout

### DIFF
--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -478,6 +478,7 @@ func (t *TestWorkflowEnvironment) SetTestTimeout(idleTimeout time.Duration) *Tes
 // This is based on the workflow time (a.k.a workflow.Now() time).
 func (t *TestWorkflowEnvironment) SetWorkflowTimeout(executionTimeout time.Duration) *TestWorkflowEnvironment {
 	t.impl.executionTimeout = executionTimeout
+	t.impl.workflowInfo.ExecutionStartToCloseTimeoutSeconds = int32(executionTimeout.Seconds())
 	return t
 }
 

--- a/internal/workflow_testsuite_test.go
+++ b/internal/workflow_testsuite_test.go
@@ -30,6 +30,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSetWorkflowTimeout(t *testing.T) {
+	t.Parallel()
+	env := newTestWorkflowEnv(t)
+
+	executionTimeout := 30 * time.Minute
+	require.Equal(t, int32(1), env.impl.workflowInfo.ExecutionStartToCloseTimeoutSeconds)
+
+	result := env.SetWorkflowTimeout(executionTimeout)
+
+	require.Equal(t, env, result)
+	require.Equal(t, int32(executionTimeout.Seconds()), result.impl.workflowInfo.ExecutionStartToCloseTimeoutSeconds)
+	require.Equal(t, executionTimeout, result.impl.executionTimeout)
+}
+
 func TestSetMemoOnStart(t *testing.T) {
 	t.Parallel()
 	env := newTestWorkflowEnv(t)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

The workflow relies on `ExecutionStartToCloseTimeoutSeconds` ([see usage](https://github.com/cadence-workflow/cadence/blob/66a86e0107bf0ce1a80ddeebd45ea58941be62eb/bench/load/timer/launchWorkflow.go#L65)). 

With this change I am updating test `WorkflowInfo`'s `ExecutionStartToCloseTimeoutSeconds` to match the execution timeout specified to the `TestWorkflowEnvironment`

Relevant issue:
https://github.com/cadence-workflow/cadence/issues/7563

<!-- Tell your future self why have you made these changes -->
**Why?**

If it is not done then `ExecutionStartToCloseTimeoutSeconds` is [always set to 1](https://github.com/cadence-workflow/cadence-go-client/blob/f0ff1c04a44f4200a5e00c2fc470f38f1cbfe6a0/internal/internal_workflow_testsuite.go#L253).


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
