### PR TITLE
fix: switch metrics default emit mode to histogram only

### DIFF
--- a/internal/common/metrics/EMIT_MODE.md
+++ b/internal/common/metrics/EMIT_MODE.md
@@ -7,10 +7,10 @@ This document describes how to configure metric emission behavior for the timer�
 The cadence-go-client supports three metric emission modes:
 
 1. **EmitTimersOnly** - Only timer metrics (legacy OSS behavior)
-2. **EmitBoth** (default) - Both timer and histogram metrics (for migration)
-3. **EmitHistogramsOnly** - Only histogram metrics (post-migration)
+2. **EmitBoth** - Both timer and histogram metrics (for migration)
+3. **EmitHistogramsOnly** (default) - Only histogram metrics (post-migration)
 
-**Default**: `EmitBoth` - This allows all users (OSS and monorepo) to see both metrics during the migration period.
+**Default**: `EmitHistogramsOnly` - The migration from timers to histograms is complete. Users who still need timers can opt in via configuration.
 
 ## Configuration Methods
 
@@ -36,10 +36,10 @@ func main() {
 				// Option A: Use only timers (legacy behavior)
 				MetricEmitMode: metrics.EmitTimersOnly,
 
-				// Option B: Use both (default, no need to set)
+				// Option B: Use both (dual-emit for migration)
 				// MetricEmitMode: metrics.EmitBoth,
 
-				// Option C: Use only histograms (post-migration)
+				// Option C: Use only histograms (default, no need to set)
 				// MetricEmitMode: metrics.EmitHistogramsOnly,
 			},
 		},
@@ -64,7 +64,7 @@ cadence:
         # Feature flags for controlling worker behavior
         feature_flags:
           # Options: "timers_only", "both", "histograms_only"
-          # Default: "both" (dual-emit for migration)
+          # Default: "histograms_only" (post-migration)
           metric_emit_mode: "timers_only"  # or "both" or "histograms_only"
 ```
 
@@ -102,25 +102,17 @@ worker.Options{
 
 ## Migration Path
 
-### Phase 1: Enable Dual Emission (Current Default)
+### Phase 1: Dual Emission (Completed)
 
-The default `EmitBoth` mode is already active. No changes needed.
+The `EmitBoth` mode was the previous default during migration.
 
-- Both timer and histogram metrics emit automatically
-- Create new dashboards/alerts using histogram metrics (`_ns` suffix
-- Validate histogram metrics match timer metrics
+- Both timer and histogram metrics were emitted
+- New dashboards/alerts were created using histogram metrics (`_ns` suffix)
+- Histogram metrics were validated against timer metrics
 
-### Phase 2: Switch to Histogram-Only
+### Phase 2: Histogram-Only (Current Default)
 
-After validating histograms and migrating all dashboards/alerts:
-
-```go
-worker.Options{
-	FeatureFlags: internal.FeatureFlags{
-		MetricEmitMode: metrics.EmitHistogramsOnly,
-	},
-}
-```
+The default is now `EmitHistogramsOnly`:
 
 - Only histogram metrics emit
 - Remove old timer-based dashboards/alerts
@@ -141,7 +133,7 @@ All 62 latency metrics are controlled by this setting:
 ## Benefits
 
 ✅ **Consistent across OSS and monorepo** - Same mechanism for everyone
-✅ **Safe default** - Dual-emit ensures metrics availability during migration
+✅ **Safe default** - Histogram-only reduces metric cardinality post-migration
 ✅ **Per-worker configuration** - Different workers can have different modes
 ✅ **Clear and explicit** - Configuration visible in WorkerOptions
 ✅ **Simple and lightweight** - No runtime overhead

--- a/internal/common/metrics/MIGRATION.md
+++ b/internal/common/metrics/MIGRATION.md
@@ -2,18 +2,17 @@
 
 ## Summary
 
-**Starting in v1.3.1, all latency metrics automatically emit BOTH timer and histogram formats.**
+**The timer→histogram migration is complete. The default is now `EmitHistogramsOnly`.**
 
-- Your existing dashboards continue to work (timers)
-- New histogram metrics available (with `_ns` suffix)
-- Migrate dashboards at your own pace
-- No code changes needed
+- Only histogram metrics emit by default
+- Users who still need timers can opt in with `EmitTimersOnly` or `EmitBoth`
+- See `EMIT_MODE.md` for configuration details
 
 ## What Changed
 
-All latency metrics now dual-emit:
-- **Timer**: `cadence-decision-poll-latency` (existing)
-- **Histogram**: `cadence-decision-poll-latency_ns` (new)
+All latency metrics now emit as histograms by default:
+- **Histogram**: `cadence-decision-poll-latency_ns` (default)
+- **Timer**: `cadence-decision-poll-latency` (opt-in via EmitTimersOnly or EmitBoth)
 
 ### Affected Metrics (62 total)
 
@@ -28,9 +27,9 @@ All latency metrics now dual-emit:
 
 ## Impact
 
-**Cardinality:** +62 histogram metrics (temporary during migration)
+**Cardinality:** Reduced — only histogram metrics emit by default
 **Performance:** Minimal impact
-**Compatibility:** 100% backward compatible
+**Compatibility:** Users can opt back into timers via EmitTimersOnly or EmitBoth
 
 ## Why Migrate?
 
@@ -57,9 +56,9 @@ All latency metrics now dual-emit:
 - **Range**: 1ms → ~3 days
 - **Use for**: Long-running operations with high cardinality
 
-## Developer Guide (Future)
+## Developer Guide
 
-Currently, the client automatically dual-emits. In a future version when you want to use histogram-only APIs:
+Use histogram APIs directly:
 
 ```go
 // Simple recording
