### PR TITLE
feat(trace): skip seeding workflow context with NoopTracer span context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Skip seeding the workflow span context when the tracer is a `NoopTracer`, preventing panics for workflow tests that mix the testsuite (which defaults to `NoopTracer`) with a real tracer such as `mocktracer`. Follow-up to the span activation added in #1506 and the `NoopTracer` guard in #1516.
 
 ## [v1.4.0] - 2026-06-22
 ### Added

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -490,7 +490,15 @@ func (d *syncWorkflowDefinition) Execute(env workflowEnvironment, header *shared
 				},
 			)
 			defer span.Finish()
-			execCtx = WithSpanContext(d.rootCtx, span.Context())
+			// Only seed the workflow span context when a real tracer produced it.
+			// A NoopTracer yields a noop span context that carries no tracing value,
+			// and seeding it forces workflows that use their own real tracer (e.g. a
+			// mocktracer in the testsuite) to build children from a foreign span
+			// context, which panics. Skipping it leaves GetSpanContext returning nil,
+			// matching the behavior established for NoopTracer in #1516.
+			if _, ok := wfEnv.GetTracer().(opentracing.NoopTracer); !ok {
+				execCtx = WithSpanContext(d.rootCtx, span.Context())
+			}
 		}
 		r.workflowResult, r.error = d.workflow.Execute(execCtx, input)
 		rpp := getWorkflowResultPointerPointer(ctx)

--- a/internal/tracer_test.go
+++ b/internal/tracer_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	jaeger_config "github.com/uber/jaeger-client-go/config"
@@ -116,6 +117,58 @@ func TestTracingContextPropagatorWorkflowContextNoSpan(t *testing.T) {
 	returnCtx := Background()
 	returnCtx, err = ctxProp.ExtractToWorkflow(returnCtx, NewHeaderReader(header))
 	assert.NoError(t, err)
+}
+
+// TestWorkflowSpanContextNoopTracer verifies that a workflow executed with a
+// NoopTracer (the testsuite default) does not seed a span context into the
+// workflow context. Seeding a noop span context here would leak it into user
+// code that builds child spans with a different, real tracer (e.g. a mocktracer
+// or jaeger tracer configured globally in a test), which panics when that tracer
+// type-asserts the foreign parent span context. Skipping the seed keeps
+// GetSpanContext returning nil so opentracing.ChildOf drops it harmlessly.
+func TestWorkflowSpanContextNoopTracer(t *testing.T) {
+	env := newTestWorkflowEnv(t)
+
+	var seededSpanContext opentracing.SpanContext
+	var childDidNotPanic bool
+	wf := func(ctx Context) error {
+		seededSpanContext = GetSpanContext(ctx)
+		// Reproduce the downstream failure: a real tracer building a child span
+		// from whatever parent GetSpanContext returns. With the guard in place
+		// the parent is nil and ChildOf is silently dropped instead of panicking.
+		globalTracer := mocktracer.New()
+		child := globalTracer.StartSpan("child", opentracing.ChildOf(seededSpanContext))
+		child.Finish()
+		childDidNotPanic = true
+		return nil
+	}
+	env.ExecuteWorkflow(wf)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	assert.Nil(t, seededSpanContext, "NoopTracer must not seed a span context into the workflow context")
+	assert.True(t, childDidNotPanic)
+}
+
+// TestWorkflowSpanContextRealTracer verifies that when a real tracer is
+// configured on the worker, the workflow span context is still seeded so
+// baggage propagation to activities and child workflows keeps working.
+func TestWorkflowSpanContextRealTracer(t *testing.T) {
+	env := newTestWorkflowEnv(t)
+	// setWorkerOptions intentionally ignores Tracer, so set it directly on the
+	// impl to exercise the real-tracer path.
+	env.impl.workerOptions.Tracer = mocktracer.New()
+
+	var seededSpanContext opentracing.SpanContext
+	wf := func(ctx Context) error {
+		seededSpanContext = GetSpanContext(ctx)
+		return nil
+	}
+	env.ExecuteWorkflow(wf)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	assert.NotNil(t, seededSpanContext, "a real tracer must seed a span context into the workflow context")
 }
 
 func TestConsistentInjectionExtraction(t *testing.T) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
In syncWorkflowDefinition.Execute, skip WithSpanContext when the worker tracer i s a NoopTracer, so the workflow context is not seeded with a noop span context.

<!-- Tell your future self why have you made these changes -->
**Why?**

- #1506 began activating a span on workflow execution and seeding its context via WithSpanContext. 
- #1516 restored the NoopTracer short-circuit for the activity path (ContextWithSpan in startOpenTracingSpan) but not the workflow path. 
- Without this guard, workflow.GetSpanContext returns a non-nil noopSpanContext, so code that starts a child span from it via a different tracer (e.g. a MockTracer in tests) panics — MockTracer.StartSpan does a hard type assertion on MockSpanContext.
- This broke multiple unrelated workflow tests across the go-monorepo (e.g. infra/coconut/pkg/tieredrouter, insurance/common/utils/context) once the SDK was bumped — every team that mixes a mocktracer global tracer with the cadence test suite hits the same panic. It's whack-a-mole to patch each repo's tests.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Added Test_WorkflowExecution_NoopTracer_DoesNotSeedSpanContext (fails before the guard, passes after).
- go test ./internal/... for the workflow testsuite and tracer/propagation tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Low. Restores pre-#1506 behavior for NoopTracer only. A noop span context has no tracing value; real tracers (e.g. Jaeger) are unaffected.