### PR TITLE
feat(trace): skip ContextWithSpan for NoopTracer to preserve context type

### DIFF
--- a/internal/propagation.go
+++ b/internal/propagation.go
@@ -93,6 +93,8 @@ func startOpenTracingSpan(
 	}
 
 	span := tracer.StartSpan(name, opts...)
-	ctx = opentracing.ContextWithSpan(ctx, span)
+	if _, ok := tracer.(opentracing.NoopTracer); !ok {
+		ctx = opentracing.ContextWithSpan(ctx, span)
+	}
 	return ctx, span
 }

--- a/internal/propagation_test.go
+++ b/internal/propagation_test.go
@@ -1,0 +1,125 @@
+package internal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartOpenTracingSpan_NoopTracer_DoesNotWrapContext(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tracer := opentracing.NoopTracer{}
+
+	returnedCtx, span := startOpenTracingSpan(ctx, tracer, time.Now(), "test-op", nil, nil)
+
+	assert.NotNil(t, span)
+	assert.Nil(t, opentracing.SpanFromContext(returnedCtx), "NoopTracer should not inject span into context")
+}
+
+func TestStartOpenTracingSpan_RealTracer_WrapsContext(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tracer := mocktracer.New()
+
+	returnedCtx, span := startOpenTracingSpan(ctx, tracer, time.Now(), "test-op", nil, nil)
+
+	assert.NotNil(t, span)
+	assert.Equal(t, span, opentracing.SpanFromContext(returnedCtx), "real tracer should inject span into context")
+}
+
+func TestStartOpenTracingSpan_WithParent(t *testing.T) {
+	t.Parallel()
+	tracer := mocktracer.New()
+	parentSpan := tracer.StartSpan("parent")
+
+	_, childSpan := startOpenTracingSpan(
+		context.Background(), tracer, time.Now(), "child",
+		opentracing.Tags{"key": "val"}, parentSpan.Context(),
+	)
+
+	require.NotNil(t, childSpan)
+	ms := childSpan.(*mocktracer.MockSpan)
+	assert.Equal(t, parentSpan.(*mocktracer.MockSpan).SpanContext.SpanID, ms.ParentID)
+}
+
+func TestCreateOpenTracingWorkflowSpan_NoopTracer(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tracer := opentracing.NoopTracer{}
+
+	returnedCtx, span := createOpenTracingWorkflowSpan(ctx, tracer, time.Now(), "test-workflow", "wf-id")
+
+	assert.NotNil(t, span)
+	assert.Nil(t, opentracing.SpanFromContext(returnedCtx))
+}
+
+func TestCreateOpenTracingWorkflowSpan_WithActiveSpan(t *testing.T) {
+	t.Parallel()
+	tracer := mocktracer.New()
+	parentSpan := tracer.StartSpan("parent")
+	ctx := opentracing.ContextWithSpan(context.Background(), parentSpan)
+
+	returnedCtx, span := createOpenTracingWorkflowSpan(ctx, tracer, time.Now(), "test-workflow", "wf-id")
+
+	require.NotNil(t, span)
+	assert.NotNil(t, opentracing.SpanFromContext(returnedCtx))
+	ms := span.(*mocktracer.MockSpan)
+	assert.Equal(t, parentSpan.(*mocktracer.MockSpan).SpanContext.SpanID, ms.ParentID)
+}
+
+func TestCreateOpenTracingWorkflowSpan_WithSpanContextKey(t *testing.T) {
+	t.Parallel()
+	tracer := mocktracer.New()
+	parentSpan := tracer.StartSpan("parent")
+	ctx := context.WithValue(context.Background(), activeSpanContextKey, parentSpan.Context())
+
+	_, span := createOpenTracingWorkflowSpan(ctx, tracer, time.Now(), "test-workflow", "wf-id")
+
+	require.NotNil(t, span)
+	ms := span.(*mocktracer.MockSpan)
+	assert.Equal(t, parentSpan.(*mocktracer.MockSpan).SpanContext.SpanID, ms.ParentID)
+}
+
+func TestCreateOpenTracingSpanFromHeaders_NoopTracer(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tracer := opentracing.NoopTracer{}
+
+	returnedCtx, span := createOpenTracingSpanFromHeaders(ctx, tracer, time.Now(), "test-activity", nil)
+
+	assert.NotNil(t, span)
+	assert.Nil(t, opentracing.SpanFromContext(returnedCtx))
+}
+
+func TestCreateOpenTracingSpanFromHeaders_WithSpanContextKey(t *testing.T) {
+	t.Parallel()
+	tracer := mocktracer.New()
+	parentSpan := tracer.StartSpan("parent")
+	ctx := context.WithValue(context.Background(), activeSpanContextKey, parentSpan.Context())
+
+	returnedCtx, span := createOpenTracingSpanFromHeaders(ctx, tracer, time.Now(), "test-activity", nil)
+
+	require.NotNil(t, span)
+	assert.NotNil(t, opentracing.SpanFromContext(returnedCtx))
+	ms := span.(*mocktracer.MockSpan)
+	assert.Equal(t, parentSpan.(*mocktracer.MockSpan).SpanContext.SpanID, ms.ParentID)
+}
+
+func TestCreateOpenTracingSpanFromHeaders_IgnoresActiveSpan(t *testing.T) {
+	t.Parallel()
+	tracer := mocktracer.New()
+	activeSpan := tracer.StartSpan("active")
+	ctx := opentracing.ContextWithSpan(context.Background(), activeSpan)
+
+	_, span := createOpenTracingSpanFromHeaders(ctx, tracer, time.Now(), "test-activity", nil)
+
+	require.NotNil(t, span)
+	ms := span.(*mocktracer.MockSpan)
+	assert.Equal(t, 0, ms.ParentID, "should not use active span as parent — only uses activeSpanContextKey")
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- In startOpenTracingSpan, skip the opentracing.ContextWithSpan call when the tracer is a NoopTracer. This restores the guard that was originally added in bd283b3 and inadvertently removed during the refactor in https://github.com/cadence-workflow/cadence-go-client/pull/1506 .


<!-- Tell your future self why have you made these changes -->
**Why?**
https://github.com/cadence-workflow/cadence-go-client/pull/1506 refactored span creation into startOpenTracingSpan but dropped the NoopTracer short-circuit. Without it, ContextWithSpan always wraps the context in an extra context.WithValue layer — even for NoopTracer. This causes two downstream failures:

1. Tests using mock.AnythingOfType("*context.timerCtx") break because the outermost context type changes from *context.timerCtx to *context.valueCtx.
2. Tests using a MockTracer panic because the noop span injected by the harness's NoopTracer becomes an incompatible parent when activity code calls StartSpanFromContextWithTracer with a different tracer (MockTracer.StartSpan does a hard type assertion on MockSpanContext).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- go test -race ./internal/... — all tests pass.
- Verified the fix resolves both failure modes: the bibliotek context-type mismatch and the cron/activity MockTracer panic seen in go-monorepo CI.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

- Low. This restores behavior that existed for 7 years (since bd283b3 in 2019). A noop span in context provides no tracing value, so skipping ContextWithSpan for NoopTracer has no functional impact on production tracing. Real tracers are unaffected by this change.