### PR TITLE
feat(workflow): add GetActivityOptions to read options from context

### DIFF
--- a/internal/convert.go
+++ b/internal/convert.go
@@ -21,6 +21,8 @@
 package internal
 
 import (
+	"time"
+
 	s "go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/internal/common"
 	"go.uber.org/cadence/internal/common/backoff"
@@ -42,6 +44,20 @@ func convertRetryPolicy(retryPolicy *RetryPolicy) *s.RetryPolicy {
 		thriftRetryPolicy.BackoffCoefficient = common.Float64Ptr(backoff.DefaultBackoffCoefficient)
 	}
 	return &thriftRetryPolicy
+}
+
+func convertFromThriftRetryPolicy(p *s.RetryPolicy) *RetryPolicy {
+	if p == nil {
+		return nil
+	}
+	return &RetryPolicy{
+		InitialInterval:          time.Second * time.Duration(p.GetInitialIntervalInSeconds()),
+		BackoffCoefficient:       p.GetBackoffCoefficient(),
+		MaximumInterval:          time.Second * time.Duration(p.GetMaximumIntervalInSeconds()),
+		ExpirationInterval:       time.Second * time.Duration(p.GetExpirationIntervalInSeconds()),
+		MaximumAttempts:          p.GetMaximumAttempts(),
+		NonRetriableErrorReasons: p.NonRetriableErrorReasons,
+	}
 }
 
 func convertActiveClusterSelectionPolicy(policy *ActiveClusterSelectionPolicy) (*s.ActiveClusterSelectionPolicy, error) {

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -1079,6 +1079,15 @@ func (s *WorkflowUnitTest) Test_GetActivityOptionsNil() {
 	s.Equal("defaults", result)
 }
 
+func (s *WorkflowUnitTest) Test_GetActivityOptionsNoContext() {
+	// Background() has no activity options set, so GetActivityOptions returns nil
+	s.Nil(GetActivityOptions(Background()))
+}
+
+func (s *WorkflowUnitTest) Test_ConvertFromThriftRetryPolicyNil() {
+	s.Nil(convertFromThriftRetryPolicy(nil))
+}
+
 const (
 	memoTestKey = "testKey"
 	memoTestVal = "testVal"

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -974,6 +974,111 @@ func (s *WorkflowUnitTest) Test_ActivityOptionsWorkflow() {
 	s.Equal("id1 id2", result)
 }
 
+func getActivityOptionsWorkflow(ctx Context) (result string, err error) {
+	ao := ActivityOptions{
+		TaskList:               "test-task-list",
+		ActivityID:             "test-activity-id",
+		ScheduleToCloseTimeout: 10 * time.Second,
+		ScheduleToStartTimeout: 5 * time.Second,
+		StartToCloseTimeout:    7 * time.Second,
+		HeartbeatTimeout:       3 * time.Second,
+		WaitForCancellation:    true,
+		RetryPolicy: &RetryPolicy{
+			InitialInterval:          time.Second,
+			BackoffCoefficient:       2.0,
+			MaximumInterval:          10 * time.Second,
+			ExpirationInterval:       60 * time.Second,
+			MaximumAttempts:          5,
+			NonRetriableErrorReasons: []string{"bad-error"},
+		},
+	}
+	ctx = WithActivityOptions(ctx, ao)
+	got := GetActivityOptions(ctx)
+	if got == nil {
+		return "", fmt.Errorf("GetActivityOptions returned nil")
+	}
+	if got.TaskList != ao.TaskList {
+		return "", fmt.Errorf("TaskList: got %q, want %q", got.TaskList, ao.TaskList)
+	}
+	if got.ActivityID != ao.ActivityID {
+		return "", fmt.Errorf("ActivityID: got %q, want %q", got.ActivityID, ao.ActivityID)
+	}
+	if got.ScheduleToCloseTimeout != ao.ScheduleToCloseTimeout {
+		return "", fmt.Errorf("ScheduleToCloseTimeout: got %v, want %v", got.ScheduleToCloseTimeout, ao.ScheduleToCloseTimeout)
+	}
+	if got.ScheduleToStartTimeout != ao.ScheduleToStartTimeout {
+		return "", fmt.Errorf("ScheduleToStartTimeout: got %v, want %v", got.ScheduleToStartTimeout, ao.ScheduleToStartTimeout)
+	}
+	if got.StartToCloseTimeout != ao.StartToCloseTimeout {
+		return "", fmt.Errorf("StartToCloseTimeout: got %v, want %v", got.StartToCloseTimeout, ao.StartToCloseTimeout)
+	}
+	if got.HeartbeatTimeout != ao.HeartbeatTimeout {
+		return "", fmt.Errorf("HeartbeatTimeout: got %v, want %v", got.HeartbeatTimeout, ao.HeartbeatTimeout)
+	}
+	if got.WaitForCancellation != ao.WaitForCancellation {
+		return "", fmt.Errorf("WaitForCancellation: got %v, want %v", got.WaitForCancellation, ao.WaitForCancellation)
+	}
+	if got.RetryPolicy == nil {
+		return "", fmt.Errorf("RetryPolicy is nil")
+	}
+	if got.RetryPolicy.InitialInterval != ao.RetryPolicy.InitialInterval {
+		return "", fmt.Errorf("RetryPolicy.InitialInterval: got %v, want %v", got.RetryPolicy.InitialInterval, ao.RetryPolicy.InitialInterval)
+	}
+	if got.RetryPolicy.BackoffCoefficient != ao.RetryPolicy.BackoffCoefficient {
+		return "", fmt.Errorf("RetryPolicy.BackoffCoefficient: got %v, want %v", got.RetryPolicy.BackoffCoefficient, ao.RetryPolicy.BackoffCoefficient)
+	}
+	if got.RetryPolicy.MaximumInterval != ao.RetryPolicy.MaximumInterval {
+		return "", fmt.Errorf("RetryPolicy.MaximumInterval: got %v, want %v", got.RetryPolicy.MaximumInterval, ao.RetryPolicy.MaximumInterval)
+	}
+	if got.RetryPolicy.ExpirationInterval != ao.RetryPolicy.ExpirationInterval {
+		return "", fmt.Errorf("RetryPolicy.ExpirationInterval: got %v, want %v", got.RetryPolicy.ExpirationInterval, ao.RetryPolicy.ExpirationInterval)
+	}
+	if got.RetryPolicy.MaximumAttempts != ao.RetryPolicy.MaximumAttempts {
+		return "", fmt.Errorf("RetryPolicy.MaximumAttempts: got %v, want %v", got.RetryPolicy.MaximumAttempts, ao.RetryPolicy.MaximumAttempts)
+	}
+	if len(got.RetryPolicy.NonRetriableErrorReasons) != 1 || got.RetryPolicy.NonRetriableErrorReasons[0] != "bad-error" {
+		return "", fmt.Errorf("RetryPolicy.NonRetriableErrorReasons: got %v, want [bad-error]", got.RetryPolicy.NonRetriableErrorReasons)
+	}
+	return "ok", nil
+}
+
+func (s *WorkflowUnitTest) Test_GetActivityOptions() {
+	env := newTestWorkflowEnv(s.T())
+	env.ExecuteWorkflow(getActivityOptionsWorkflow)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	var result string
+	env.GetWorkflowResult(&result)
+	s.Equal("ok", result)
+}
+
+func getActivityOptionsNilWorkflow(ctx Context) (result string, err error) {
+	// The workflow framework initializes activity options on the root context
+	// (including TaskList from the workflow's task list), so GetActivityOptions
+	// always returns non-nil within a workflow.
+	got := GetActivityOptions(ctx)
+	if got == nil {
+		return "", fmt.Errorf("GetActivityOptions returned nil, expected non-nil with defaults")
+	}
+	if got.ActivityID != "" {
+		return "", fmt.Errorf("ActivityID: got %q, want empty", got.ActivityID)
+	}
+	if got.RetryPolicy != nil {
+		return "", fmt.Errorf("RetryPolicy: got %v, want nil", got.RetryPolicy)
+	}
+	return "defaults", nil
+}
+
+func (s *WorkflowUnitTest) Test_GetActivityOptionsNil() {
+	env := newTestWorkflowEnv(s.T())
+	env.ExecuteWorkflow(getActivityOptionsNilWorkflow)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	var result string
+	env.GetWorkflowResult(&result)
+	s.Equal("defaults", result)
+}
+
 const (
 	memoTestKey = "testKey"
 	memoTestVal = "testVal"

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1129,7 +1129,7 @@ func (env *testWorkflowEnvironmentImpl) executeActivityWithRetryForTest(
 
 		// check if a retry is needed
 		if request, ok := result.(*shared.RespondActivityTaskFailedRequest); ok && parameters.RetryPolicy != nil {
-			p := fromThriftRetryPolicy(parameters.RetryPolicy)
+			p := convertFromThriftRetryPolicy(parameters.RetryPolicy)
 			backoff := getRetryBackoffWithNowTime(p, task.GetAttempt(), *request.Reason, env.Now(), expireTime)
 			if backoff > 0 {
 				// need a retry
@@ -1160,23 +1160,12 @@ func (env *testWorkflowEnvironmentImpl) executeActivityWithRetryForTest(
 	return
 }
 
-func fromThriftRetryPolicy(p *shared.RetryPolicy) *RetryPolicy {
-	return &RetryPolicy{
-		InitialInterval:          time.Second * time.Duration(p.GetInitialIntervalInSeconds()),
-		BackoffCoefficient:       p.GetBackoffCoefficient(),
-		MaximumInterval:          time.Second * time.Duration(p.GetMaximumIntervalInSeconds()),
-		ExpirationInterval:       time.Second * time.Duration(p.GetExpirationIntervalInSeconds()),
-		MaximumAttempts:          p.GetMaximumAttempts(),
-		NonRetriableErrorReasons: p.NonRetriableErrorReasons,
-	}
-}
-
 func getRetryBackoffFromThriftRetryPolicy(tp *shared.RetryPolicy, attempt int32, errReason string, now, expireTime time.Time) time.Duration {
 	if tp == nil {
 		return noRetryBackoff
 	}
 
-	p := fromThriftRetryPolicy(tp)
+	p := convertFromThriftRetryPolicy(tp)
 	return getRetryBackoffWithNowTime(p, attempt, errReason, now, expireTime)
 }
 

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1845,6 +1845,30 @@ func GetActivityTaskList(ctx Context) *string {
 	return &tl
 }
 
+// GetActivityOptions retrieves ActivityOptions from the context.
+// Returns nil if no activity options have been set on the context.
+func GetActivityOptions(ctx Context) *ActivityOptions {
+	ao := getActivityOptions(ctx)
+	if ao == nil {
+		return nil
+	}
+	opts := ActivityOptions{
+		TaskList:               ao.TaskListName,
+		ScheduleToCloseTimeout: time.Duration(ao.ScheduleToCloseTimeoutSeconds) * time.Second,
+		ScheduleToStartTimeout: time.Duration(ao.ScheduleToStartTimeoutSeconds) * time.Second,
+		StartToCloseTimeout:    time.Duration(ao.StartToCloseTimeoutSeconds) * time.Second,
+		HeartbeatTimeout:       time.Duration(ao.HeartbeatTimeoutSeconds) * time.Second,
+		WaitForCancellation:    ao.WaitForCancellation,
+	}
+	if ao.ActivityID != nil {
+		opts.ActivityID = *ao.ActivityID
+	}
+	if ao.RetryPolicy != nil {
+		opts.RetryPolicy = convertFromThriftRetryPolicy(ao.RetryPolicy)
+	}
+	return &opts
+}
+
 // WithScheduleToCloseTimeout adds a timeout to the copy of the context.
 // The current timeout resolution implementation is in seconds and uses math.Ceil(d.Seconds()) as the duration. But is
 // subjected to change in the future.

--- a/workflow/activity_options.go
+++ b/workflow/activity_options.go
@@ -68,6 +68,12 @@ func GetActivityTaskList(ctx Context) string {
 	return GetInfo(ctx).TaskListName
 }
 
+// GetActivityOptions returns the current ActivityOptions from the context.
+// Returns nil if no activity options have been set on the context.
+func GetActivityOptions(ctx Context) *ActivityOptions {
+	return internal.GetActivityOptions(ctx)
+}
+
 // WithScheduleToCloseTimeout makes a copy of the current context and update
 // the ScheduleToCloseTimeout field in its activity options. An empty activity
 // options will be created if it does not exist in the original context.


### PR DESCRIPTION
**What changed?**
Added a public `GetActivityOptions(ctx)` function that reads the current `ActivityOptions` from a workflow context, returning nil if none are set. Also added `convertFromThriftRetryPolicy` in `convert.go` to consolidate the reverse RetryPolicy conversion (previously duplicated in test code).

**Why?**
There is no public way to read `ActivityOptions` from a workflow context. This makes it impossible for hooks/middleware to read-modify-write activity options — they can only overwrite. A public getter follows the same pattern as `GetActivityTaskList` ([PR #1292](https://github.com/uber-go/cadence-client/pull/1292), approved by @Groxx), extending it to expose all activity option fields.

**How did you test it?**
- Added `Test_GetActivityOptions` — round-trip test that sets all fields via `WithActivityOptions` and verifies they read back correctly including RetryPolicy
- Added `Test_GetActivityOptionsNil` — verifies behavior on a fresh workflow context (returns non-nil with framework defaults)
- Added `Test_GetActivityOptionsNoContext` — verifies nil return when context has no activity options
- Added `Test_ConvertFromThriftRetryPolicyNil` — verifies nil input returns nil
- Full `go test ./internal/` passes

**Potential risks**
None — this is a purely additive public API. No existing behavior is changed. The only refactor is replacing a local `fromThriftRetryPolicy` function in test code with the new shared `convertFromThriftRetryPolicy`.

---

**Detailed Description**
Added a new public function `GetActivityOptions(ctx Context) *ActivityOptions` to `internal/workflow.go` (exposed via `workflow/activity_options.go`). This reads the internal `activityOptions` struct from the workflow context and converts it back to the public `ActivityOptions` type. Also added `convertFromThriftRetryPolicy(*s.RetryPolicy) *RetryPolicy` in `internal/convert.go` to consolidate the thrift-to-domain RetryPolicy conversion that was previously duplicated as a local function in test code. No fields were removed or modified — this is purely additive.

**Impact Analysis**
- **Backward Compatibility**: Fully backward compatible. No existing APIs, types, or behaviors are changed. The new function is additive. The refactor of `fromThriftRetryPolicy` from a test-local function to a shared `convertFromThriftRetryPolicy` is internal and does not affect any public API.
- **Forward Compatibility**: Fully forward compatible. Older clients that do not use `GetActivityOptions` are unaffected. Newer clients using it will get a nil return if the context has no options set, which is a safe default.

**Testing Plan**
- **Unit Tests**: Yes — `Test_GetActivityOptions` (round-trip all fields), `Test_GetActivityOptionsNil` (framework defaults), `Test_GetActivityOptionsNoContext` (nil context path), `Test_ConvertFromThriftRetryPolicyNil` (nil retry policy path)
- **Persistence Tests**: N/A — this change is not related to persisted data types
- **Integration Tests**: Existing integration tests pass unchanged (sticky on, sticky off, gRPC adapter)
- **Compatibility Tests**: N/A — purely additive, no wire format or persistence changes

**Rollout Plan**
- No special rollout needed — this is a purely additive API addition with no behavior changes to existing code
- Order of deployment does not matter
- Safe to rollback — removing this function would only break code that explicitly calls `GetActivityOptions`, which does not exist yet
- No kill switch needed — the function is stateless and read-only