### PR TITLE
fix: do not terminate worker on non-retryable poll errors

### DIFF
--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -27,9 +27,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"sync"
-	"syscall"
 	"time"
 
 	"go.uber.org/cadence/internal/common/debug"
@@ -338,10 +336,7 @@ func (bw *baseWorker) pollTask() {
 		}
 		if err != nil {
 			if isNonRetriableError(err) {
-				bw.logger.Error("Worker received non-retriable error. Shutting down.", zap.Error(err))
-				p, _ := os.FindProcess(os.Getpid())
-				p.Signal(syscall.SIGINT)
-				return
+				bw.logger.Error("Worker received non-retriable error from PollTask; continue polling.", zap.Error(err)) //Report error and continue polling
 			}
 			bw.retrier.Failed()
 		} else {

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
+	"go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/internal/common/debug"
 )
 
@@ -52,6 +53,31 @@ func TestBaseWorker_processTask_warnLogOnOtherError(t *testing.T) {
 	assert.GreaterOrEqual(t, observed.FilterMessage("poller permit acquire error").Len(), 1)
 }
 
+func TestBaseWorker_pollTask_logsNonRetriableError(t *testing.T) {
+	core, observed := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core, zap.Development())
+
+	worker := newBaseWorker(baseWorkerOptions{
+		maxConcurrentTask:             1,
+		pollerCountWithoutAutoScaling: 1,
+		identity:                      "test-identity",
+		pollerTracker:                 debug.NewNoopPollerTracker(),
+		taskWorker:                    &nonRetryableTaskWorker{},
+	}, logger, tally.NoopScope, nil)
+
+	// Simulate two successive poll iterations
+	// Verify the worker continues polling after a non-retriable PollTask error
+	assert.NoError(t, worker.concurrency.TaskPermit.Acquire(worker.limiterContext))
+	worker.pollTask()
+
+	assert.NoError(t, worker.concurrency.TaskPermit.Acquire(worker.limiterContext))
+	worker.pollTask()
+
+	assert.Equal(t, 2, observed.FilterMessage(
+		"Worker received non-retriable error from PollTask; continue polling.",
+	).Len())
+}
+
 type testTaskWorker struct{}
 
 func (t *testTaskWorker) PollTask() (interface{}, error) {
@@ -59,5 +85,15 @@ func (t *testTaskWorker) PollTask() (interface{}, error) {
 }
 
 func (t *testTaskWorker) ProcessTask(task interface{}) error {
+	return nil
+}
+
+type nonRetryableTaskWorker struct{}
+
+func (t *nonRetryableTaskWorker) PollTask() (interface{}, error) {
+	return nil, &shared.BadRequestError{Message: "bad request"}
+}
+
+func (t *nonRetryableTaskWorker) ProcessTask(task interface{}) error {
 	return nil
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
**Related:** cadence-workflow/cadence#7561
Updated baseWorker.pollTask() in internal/internal_worker_base.go addressing request to remove unretryable error logic. Now the worker logs the error and continues polling instead of self-terminating. 
Added a unit test in internal_worker_base_test.go to test error behavior.

<!-- Tell your future self why have you made these changes -->
**Why?**
Fixes cadence-workflow/cadence#7561

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Uses cadence-go-client make unit_test on macOS (exit code 0).

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
The worker no longer exits on non-retryable poll errors, so it may continue running and repeatedly backoff. Backoff is preserved to prevent tight-looping, but log volume could explode if the underlying problem persists.