@@ -84,19 +83,16 @@ sw.Stop()
 
 ## Migration Timeline
 
-### Phase 1: Automatic Dual-Emit (Now)
-- Upgrade to v1.3.1
-- Both metrics automatically emit
+### Phase 1: Automatic Dual-Emit (Completed)
+- Both metrics emitted automatically
 - No code changes needed
 
-### Phase 2: Migrate Dashboards (Your Pace)
-1. Identify dashboards using timer metrics
-2. Create new panels using histogram metrics (`_ns` suffix)
-3. Compare side-by-side
-4. Switch over when validated
+### Phase 2: Histogram-Only Default (Current)
+- Default switched to `EmitHistogramsOnly`
+- Users who haven't migrated dashboards can opt in to `EmitBoth` or `EmitTimersOnly`
 
-### Phase 3: Timers Removed (Future v1.3.*)
-- Timer emission removed in future major version
+### Phase 3: Timers Removed (Future)
+- Timer emission support removed in future major version
 - Plenty of advance notice provided
 
 ## Testing

--- a/internal/common/metrics/emit.go
+++ b/internal/common/metrics/emit.go
@@ -45,17 +45,17 @@ const (
 	EmitModeUnset MetricEmitMode = iota
 	// EmitTimersOnly emits only timer metrics (legacy OSS behavior)
 	EmitTimersOnly
-	// EmitBoth emits both timer and histogram metrics (default for migration)
+	// EmitBoth emits both timer and histogram metrics (for migration)
 	EmitBoth
 	// EmitHistogramsOnly emits only histogram metrics (post-migration)
 	EmitHistogramsOnly
 )
 
-// currentEmitMode is the active emission mode. Default is EmitBoth for migration.
+// currentEmitMode is the active emission mode. Default is EmitHistogramsOnly (post-migration).
 // This should be set during application initialization (e.g., in init() or before starting workers).
 // It should NOT be changed dynamically after workers have started.
 // Access via atomic operations for thread-safety.
-var currentEmitMode = int32(EmitBoth)
+var currentEmitMode = int32(EmitHistogramsOnly)
 
 // SetEmitMode configures the metric emission strategy.
 // This should be called during application initialization, before any metrics are emitted.

