### PR TITLE
feat: Add cadence-caller-type to client header

### DIFF
--- a/evictiontest/workflow_cache_eviction_test.go
+++ b/evictiontest/workflow_cache_eviction_test.go
@@ -56,6 +56,7 @@ func callOptions() []interface{} {
 		gomock.Any(), // library version
 		gomock.Any(), // feature version
 		gomock.Any(), // client name
+		gomock.Any(), // caller type
 		gomock.Any(), // feature flags
 		gomock.Any(), // isolation group
 	}

--- a/internal/client.go
+++ b/internal/client.go
@@ -671,7 +671,7 @@ func NewClient(service workflowserviceclient.Interface, domain string, options *
 	if options != nil {
 		metricScope = options.MetricsScope
 	}
-	metricScope = tagScope(metricScope, tagDomain, domain, clientImplHeaderName, clientImplHeaderValue)
+	metricScope = tagScope(metricScope, tagDomain, domain, clientImplHeaderName, clientImplHeaderValue, callerTypeHeaderName, callerTypeHeaderValue)
 	var dataConverter DataConverter
 	if options != nil && options.DataConverter != nil {
 		dataConverter = options.DataConverter
@@ -721,7 +721,7 @@ func NewDomainClient(service workflowserviceclient.Interface, options *ClientOpt
 	if options != nil {
 		metricScope = options.MetricsScope
 	}
-	metricScope = tagScope(metricScope, tagDomain, "domain-client", clientImplHeaderName, clientImplHeaderValue)
+	metricScope = tagScope(metricScope, tagDomain, "domain-client", clientImplHeaderName, clientImplHeaderValue, callerTypeHeaderName, callerTypeHeaderValue)
 	if options != nil && options.Authorization != nil {
 		service = auth.NewWorkflowServiceWrapper(service, options.Authorization)
 	}

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -96,7 +96,7 @@ func TestRespondTaskCompleted_failed(t *testing.T) {
 			Details:        []byte(assert.AnError.Error()),
 			Identity:       common.StringPtr(_testIdentity),
 			BinaryChecksum: common.StringPtr(getBinaryChecksum()),
-		}, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		}, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 		res, err := poller.RespondTaskCompletedWithMetrics(nil, assert.AnError, &s.PollForDecisionTaskResponse{
 			TaskToken: testTaskToken,
@@ -115,7 +115,7 @@ func TestRespondTaskCompleted_failed(t *testing.T) {
 			Details:        []byte(assert.AnError.Error()),
 			Identity:       common.StringPtr(_testIdentity),
 			BinaryChecksum: common.StringPtr(getBinaryChecksum()),
-		}, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(assert.AnError)
+		}, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(assert.AnError)
 
 		// We cannot test RespondTaskCompleted since it uses backoff and has a hardcoded retry mechanism for 60 seconds.
 		_, err := poller.respondTaskCompletedAttempt(errorToFailDecisionTask(testTaskToken, assert.AnError, _testIdentity), &s.PollForDecisionTaskResponse{

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -59,6 +59,10 @@ const (
 	clientImplHeaderName  = "cadence-client-name"
 	clientImplHeaderValue = "uber-go"
 
+	// callerTypeHeaderName refers to the name of the header that contains the caller type
+	callerTypeHeaderName  = "cadence-caller-type"
+	callerTypeHeaderValue = "sdk"
+
 	clientFeatureFlagsHeaderName = "cadence-client-feature-flags"
 
 	// defaultRPCTimeout is the default tchannel rpc call timeout
@@ -86,6 +90,7 @@ var (
 		yarpc.WithHeader(libraryVersionHeaderName, LibraryVersion),
 		yarpc.WithHeader(featureVersionHeaderName, FeatureVersion),
 		yarpc.WithHeader(clientImplHeaderName, clientImplHeaderValue),
+		yarpc.WithHeader(callerTypeHeaderName, callerTypeHeaderValue),
 	}
 )
 

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1045,7 +1045,7 @@ func newAggregatedWorker(
 	}
 
 	ensureRequiredParams(&workerParams)
-	workerParams.MetricsScope = tagScope(workerParams.MetricsScope, tagDomain, domain, tagTaskList, taskList, clientImplHeaderName, clientImplHeaderValue)
+	workerParams.MetricsScope = tagScope(workerParams.MetricsScope, tagDomain, domain, tagTaskList, taskList, clientImplHeaderName, clientImplHeaderValue, callerTypeHeaderName, callerTypeHeaderValue)
 	workerParams.Logger = workerParams.Logger.With(
 		zapcore.Field{Key: tagDomain, Type: zapcore.StringType, String: domain},
 		zapcore.Field{Key: tagTaskList, Type: zapcore.StringType, String: taskList},

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -520,7 +520,7 @@ func (s *workflowRunSuite) TestExecuteWorkflowWorkflowExecutionAlreadyStartedErr
 	}
 	getHistory := s.workflowServiceClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), gomock.Any(), callOptions()...).
 		Return(getResponse, nil).Times(1)
-	getHistory.Do(func(ctx interface{}, getRequest *shared.GetWorkflowExecutionHistoryRequest, opt1 interface{}, opt2 interface{}, opt3 interface{}, opt4 interface{}) {
+	getHistory.Do(func(ctx interface{}, getRequest *shared.GetWorkflowExecutionHistoryRequest, opt1 interface{}, opt2 interface{}, opt3 interface{}, opt4 interface{}, opt5 interface{}) {
 		workflowID := getRequest.Execution.WorkflowId
 		s.NotNil(workflowID)
 		s.NotEmpty(*workflowID)
@@ -576,7 +576,7 @@ func (s *workflowRunSuite) TestExecuteWorkflowWorkflowExecutionAlreadyStartedErr
 	}
 	getHistory := s.workflowServiceClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), gomock.Any(), callOptions()...).
 		Return(getResponse, nil).Times(1)
-	getHistory.Do(func(ctx interface{}, getRequest *shared.GetWorkflowExecutionHistoryRequest, opt1 interface{}, opt2 interface{}, opt3 interface{}, opt4 interface{}) {
+	getHistory.Do(func(ctx interface{}, getRequest *shared.GetWorkflowExecutionHistoryRequest, opt1 interface{}, opt2 interface{}, opt3 interface{}, opt4 interface{}, opt5 interface{}) {
 		workflowID := getRequest.Execution.WorkflowId
 		s.NotNil(workflowID)
 		s.NotEmpty(*workflowID)
@@ -627,7 +627,7 @@ func (s *workflowRunSuite) TestExecuteWorkflow_NoIdInOptions() {
 	}
 	var wid *string
 	getHistory := s.workflowServiceClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), gomock.Any(), callOptions()...).Return(getResponse, nil).Times(1)
-	getHistory.Do(func(ctx interface{}, getRequest *shared.GetWorkflowExecutionHistoryRequest, opt1 interface{}, opt2 interface{}, opt3 interface{}, opt4 interface{}) {
+	getHistory.Do(func(ctx interface{}, getRequest *shared.GetWorkflowExecutionHistoryRequest, opt1 interface{}, opt2 interface{}, opt3 interface{}, opt4 interface{}, opt5 interface{}) {
 		wid = getRequest.Execution.WorkflowId
 		s.NotNil(wid)
 		s.NotEmpty(*wid)
@@ -680,7 +680,7 @@ func (s *workflowRunSuite) TestExecuteWorkflow_NoIdInOptions_RawHistory() {
 	}
 	var wid *string
 	getHistory := s.workflowServiceClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), gomock.Any(), callOptions()...).Return(getResponse, nil).Times(1)
-	getHistory.Do(func(ctx interface{}, getRequest *shared.GetWorkflowExecutionHistoryRequest, opt1 interface{}, opt2 interface{}, opt3 interface{}, opt4 interface{}) {
+	getHistory.Do(func(ctx interface{}, getRequest *shared.GetWorkflowExecutionHistoryRequest, opt1 interface{}, opt2 interface{}, opt3 interface{}, opt4 interface{}, opt5 interface{}) {
 		wid = getRequest.Execution.WorkflowId
 		s.NotNil(wid)
 		s.NotEmpty(*wid)
@@ -1333,7 +1333,7 @@ func (s *workflowClientTestSuite) TestSignalWithStartWorkflow_WithMemoAndSearchA
 	startResp := &shared.StartWorkflowExecutionResponse{}
 
 	s.service.EXPECT().SignalWithStartWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any(),
-		gomock.Any(), gomock.Any(), gomock.Any()).Return(startResp, nil).
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(startResp, nil).
 		Do(func(_ interface{}, req *shared.SignalWithStartWorkflowExecutionRequest, _ ...interface{}) {
 			// trailing newline is added by the dataconverter
 			s.Equal([]byte("\"memo value\"\n"), req.Memo.Fields["testMemo"], "memos use the dataconverter because they are user data")
@@ -1364,7 +1364,7 @@ func (s *workflowClientTestSuite) TestSignalWithStartWorkflowAsync_WithMemoAndSe
 	}
 
 	s.service.EXPECT().SignalWithStartWorkflowExecutionAsync(gomock.Any(), gomock.Any(), gomock.Any(),
-		gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).
 		Do(func(_ interface{}, asyncReq *shared.SignalWithStartWorkflowExecutionAsyncRequest, _ ...interface{}) {
 			req := asyncReq.Request
 			// trailing newline is added by the dataconverter
@@ -1418,7 +1418,7 @@ func (s *workflowClientTestSuite) TestSignalWithStartWorkflowAsync_RPCError() {
 	}
 
 	s.service.EXPECT().SignalWithStartWorkflowExecutionAsync(gomock.Any(), gomock.Any(), gomock.Any(),
-		gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("failed")).MinTimes(1)
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("failed")).MinTimes(1)
 
 	// Pass a context with a deadline so error retry doesn't take forever
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/internal/test_helpers_test.go
+++ b/internal/test_helpers_test.go
@@ -49,6 +49,7 @@ func callOptions() []interface{} {
 		gomock.Any(), // library version
 		gomock.Any(), // feature version
 		gomock.Any(), // client name
+		gomock.Any(), // caller type
 		gomock.Any(), // feature flags
 	}
 }
@@ -60,6 +61,7 @@ func callOptionsWithIsolationGroupHeader() []interface{} {
 		gomock.Any(), // library version
 		gomock.Any(), // feature version
 		gomock.Any(), // client name
+		gomock.Any(), // caller type
 		gomock.Any(), // feature flags
 		gomock.Any(), // isolation group header
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added cadence-caller-type to go client header with the value "sdk".

<!-- Tell your future self why have you made these changes -->
**Why?**
We want to have more information about the caller when receiving and processing requests. There is some overlap with the exiting cadence-client-name header but they will serve different purposes.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Updated unit tests. Tested locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

**Detailed Description**
Added new key-value pair to header.

**Impact Analysis**
- **Backward Compatibility**: It just adds a new header key-value pair. It's backwards compatible
- **Forward Compatibility**: It just adds a new header key-value pair. It's forward compatible

**Testing Plan**
- **Unit Tests**: No unit tests for headers
- **Persistence Tests**: N/A
- **Integration Tests**: N/A
- **Compatibility Tests**: N/A

**Rollout Plan**
- What is the rollout plan? Rollout in the next client release
- Does the order of deployment matter? No
- Is it safe to rollback? Does the order of rollback matter? Yes, it's safe to rollback.
- Is there a kill switch to mitigate the impact immediately? No