--- a/internal/common/metrics/emit_test.go
+++ b/internal/common/metrics/emit_test.go
@@ -30,8 +30,8 @@ import (
 )
 
 func TestEmitLatency_DefaultMode(t *testing.T) {
-	// Reset to default (should be EmitBoth)
-	SetEmitMode(EmitBoth)
+	// Reset to default (should be EmitHistogramsOnly)
+	SetEmitMode(EmitHistogramsOnly)
 
 	scope := tally.NewTestScope("test", nil)
 	EmitLatency(scope, "test-metric", 50*time.Millisecond, Default1ms100s)
@@ -40,20 +40,18 @@ func TestEmitLatency_DefaultMode(t *testing.T) {
 	timers := snapshot.Timers()
 	histograms := snapshot.Histograms()
 
-	// Should have both timer and histogram in default mode
-	timer, timerExists := timers["test.test-metric+"]
+	// Should have only histogram in default mode
+	_, timerExists := timers["test.test-metric+"]
 	hist, histExists := histograms["test.test-metric_ns+"]
 
-	assert.True(t, timerExists, "timer should exist in EmitBoth (default) mode")
-	assert.NotNil(t, timer)
-	assert.True(t, histExists, "histogram should exist in EmitBoth (default) mode")
+	assert.False(t, timerExists, "timer should not exist in EmitHistogramsOnly (default) mode")
+	assert.True(t, histExists, "histogram should exist in EmitHistogramsOnly (default) mode")
 	assert.NotNil(t, hist)
 }
 
 func TestEmitLatency_DualMode(t *testing.T) {
-	// Set to dual-emit mode (this is also the default)
 	SetEmitMode(EmitBoth)
-	defer SetEmitMode(EmitBoth) // Reset after test
+	defer SetEmitMode(EmitHistogramsOnly) // Reset after test
 
 	scope := tally.NewTestScope("test", nil)
 	EmitLatency(scope, "test-metric", 50*time.Millisecond, Default1ms100s)
@@ -75,7 +73,7 @@ func TestEmitLatency_DualMode(t *testing.T) {
 func TestEmitLatency_HistogramOnlyMode(t *testing.T) {
 	// Set to histogram-only mode
 	SetEmitMode(EmitHistogramsOnly)
-	defer SetEmitMode(EmitBoth) // Reset after test
+	defer SetEmitMode(EmitHistogramsOnly) // Reset after test
 
 	scope := tally.NewTestScope("test", nil)
 	EmitLatency(scope, "test-metric", 50*time.Millisecond, Default1ms100s)
@@ -96,7 +94,7 @@ func TestEmitLatency_HistogramOnlyMode(t *testing.T) {
 func TestEmitLatency_TimersOnlyMode(t *testing.T) {
 	// Set to timers-only mode (legacy behavior)
 	SetEmitMode(EmitTimersOnly)
-	defer SetEmitMode(EmitBoth) // Reset after test
+	defer SetEmitMode(EmitHistogramsOnly) // Reset after test
 
 	scope := tally.NewTestScope("test", nil)
 	EmitLatency(scope, "test-metric", 50*time.Millisecond, Default1ms100s)
@@ -115,8 +113,8 @@ func TestEmitLatency_TimersOnlyMode(t *testing.T) {
 }
 
 func TestStartLatency_DefaultMode(t *testing.T) {
-	// Reset to default (should be EmitBoth)
-	SetEmitMode(EmitBoth)
+	// Reset to default (should be EmitHistogramsOnly)
+	SetEmitMode(EmitHistogramsOnly)
 
 	scope := tally.NewTestScope("test", nil)
 	sw := StartLatency(scope, "test-metric", Default1ms100s)
@@ -127,18 +125,17 @@ func TestStartLatency_DefaultMode(t *testing.T) {
 	timers := snapshot.Timers()
 	histograms := snapshot.Histograms()
 
-	timer, timerExists := timers["test.test-metric+"]
+	_, timerExists := timers["test.test-metric+"]
 	hist, histExists := histograms["test.test-metric_ns+"]
 
-	assert.True(t, timerExists, "timer should exist in EmitBoth (default) mode")
-	assert.NotNil(t, timer)
-	assert.True(t, histExists, "histogram should exist in EmitBoth (default) mode")
+	assert.False(t, timerExists, "timer should not exist in EmitHistogramsOnly (default) mode")
+	assert.True(t, histExists, "histogram should exist in EmitHistogramsOnly (default) mode")
 	assert.NotNil(t, hist)
 }
 
 func TestStartLatency_DualMode(t *testing.T) {
 	SetEmitMode(EmitBoth)
-	defer SetEmitMode(EmitBoth)
+	defer SetEmitMode(EmitHistogramsOnly)
 
 	scope := tally.NewTestScope("test", nil)
 	sw := StartLatency(scope, "test-metric", Default1ms100s)
@@ -160,7 +157,7 @@ func TestStartLatency_DualMode(t *testing.T) {
 
 func TestStartLatency_HistogramOnlyMode(t *testing.T) {
 	SetEmitMode(EmitHistogramsOnly)
-	defer SetEmitMode(EmitBoth)
+	defer SetEmitMode(EmitHistogramsOnly)
 
 	scope := tally.NewTestScope("test", nil)
 	sw := StartLatency(scope, "test-metric", Default1ms100s)
@@ -181,6 +178,7 @@ func TestStartLatency_HistogramOnlyMode(t *testing.T) {
 
 func TestDualStopwatch_MultipleStops(t *testing.T) {
 	SetEmitMode(EmitBoth)
+	defer SetEmitMode(EmitHistogramsOnly)
 
 	scope := tally.NewTestScope("test", nil)
 	sw := StartLatency(scope, "test-metric", Default1ms100s)
@@ -208,7 +206,7 @@ func TestEmitLatency_DifferentHistograms(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetEmitMode(EmitBoth)
-			defer SetEmitMode(EmitBoth)
+			defer SetEmitMode(EmitHistogramsOnly)
 
 			scope := tally.NewTestScope("test", nil)
 			EmitLatency(scope, "test-metric", 50*time.Millisecond, tt.histogram)
@@ -263,5 +261,5 @@ func TestMetricEmitMode_ConcurrentAccess(t *testing.T) {
 	wg.Wait()
 
 	// Clean up: restore to default
-	SetEmitMode(EmitBoth)
+	SetEmitMode(EmitHistogramsOnly)
 }

--- a/internal/common/metrics/service_wrapper_test.go
+++ b/internal/common/metrics/service_wrapper_test.go
@@ -193,8 +193,9 @@ func assertMetrics(t *testing.T, reporter *CapturingStatsReporter, methodName st
 		}
 		assert.True(t, find, "counter %v not found in counters %v", counterName, reporter.counts)
 	}
-	assert.Equal(t, 1, len(reporter.timers), "expected 1 timer, got %v", len(reporter.timers))
-	assert.Equal(t, CadenceMetricsPrefix+methodName+"."+CadenceLatency, reporter.timers[0].name, "expected timer %v, got %v", CadenceMetricsPrefix+methodName+"."+CadenceLatency, reporter.timers[0].name)
+	expectedHistName := CadenceMetricsPrefix + methodName + "." + CadenceLatency + "_ns"
+	assert.True(t, len(reporter.histogramDurationSamples) > 0, "expected histogram duration samples, got %v", len(reporter.histogramDurationSamples))
+	assert.Equal(t, expectedHistName, reporter.histogramDurationSamples[0].name, "expected histogram %v, got %v", expectedHistName, reporter.histogramDurationSamples[0].name)
 }
 
 func assertPromMetrics(t *testing.T, reporter *CapturingStatsReporter, methodName string, counterNames []string) {
@@ -211,9 +212,9 @@ func assertPromMetrics(t *testing.T, reporter *CapturingStatsReporter, methodNam
 		}
 		assert.True(t, find, "counter %v not found in counters %v", counterName, reporter.counts)
 	}
-	assert.Equal(t, 1, len(reporter.timers), "expected 1 timer, got %v", len(reporter.timers))
-	expected := makePromCompatible(CadenceMetricsPrefix + methodName + "." + CadenceLatency)
-	assert.Equal(t, expected, reporter.timers[0].name, "expected timer %v, got %v", expected, reporter.timers[0].name)
+	expected := makePromCompatible(CadenceMetricsPrefix + methodName + "." + CadenceLatency + "_ns")
+	assert.True(t, len(reporter.histogramDurationSamples) > 0, "expected histogram duration samples, got %v", len(reporter.histogramDurationSamples))
+	assert.Equal(t, expected, reporter.histogramDurationSamples[0].name, "expected histogram %v, got %v", expected, reporter.histogramDurationSamples[0].name)
 }
 
 func makePromCompatible(name string) string {

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -85,7 +85,7 @@ type (
 		PollerAutoScalerEnabled   bool
 		EphemeralTaskListsEnabled bool
 		// MetricEmitMode controls how latency metrics are emitted (timers, histograms, or both).
-		// Default: metrics.EmitBoth (dual-emit for safe migration) - set automatically if not specified.
+		// Default: metrics.EmitHistogramsOnly (post-migration) - set automatically if not specified.
 		// Set to metrics.EmitTimersOnly for legacy OSS behavior, or metrics.EmitHistogramsOnly post-migration.
 		MetricEmitMode metrics.MetricEmitMode
 	}

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1307,9 +1307,9 @@ func AugmentWorkerOptions(options WorkerOptions) WorkerOptions {
 		options.EnableSessionWorker = false
 	}
 
-	// Set default MetricEmitMode to EmitBoth if not explicitly configured
+	// Set default MetricEmitMode to EmitHistogramsOnly if not explicitly configured
 	if options.FeatureFlags.MetricEmitMode == metrics.EmitModeUnset {
-		options.FeatureFlags.MetricEmitMode = metrics.EmitBoth
+		options.FeatureFlags.MetricEmitMode = metrics.EmitHistogramsOnly
 	}
 
 	return options

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1321,7 +1321,7 @@ func Test_augmentWorkerOptions(t *testing.T) {
 				Tracer:                                  nil,
 				EnableShadowWorker:                      false,
 				ShadowOptions:                           ShadowOptions{},
-				FeatureFlags:                            FeatureFlags{MetricEmitMode: metrics.EmitBoth},
+				FeatureFlags:                            FeatureFlags{MetricEmitMode: metrics.EmitHistogramsOnly},
 				Authorization:                           nil,
 				AutoScalerOptions: AutoScalerOptions{
 					Enabled:                  true,
@@ -1362,7 +1362,7 @@ func Test_augmentWorkerOptions(t *testing.T) {
 				Tracer:                                  opentracing.NoopTracer{},
 				EnableShadowWorker:                      false,
 				ShadowOptions:                           ShadowOptions{},
-				FeatureFlags:                            FeatureFlags{MetricEmitMode: metrics.EmitBoth},
+				FeatureFlags:                            FeatureFlags{MetricEmitMode: metrics.EmitHistogramsOnly},
 				Authorization:                           nil,
 				AutoScalerOptions: AutoScalerOptions{
 					Enabled:                  true,
@@ -1407,7 +1407,7 @@ func Test_augmentWorkerOptions(t *testing.T) {
 				Tracer:                                  opentracing.NoopTracer{},
 				EnableShadowWorker:                      false,
 				ShadowOptions:                           ShadowOptions{},
-				FeatureFlags:                            FeatureFlags{MetricEmitMode: metrics.EmitBoth},
+				FeatureFlags:                            FeatureFlags{MetricEmitMode: metrics.EmitHistogramsOnly},
 				Authorization:                           nil,
 				AutoScalerOptions: AutoScalerOptions{
 					Enabled:                  false,
@@ -1577,18 +1577,18 @@ func TestAugmentWorkerOptions_MetricEmitMode(t *testing.T) {
 		expected metrics.MetricEmitMode
 	}{
 		{
-			name:     "unset defaults to EmitBoth",
+			name:     "unset defaults to EmitHistogramsOnly",
 			input:    WorkerOptions{},
-			expected: metrics.EmitBoth,
+			expected: metrics.EmitHistogramsOnly,
 		},
 		{
-			name: "explicit EmitModeUnset defaults to EmitBoth",
+			name: "explicit EmitModeUnset defaults to EmitHistogramsOnly",
 			input: WorkerOptions{
 				FeatureFlags: FeatureFlags{
 					MetricEmitMode: metrics.EmitModeUnset,
 				},
 			},
-			expected: metrics.EmitBoth,
+			expected: metrics.EmitHistogramsOnly,
 		},
 		{
 			name: "explicit EmitTimersOnly is preserved",
@@ -1635,9 +1635,9 @@ func TestNewAggregatedWorker_SetsMetricEmitMode(t *testing.T) {
 	mockService := workflowservicetest.NewMockClient(mockCtrl)
 
 	// Reset to known state
-	metrics.SetEmitMode(metrics.EmitBoth)
+	metrics.SetEmitMode(metrics.EmitHistogramsOnly)
 	initialMode := metrics.GetCurrentEmitMode()
-	assert.Equal(t, metrics.EmitBoth, initialMode)
+	assert.Equal(t, metrics.EmitHistogramsOnly, initialMode)
 
 	// Create worker with EmitTimersOnly
 	_, err := newAggregatedWorker(
@@ -1660,5 +1660,5 @@ func TestNewAggregatedWorker_SetsMetricEmitMode(t *testing.T) {
 	assert.Equal(t, metrics.EmitTimersOnly, currentMode, "newAggregatedWorker should set the global emit mode")
 
 	// Clean up: restore to default
-	metrics.SetEmitMode(metrics.EmitBoth)
+	metrics.SetEmitMode(metrics.EmitHistogramsOnly)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Switch metrics default emit mode to histogram only, internal client dashboard has been updates. OSS user can still choose their emit mode by setting metric_emit_mode in the feature flags 

<!-- Tell your future self why have you made these changes -->
**Why?**
https://github.com/cadence-workflow/cadence/issues/7741

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
go test ./internal/common/metrics/... -v

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
