### PR TITLE
feat: Add FailureOptions to CustomError

### DIFF
--- a/.gen/go/shared/shared.go
+++ b/.gen/go/shared/shared.go
@@ -2954,11 +2954,12 @@ func (v *ActivityTaskCompletedEventAttributes) IsSetIdentity() bool {
 }
 
 type ActivityTaskFailedEventAttributes struct {
-	Reason           *string `json:"reason,omitempty"`
-	Details          []byte  `json:"details,omitempty"`
-	ScheduledEventId *int64  `json:"scheduledEventId,omitempty"`
-	StartedEventId   *int64  `json:"startedEventId,omitempty"`
-	Identity         *string `json:"identity,omitempty"`
+	Reason           *string         `json:"reason,omitempty"`
+	Details          []byte          `json:"details,omitempty"`
+	FailureOptions   *FailureOptions `json:"failureOptions,omitempty"`
+	ScheduledEventId *int64          `json:"scheduledEventId,omitempty"`
+	StartedEventId   *int64          `json:"startedEventId,omitempty"`
+	Identity         *string         `json:"identity,omitempty"`
 }
 
 // ToWire translates a ActivityTaskFailedEventAttributes struct into a Thrift-level intermediate
@@ -2978,7 +2979,7 @@ type ActivityTaskFailedEventAttributes struct {
 //	}
 func (v *ActivityTaskFailedEventAttributes) ToWire() (wire.Value, error) {
 	var (
-		fields [5]wire.Field
+		fields [6]wire.Field
 		i      int = 0
 		w      wire.Value
 		err    error
@@ -2998,6 +2999,14 @@ func (v *ActivityTaskFailedEventAttributes) ToWire() (wire.Value, error) {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 20, Value: w}
+		i++
+	}
+	if v.FailureOptions != nil {
+		w, err = v.FailureOptions.ToWire()
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 25, Value: w}
 		i++
 	}
 	if v.ScheduledEventId != nil {
@@ -3026,6 +3035,12 @@ func (v *ActivityTaskFailedEventAttributes) ToWire() (wire.Value, error) {
 	}
 
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+}
+
+func _FailureOptions_Read(w wire.Value) (*FailureOptions, error) {
+	var v FailureOptions
+	err := v.FromWire(w)
+	return &v, err
 }
 
 // FromWire deserializes a ActivityTaskFailedEventAttributes struct from its Thrift-level
@@ -3063,6 +3078,14 @@ func (v *ActivityTaskFailedEventAttributes) FromWire(w wire.Value) error {
 		case 20:
 			if field.Value.Type() == wire.TBinary {
 				v.Details, err = field.Value.GetBinary(), error(nil)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 25:
+			if field.Value.Type() == wire.TStruct {
+				v.FailureOptions, err = _FailureOptions_Read(field.Value)
 				if err != nil {
 					return err
 				}
@@ -3137,6 +3160,18 @@ func (v *ActivityTaskFailedEventAttributes) Encode(sw stream.Writer) error {
 		}
 	}
 
+	if v.FailureOptions != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 25, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.FailureOptions.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
 	if v.ScheduledEventId != nil {
 		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 30, Type: wire.TI64}); err != nil {
 			return err
@@ -3176,6 +3211,12 @@ func (v *ActivityTaskFailedEventAttributes) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _FailureOptions_Decode(sr stream.Reader) (*FailureOptions, error) {
+	var v FailureOptions
+	err := v.Decode(sr)
+	return &v, err
+}
+
 // Decode deserializes a ActivityTaskFailedEventAttributes struct directly from its Thrift-level
 // representation, without going through an intemediary type.
 //
@@ -3204,6 +3245,12 @@ func (v *ActivityTaskFailedEventAttributes) Decode(sr stream.Reader) error {
 
 		case fh.ID == 20 && fh.Type == wire.TBinary:
 			v.Details, err = sr.ReadBinary()
+			if err != nil {
+				return err
+			}
+
+		case fh.ID == 25 && fh.Type == wire.TStruct:
+			v.FailureOptions, err = _FailureOptions_Decode(sr)
 			if err != nil {
 				return err
 			}
@@ -3261,7 +3308,7 @@ func (v *ActivityTaskFailedEventAttributes) String() string {
 		return "<nil>"
 	}
 
-	var fields [5]string
+	var fields [6]string
 	i := 0
 	if v.Reason != nil {
 		fields[i] = fmt.Sprintf("Reason: %v", *(v.Reason))
@@ -3269,6 +3316,10 @@ func (v *ActivityTaskFailedEventAttributes) String() string {
 	}
 	if v.Details != nil {
 		fields[i] = fmt.Sprintf("Details: %v", v.Details)
+		i++
+	}
+	if v.FailureOptions != nil {
+		fields[i] = fmt.Sprintf("FailureOptions: %v", v.FailureOptions)
 		i++
 	}
 	if v.ScheduledEventId != nil {
@@ -3303,6 +3354,9 @@ func (v *ActivityTaskFailedEventAttributes) Equals(rhs *ActivityTaskFailedEventA
 	if !((v.Details == nil && rhs.Details == nil) || (v.Details != nil && rhs.Details != nil && bytes.Equal(v.Details, rhs.Details))) {
 		return false
 	}
+	if !((v.FailureOptions == nil && rhs.FailureOptions == nil) || (v.FailureOptions != nil && rhs.FailureOptions != nil && v.FailureOptions.Equals(rhs.FailureOptions))) {
+		return false
+	}
 	if !_I64_EqualsPtr(v.ScheduledEventId, rhs.ScheduledEventId) {
 		return false
 	}
@@ -3327,6 +3381,9 @@ func (v *ActivityTaskFailedEventAttributes) MarshalLogObject(enc zapcore.ObjectE
 	}
 	if v.Details != nil {
 		enc.AddString("details", base64.StdEncoding.EncodeToString(v.Details))
+	}
+	if v.FailureOptions != nil {
+		err = multierr.Append(err, enc.AddObject("failureOptions", v.FailureOptions))
 	}
 	if v.ScheduledEventId != nil {
 		enc.AddInt64("scheduledEventId", *v.ScheduledEventId)
@@ -3368,6 +3425,21 @@ func (v *ActivityTaskFailedEventAttributes) GetDetails() (o []byte) {
 // IsSetDetails returns true if Details is not nil.
 func (v *ActivityTaskFailedEventAttributes) IsSetDetails() bool {
 	return v != nil && v.Details != nil
+}
+
+// GetFailureOptions returns the value of FailureOptions if it is set or its
+// zero value if it is unset.
+func (v *ActivityTaskFailedEventAttributes) GetFailureOptions() (o *FailureOptions) {
+	if v != nil && v.FailureOptions != nil {
+		return v.FailureOptions
+	}
+
+	return
+}
+
+// IsSetFailureOptions returns true if FailureOptions is not nil.
+func (v *ActivityTaskFailedEventAttributes) IsSetFailureOptions() bool {
+	return v != nil && v.FailureOptions != nil
 }
 
 // GetScheduledEventId returns the value of ScheduledEventId if it is set or its
@@ -4368,12 +4440,13 @@ func (v *ActivityTaskScheduledEventAttributes) IsSetHeader() bool {
 }
 
 type ActivityTaskStartedEventAttributes struct {
-	ScheduledEventId   *int64  `json:"scheduledEventId,omitempty"`
-	Identity           *string `json:"identity,omitempty"`
-	RequestId          *string `json:"requestId,omitempty"`
-	Attempt            *int32  `json:"attempt,omitempty"`
-	LastFailureReason  *string `json:"lastFailureReason,omitempty"`
-	LastFailureDetails []byte  `json:"lastFailureDetails,omitempty"`
+	ScheduledEventId   *int64          `json:"scheduledEventId,omitempty"`
+	Identity           *string         `json:"identity,omitempty"`
+	RequestId          *string         `json:"requestId,omitempty"`
+	Attempt            *int32          `json:"attempt,omitempty"`
+	LastFailureReason  *string         `json:"lastFailureReason,omitempty"`
+	LastFailureDetails []byte          `json:"lastFailureDetails,omitempty"`
+	LastFailureOptions *FailureOptions `json:"lastFailureOptions,omitempty"`
 }
 
 // ToWire translates a ActivityTaskStartedEventAttributes struct into a Thrift-level intermediate
@@ -4393,7 +4466,7 @@ type ActivityTaskStartedEventAttributes struct {
 //	}
 func (v *ActivityTaskStartedEventAttributes) ToWire() (wire.Value, error) {
 	var (
-		fields [6]wire.Field
+		fields [7]wire.Field
 		i      int = 0
 		w      wire.Value
 		err    error
@@ -4445,6 +4518,14 @@ func (v *ActivityTaskStartedEventAttributes) ToWire() (wire.Value, error) {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 60, Value: w}
+		i++
+	}
+	if v.LastFailureOptions != nil {
+		w, err = v.LastFailureOptions.ToWire()
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 70, Value: w}
 		i++
 	}
 
@@ -4526,6 +4607,14 @@ func (v *ActivityTaskStartedEventAttributes) FromWire(w wire.Value) error {
 		case 60:
 			if field.Value.Type() == wire.TBinary {
 				v.LastFailureDetails, err = field.Value.GetBinary(), error(nil)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 70:
+			if field.Value.Type() == wire.TStruct {
+				v.LastFailureOptions, err = _FailureOptions_Read(field.Value)
 				if err != nil {
 					return err
 				}
@@ -4618,6 +4707,18 @@ func (v *ActivityTaskStartedEventAttributes) Encode(sw stream.Writer) error {
 		}
 	}
 
+	if v.LastFailureOptions != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 70, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.LastFailureOptions.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
 	return sw.WriteStructEnd()
 }
 
@@ -4685,6 +4786,12 @@ func (v *ActivityTaskStartedEventAttributes) Decode(sr stream.Reader) error {
 				return err
 			}
 
+		case fh.ID == 70 && fh.Type == wire.TStruct:
+			v.LastFailureOptions, err = _FailureOptions_Decode(sr)
+			if err != nil {
+				return err
+			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -4714,7 +4821,7 @@ func (v *ActivityTaskStartedEventAttributes) String() string {
 		return "<nil>"
 	}
 
-	var fields [6]string
+	var fields [7]string
 	i := 0
 	if v.ScheduledEventId != nil {
 		fields[i] = fmt.Sprintf("ScheduledEventId: %v", *(v.ScheduledEventId))
@@ -4738,6 +4845,10 @@ func (v *ActivityTaskStartedEventAttributes) String() string {
 	}
 	if v.LastFailureDetails != nil {
 		fields[i] = fmt.Sprintf("LastFailureDetails: %v", v.LastFailureDetails)
+		i++
+	}
+	if v.LastFailureOptions != nil {
+		fields[i] = fmt.Sprintf("LastFailureOptions: %v", v.LastFailureOptions)
 		i++
 	}
 
@@ -4772,6 +4883,9 @@ func (v *ActivityTaskStartedEventAttributes) Equals(rhs *ActivityTaskStartedEven
 	if !((v.LastFailureDetails == nil && rhs.LastFailureDetails == nil) || (v.LastFailureDetails != nil && rhs.LastFailureDetails != nil && bytes.Equal(v.LastFailureDetails, rhs.LastFailureDetails))) {
 		return false
 	}
+	if !((v.LastFailureOptions == nil && rhs.LastFailureOptions == nil) || (v.LastFailureOptions != nil && rhs.LastFailureOptions != nil && v.LastFailureOptions.Equals(rhs.LastFailureOptions))) {
+		return false
+	}
 
 	return true
 }
@@ -4799,6 +4913,9 @@ func (v *ActivityTaskStartedEventAttributes) MarshalLogObject(enc zapcore.Object
 	}
 	if v.LastFailureDetails != nil {
 		enc.AddString("lastFailureDetails", base64.StdEncoding.EncodeToString(v.LastFailureDetails))
+	}
+	if v.LastFailureOptions != nil {
+		err = multierr.Append(err, enc.AddObject("lastFailureOptions", v.LastFailureOptions))
 	}
 	return err
 }
@@ -4893,13 +5010,29 @@ func (v *ActivityTaskStartedEventAttributes) IsSetLastFailureDetails() bool {
 	return v != nil && v.LastFailureDetails != nil
 }
 
+// GetLastFailureOptions returns the value of LastFailureOptions if it is set or its
+// zero value if it is unset.
+func (v *ActivityTaskStartedEventAttributes) GetLastFailureOptions() (o *FailureOptions) {
+	if v != nil && v.LastFailureOptions != nil {
+		return v.LastFailureOptions
+	}
+
+	return
+}
+
+// IsSetLastFailureOptions returns true if LastFailureOptions is not nil.
+func (v *ActivityTaskStartedEventAttributes) IsSetLastFailureOptions() bool {
+	return v != nil && v.LastFailureOptions != nil
+}
+
 type ActivityTaskTimedOutEventAttributes struct {
-	Details            []byte       `json:"details,omitempty"`
-	ScheduledEventId   *int64       `json:"scheduledEventId,omitempty"`
-	StartedEventId     *int64       `json:"startedEventId,omitempty"`
-	TimeoutType        *TimeoutType `json:"timeoutType,omitempty"`
-	LastFailureReason  *string      `json:"lastFailureReason,omitempty"`
-	LastFailureDetails []byte       `json:"lastFailureDetails,omitempty"`
+	Details            []byte          `json:"details,omitempty"`
+	ScheduledEventId   *int64          `json:"scheduledEventId,omitempty"`
+	StartedEventId     *int64          `json:"startedEventId,omitempty"`
+	TimeoutType        *TimeoutType    `json:"timeoutType,omitempty"`
+	LastFailureReason  *string         `json:"lastFailureReason,omitempty"`
+	LastFailureDetails []byte          `json:"lastFailureDetails,omitempty"`
+	LastFailureOptions *FailureOptions `json:"lastFailureOptions,omitempty"`
 }
 
 // ToWire translates a ActivityTaskTimedOutEventAttributes struct into a Thrift-level intermediate
@@ -4919,7 +5052,7 @@ type ActivityTaskTimedOutEventAttributes struct {
 //	}
 func (v *ActivityTaskTimedOutEventAttributes) ToWire() (wire.Value, error) {
 	var (
-		fields [6]wire.Field
+		fields [7]wire.Field
 		i      int = 0
 		w      wire.Value
 		err    error
@@ -4971,6 +5104,14 @@ func (v *ActivityTaskTimedOutEventAttributes) ToWire() (wire.Value, error) {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 50, Value: w}
+		i++
+	}
+	if v.LastFailureOptions != nil {
+		w, err = v.LastFailureOptions.ToWire()
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 60, Value: w}
 		i++
 	}
 
@@ -5056,6 +5197,14 @@ func (v *ActivityTaskTimedOutEventAttributes) FromWire(w wire.Value) error {
 		case 50:
 			if field.Value.Type() == wire.TBinary {
 				v.LastFailureDetails, err = field.Value.GetBinary(), error(nil)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 60:
+			if field.Value.Type() == wire.TStruct {
+				v.LastFailureOptions, err = _FailureOptions_Read(field.Value)
 				if err != nil {
 					return err
 				}
@@ -5148,6 +5297,18 @@ func (v *ActivityTaskTimedOutEventAttributes) Encode(sw stream.Writer) error {
 		}
 	}
 
+	if v.LastFailureOptions != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 60, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.LastFailureOptions.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
 	return sw.WriteStructEnd()
 }
 
@@ -5219,6 +5380,12 @@ func (v *ActivityTaskTimedOutEventAttributes) Decode(sr stream.Reader) error {
 				return err
 			}
 
+		case fh.ID == 60 && fh.Type == wire.TStruct:
+			v.LastFailureOptions, err = _FailureOptions_Decode(sr)
+			if err != nil {
+				return err
+			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -5248,7 +5415,7 @@ func (v *ActivityTaskTimedOutEventAttributes) String() string {
 		return "<nil>"
 	}
 
-	var fields [6]string
+	var fields [7]string
 	i := 0
 	if v.Details != nil {
 		fields[i] = fmt.Sprintf("Details: %v", v.Details)
@@ -5272,6 +5439,10 @@ func (v *ActivityTaskTimedOutEventAttributes) String() string {
 	}
 	if v.LastFailureDetails != nil {
 		fields[i] = fmt.Sprintf("LastFailureDetails: %v", v.LastFailureDetails)
+		i++
+	}
+	if v.LastFailureOptions != nil {
+		fields[i] = fmt.Sprintf("LastFailureOptions: %v", v.LastFailureOptions)
 		i++
 	}
 
@@ -5316,6 +5487,9 @@ func (v *ActivityTaskTimedOutEventAttributes) Equals(rhs *ActivityTaskTimedOutEv
 	if !((v.LastFailureDetails == nil && rhs.LastFailureDetails == nil) || (v.LastFailureDetails != nil && rhs.LastFailureDetails != nil && bytes.Equal(v.LastFailureDetails, rhs.LastFailureDetails))) {
 		return false
 	}
+	if !((v.LastFailureOptions == nil && rhs.LastFailureOptions == nil) || (v.LastFailureOptions != nil && rhs.LastFailureOptions != nil && v.LastFailureOptions.Equals(rhs.LastFailureOptions))) {
+		return false
+	}
 
 	return true
 }
@@ -5343,6 +5517,9 @@ func (v *ActivityTaskTimedOutEventAttributes) MarshalLogObject(enc zapcore.Objec
 	}
 	if v.LastFailureDetails != nil {
 		enc.AddString("lastFailureDetails", base64.StdEncoding.EncodeToString(v.LastFailureDetails))
+	}
+	if v.LastFailureOptions != nil {
+		err = multierr.Append(err, enc.AddObject("lastFailureOptions", v.LastFailureOptions))
 	}
 	return err
 }
@@ -5435,6 +5612,21 @@ func (v *ActivityTaskTimedOutEventAttributes) GetLastFailureDetails() (o []byte)
 // IsSetLastFailureDetails returns true if LastFailureDetails is not nil.
 func (v *ActivityTaskTimedOutEventAttributes) IsSetLastFailureDetails() bool {
 	return v != nil && v.LastFailureDetails != nil
+}
+
+// GetLastFailureOptions returns the value of LastFailureOptions if it is set or its
+// zero value if it is unset.
+func (v *ActivityTaskTimedOutEventAttributes) GetLastFailureOptions() (o *FailureOptions) {
+	if v != nil && v.LastFailureOptions != nil {
+		return v.LastFailureOptions
+	}
+
+	return
+}
+
+// IsSetLastFailureOptions returns true if LastFailureOptions is not nil.
+func (v *ActivityTaskTimedOutEventAttributes) IsSetLastFailureOptions() bool {
+	return v != nil && v.LastFailureOptions != nil
 }
 
 type ActivityType struct {
@@ -46786,6 +46978,514 @@ func (v *FailoverType) UnmarshalJSON(text []byte) error {
 	}
 }
 
+type FailureCategory int32
+
+const (
+	FailureCategoryPoll     FailureCategory = 0
+	FailureCategoryStandard FailureCategory = 1
+	FailureCategoryFatal    FailureCategory = 2
+)
+
+// FailureCategory_Values returns all recognized values of FailureCategory.
+func FailureCategory_Values() []FailureCategory {
+	return []FailureCategory{
+		FailureCategoryPoll,
+		FailureCategoryStandard,
+		FailureCategoryFatal,
+	}
+}
+
+// UnmarshalText tries to decode FailureCategory from a byte slice
+// containing its name.
+//
+//	var v FailureCategory
+//	err := v.UnmarshalText([]byte("Poll"))
+func (v *FailureCategory) UnmarshalText(value []byte) error {
+	switch s := string(value); s {
+	case "Poll":
+		*v = FailureCategoryPoll
+		return nil
+	case "Standard":
+		*v = FailureCategoryStandard
+		return nil
+	case "Fatal":
+		*v = FailureCategoryFatal
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "FailureCategory", err)
+		}
+		*v = FailureCategory(val)
+		return nil
+	}
+}
+
+// MarshalText encodes FailureCategory to text.
+//
+// If the enum value is recognized, its name is returned.
+// Otherwise, its integer value is returned.
+//
+// This implements the TextMarshaler interface.
+func (v FailureCategory) MarshalText() ([]byte, error) {
+	switch int32(v) {
+	case 0:
+		return []byte("Poll"), nil
+	case 1:
+		return []byte("Standard"), nil
+	case 2:
+		return []byte("Fatal"), nil
+	}
+	return []byte(strconv.FormatInt(int64(v), 10)), nil
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, enabling
+// fast logging of FailureCategory.
+// Enums are logged as objects, where the value is logged with key "value", and
+// if this value's name is known, the name is logged with key "name".
+func (v FailureCategory) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddInt32("value", int32(v))
+	switch int32(v) {
+	case 0:
+		enc.AddString("name", "Poll")
+	case 1:
+		enc.AddString("name", "Standard")
+	case 2:
+		enc.AddString("name", "Fatal")
+	}
+	return nil
+}
+
+// Ptr returns a pointer to this enum value.
+func (v FailureCategory) Ptr() *FailureCategory {
+	return &v
+}
+
+// Encode encodes FailureCategory directly to bytes.
+//
+//	sWriter := BinaryStreamer.Writer(writer)
+//
+//	var v FailureCategory
+//	return v.Encode(sWriter)
+func (v FailureCategory) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
+}
+
+// ToWire translates FailureCategory into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// Enums are represented as 32-bit integers over the wire.
+func (v FailureCategory) ToWire() (wire.Value, error) {
+	return wire.NewValueI32(int32(v)), nil
+}
+
+// FromWire deserializes FailureCategory from its Thrift-level
+// representation.
+//
+//	x, err := binaryProtocol.Decode(reader, wire.TI32)
+//	if err != nil {
+//	    return FailureCategory(0), err
+//	}
+//
+//	var v FailureCategory
+//	if err := v.FromWire(x); err != nil {
+//	    return FailureCategory(0), err
+//	}
+//	return v, nil
+func (v *FailureCategory) FromWire(w wire.Value) error {
+	*v = (FailureCategory)(w.GetI32())
+	return nil
+}
+
+// Decode reads off the encoded FailureCategory directly off of the wire.
+//
+//	sReader := BinaryStreamer.Reader(reader)
+//
+//	var v FailureCategory
+//	if err := v.Decode(sReader); err != nil {
+//	    return FailureCategory(0), err
+//	}
+//	return v, nil
+func (v *FailureCategory) Decode(sr stream.Reader) error {
+	i, err := sr.ReadInt32()
+	if err != nil {
+		return err
+	}
+	*v = (FailureCategory)(i)
+	return nil
+}
+
+// String returns a readable string representation of FailureCategory.
+func (v FailureCategory) String() string {
+	w := int32(v)
+	switch w {
+	case 0:
+		return "Poll"
+	case 1:
+		return "Standard"
+	case 2:
+		return "Fatal"
+	}
+	return fmt.Sprintf("FailureCategory(%d)", w)
+}
+
+// Equals returns true if this FailureCategory value matches the provided
+// value.
+func (v FailureCategory) Equals(rhs FailureCategory) bool {
+	return v == rhs
+}
+
+// MarshalJSON serializes FailureCategory into JSON.
+//
+// If the enum value is recognized, its name is returned.
+// Otherwise, its integer value is returned.
+//
+// This implements json.Marshaler.
+func (v FailureCategory) MarshalJSON() ([]byte, error) {
+	switch int32(v) {
+	case 0:
+		return ([]byte)("\"Poll\""), nil
+	case 1:
+		return ([]byte)("\"Standard\""), nil
+	case 2:
+		return ([]byte)("\"Fatal\""), nil
+	}
+	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
+}
+
+// UnmarshalJSON attempts to decode FailureCategory from its JSON
+// representation.
+//
+// This implementation supports both, numeric and string inputs. If a
+// string is provided, it must be a known enum name.
+//
+// This implements json.Unmarshaler.
+func (v *FailureCategory) UnmarshalJSON(text []byte) error {
+	d := json.NewDecoder(bytes.NewReader(text))
+	d.UseNumber()
+	t, err := d.Token()
+	if err != nil {
+		return err
+	}
+
+	switch w := t.(type) {
+	case json.Number:
+		x, err := w.Int64()
+		if err != nil {
+			return err
+		}
+		if x > math.MaxInt32 {
+			return fmt.Errorf("enum overflow from JSON %q for %q", text, "FailureCategory")
+		}
+		if x < math.MinInt32 {
+			return fmt.Errorf("enum underflow from JSON %q for %q", text, "FailureCategory")
+		}
+		*v = (FailureCategory)(x)
+		return nil
+	case string:
+		return v.UnmarshalText([]byte(w))
+	default:
+		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "FailureCategory")
+	}
+}
+
+type FailureOptions struct {
+	FailureCategory          *FailureCategory `json:"failureCategory,omitempty"`
+	NextRetryIntervalSeconds *int32           `json:"nextRetryIntervalSeconds,omitempty"`
+}
+
+// ToWire translates a FailureOptions struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
+//
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
+func (v *FailureOptions) ToWire() (wire.Value, error) {
+	var (
+		fields [2]wire.Field
+		i      int = 0
+		w      wire.Value
+		err    error
+	)
+
+	if v.FailureCategory != nil {
+		w, err = v.FailureCategory.ToWire()
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 10, Value: w}
+		i++
+	}
+	if v.NextRetryIntervalSeconds != nil {
+		w, err = wire.NewValueI32(*(v.NextRetryIntervalSeconds)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 20, Value: w}
+		i++
+	}
+
+	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+}
+
+func _FailureCategory_Read(w wire.Value) (FailureCategory, error) {
+	var v FailureCategory
+	err := v.FromWire(w)
+	return v, err
+}
+
+// FromWire deserializes a FailureOptions struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a FailureOptions struct
+// from the provided intermediate representation.
+//
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	var v FailureOptions
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
+func (v *FailureOptions) FromWire(w wire.Value) error {
+	var err error
+
+	for _, field := range w.GetStruct().Fields {
+		switch field.ID {
+		case 10:
+			if field.Value.Type() == wire.TI32 {
+				var x FailureCategory
+				x, err = _FailureCategory_Read(field.Value)
+				v.FailureCategory = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 20:
+			if field.Value.Type() == wire.TI32 {
+				var x int32
+				x, err = field.Value.GetI32(), error(nil)
+				v.NextRetryIntervalSeconds = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+	}
+
+	return nil
+}
+
+// Encode serializes a FailureOptions struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a FailureOptions struct could not be encoded.
+func (v *FailureOptions) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.FailureCategory != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 10, Type: wire.TI32}); err != nil {
+			return err
+		}
+		if err := v.FailureCategory.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.NextRetryIntervalSeconds != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 20, Type: wire.TI32}); err != nil {
+			return err
+		}
+		if err := sw.WriteInt32(*(v.NextRetryIntervalSeconds)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
+func _FailureCategory_Decode(sr stream.Reader) (FailureCategory, error) {
+	var v FailureCategory
+	err := v.Decode(sr)
+	return v, err
+}
+
+// Decode deserializes a FailureOptions struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a FailureOptions struct could not be generated from the wire
+// representation.
+func (v *FailureOptions) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch {
+		case fh.ID == 10 && fh.Type == wire.TI32:
+			var x FailureCategory
+			x, err = _FailureCategory_Decode(sr)
+			v.FailureCategory = &x
+			if err != nil {
+				return err
+			}
+
+		case fh.ID == 20 && fh.Type == wire.TI32:
+			var x int32
+			x, err = sr.ReadInt32()
+			v.NextRetryIntervalSeconds = &x
+			if err != nil {
+				return err
+			}
+
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// String returns a readable string representation of a FailureOptions
+// struct.
+func (v *FailureOptions) String() string {
+	if v == nil {
+		return "<nil>"
+	}
+
+	var fields [2]string
+	i := 0
+	if v.FailureCategory != nil {
+		fields[i] = fmt.Sprintf("FailureCategory: %v", *(v.FailureCategory))
+		i++
+	}
+	if v.NextRetryIntervalSeconds != nil {
+		fields[i] = fmt.Sprintf("NextRetryIntervalSeconds: %v", *(v.NextRetryIntervalSeconds))
+		i++
+	}
+
+	return fmt.Sprintf("FailureOptions{%v}", strings.Join(fields[:i], ", "))
+}
+
+func _FailureCategory_EqualsPtr(lhs, rhs *FailureCategory) bool {
+	if lhs != nil && rhs != nil {
+
+		x := *lhs
+		y := *rhs
+		return x.Equals(y)
+	}
+	return lhs == nil && rhs == nil
+}
+
+// Equals returns true if all the fields of this FailureOptions match the
+// provided FailureOptions.
+//
+// This function performs a deep comparison.
+func (v *FailureOptions) Equals(rhs *FailureOptions) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
+	if !_FailureCategory_EqualsPtr(v.FailureCategory, rhs.FailureCategory) {
+		return false
+	}
+	if !_I32_EqualsPtr(v.NextRetryIntervalSeconds, rhs.NextRetryIntervalSeconds) {
+		return false
+	}
+
+	return true
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, enabling
+// fast logging of FailureOptions.
+func (v *FailureOptions) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
+	if v.FailureCategory != nil {
+		err = multierr.Append(err, enc.AddObject("failureCategory", *v.FailureCategory))
+	}
+	if v.NextRetryIntervalSeconds != nil {
+		enc.AddInt32("nextRetryIntervalSeconds", *v.NextRetryIntervalSeconds)
+	}
+	return err
+}
+
+// GetFailureCategory returns the value of FailureCategory if it is set or its
+// zero value if it is unset.
+func (v *FailureOptions) GetFailureCategory() (o FailureCategory) {
+	if v != nil && v.FailureCategory != nil {
+		return *v.FailureCategory
+	}
+
+	return
+}
+
+// IsSetFailureCategory returns true if FailureCategory is not nil.
+func (v *FailureOptions) IsSetFailureCategory() bool {
+	return v != nil && v.FailureCategory != nil
+}
+
+// GetNextRetryIntervalSeconds returns the value of NextRetryIntervalSeconds if it is set or its
+// zero value if it is unset.
+func (v *FailureOptions) GetNextRetryIntervalSeconds() (o int32) {
+	if v != nil && v.NextRetryIntervalSeconds != nil {
+		return *v.NextRetryIntervalSeconds
+	}
+
+	return
+}
+
+// IsSetNextRetryIntervalSeconds returns true if NextRetryIntervalSeconds is not nil.
+func (v *FailureOptions) IsSetNextRetryIntervalSeconds() bool {
+	return v != nil && v.NextRetryIntervalSeconds != nil
+}
+
 type FeatureFlags struct {
 	WorkflowExecutionAlreadyCompletedErrorEnabled *bool `json:"WorkflowExecutionAlreadyCompletedErrorEnabled,omitempty"`
 	AutoForwardingEnabled                         *bool `json:"AutoForwardingEnabled,omitempty"`
@@ -65727,6 +66427,7 @@ type PendingActivityInfo struct {
 	LastFailureReason      *string               `json:"lastFailureReason,omitempty"`
 	LastWorkerIdentity     *string               `json:"lastWorkerIdentity,omitempty"`
 	LastFailureDetails     []byte                `json:"lastFailureDetails,omitempty"`
+	LastFailureOptions     *FailureOptions       `json:"lastFailureOptions,omitempty"`
 	StartedWorkerIdentity  *string               `json:"startedWorkerIdentity,omitempty"`
 	ScheduleID             *int64                `json:"scheduleID,omitempty"`
 }
@@ -65748,7 +66449,7 @@ type PendingActivityInfo struct {
 //	}
 func (v *PendingActivityInfo) ToWire() (wire.Value, error) {
 	var (
-		fields [15]wire.Field
+		fields [16]wire.Field
 		i      int = 0
 		w      wire.Value
 		err    error
@@ -65856,6 +66557,14 @@ func (v *PendingActivityInfo) ToWire() (wire.Value, error) {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 130, Value: w}
+		i++
+	}
+	if v.LastFailureOptions != nil {
+		w, err = v.LastFailureOptions.ToWire()
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 135, Value: w}
 		i++
 	}
 	if v.StartedWorkerIdentity != nil {
@@ -66025,6 +66734,14 @@ func (v *PendingActivityInfo) FromWire(w wire.Value) error {
 		case 130:
 			if field.Value.Type() == wire.TBinary {
 				v.LastFailureDetails, err = field.Value.GetBinary(), error(nil)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 135:
+			if field.Value.Type() == wire.TStruct {
+				v.LastFailureOptions, err = _FailureOptions_Read(field.Value)
 				if err != nil {
 					return err
 				}
@@ -66221,6 +66938,18 @@ func (v *PendingActivityInfo) Encode(sw stream.Writer) error {
 		}
 	}
 
+	if v.LastFailureOptions != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 135, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.LastFailureOptions.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
 	if v.StartedWorkerIdentity != nil {
 		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 140, Type: wire.TBinary}); err != nil {
 			return err
@@ -66370,6 +67099,12 @@ func (v *PendingActivityInfo) Decode(sr stream.Reader) error {
 				return err
 			}
 
+		case fh.ID == 135 && fh.Type == wire.TStruct:
+			v.LastFailureOptions, err = _FailureOptions_Decode(sr)
+			if err != nil {
+				return err
+			}
+
 		case fh.ID == 140 && fh.Type == wire.TBinary:
 			var x string
 			x, err = sr.ReadString()
@@ -66415,7 +67150,7 @@ func (v *PendingActivityInfo) String() string {
 		return "<nil>"
 	}
 
-	var fields [15]string
+	var fields [16]string
 	i := 0
 	if v.ActivityID != nil {
 		fields[i] = fmt.Sprintf("ActivityID: %v", *(v.ActivityID))
@@ -66467,6 +67202,10 @@ func (v *PendingActivityInfo) String() string {
 	}
 	if v.LastFailureDetails != nil {
 		fields[i] = fmt.Sprintf("LastFailureDetails: %v", v.LastFailureDetails)
+		i++
+	}
+	if v.LastFailureOptions != nil {
+		fields[i] = fmt.Sprintf("LastFailureOptions: %v", v.LastFailureOptions)
 		i++
 	}
 	if v.StartedWorkerIdentity != nil {
@@ -66540,6 +67279,9 @@ func (v *PendingActivityInfo) Equals(rhs *PendingActivityInfo) bool {
 	if !((v.LastFailureDetails == nil && rhs.LastFailureDetails == nil) || (v.LastFailureDetails != nil && rhs.LastFailureDetails != nil && bytes.Equal(v.LastFailureDetails, rhs.LastFailureDetails))) {
 		return false
 	}
+	if !((v.LastFailureOptions == nil && rhs.LastFailureOptions == nil) || (v.LastFailureOptions != nil && rhs.LastFailureOptions != nil && v.LastFailureOptions.Equals(rhs.LastFailureOptions))) {
+		return false
+	}
 	if !_String_EqualsPtr(v.StartedWorkerIdentity, rhs.StartedWorkerIdentity) {
 		return false
 	}
@@ -66594,6 +67336,9 @@ func (v *PendingActivityInfo) MarshalLogObject(enc zapcore.ObjectEncoder) (err e
 	}
 	if v.LastFailureDetails != nil {
 		enc.AddString("lastFailureDetails", base64.StdEncoding.EncodeToString(v.LastFailureDetails))
+	}
+	if v.LastFailureOptions != nil {
+		err = multierr.Append(err, enc.AddObject("lastFailureOptions", v.LastFailureOptions))
 	}
 	if v.StartedWorkerIdentity != nil {
 		enc.AddString("startedWorkerIdentity", *v.StartedWorkerIdentity)
@@ -66797,6 +67542,21 @@ func (v *PendingActivityInfo) GetLastFailureDetails() (o []byte) {
 // IsSetLastFailureDetails returns true if LastFailureDetails is not nil.
 func (v *PendingActivityInfo) IsSetLastFailureDetails() bool {
 	return v != nil && v.LastFailureDetails != nil
+}
+
+// GetLastFailureOptions returns the value of LastFailureOptions if it is set or its
+// zero value if it is unset.
+func (v *PendingActivityInfo) GetLastFailureOptions() (o *FailureOptions) {
+	if v != nil && v.LastFailureOptions != nil {
+		return v.LastFailureOptions
+	}
+
+	return
+}
+
+// IsSetLastFailureOptions returns true if LastFailureOptions is not nil.
+func (v *PendingActivityInfo) IsSetLastFailureOptions() bool {
+	return v != nil && v.LastFailureOptions != nil
 }
 
 // GetStartedWorkerIdentity returns the value of StartedWorkerIdentity if it is set or its
@@ -85612,13 +86372,15 @@ func (v *RespondActivityTaskCompletedRequest) IsSetIdentity() bool {
 }
 
 type RespondActivityTaskFailedByIDRequest struct {
-	Domain     *string `json:"domain,omitempty"`
-	WorkflowID *string `json:"workflowID,omitempty"`
-	RunID      *string `json:"runID,omitempty"`
-	ActivityID *string `json:"activityID,omitempty"`
-	Reason     *string `json:"reason,omitempty"`
-	Details    []byte  `json:"details,omitempty"`
-	Identity   *string `json:"identity,omitempty"`
+	Domain           *string         `json:"domain,omitempty"`
+	WorkflowID       *string         `json:"workflowID,omitempty"`
+	RunID            *string         `json:"runID,omitempty"`
+	ActivityID       *string         `json:"activityID,omitempty"`
+	Reason           *string         `json:"reason,omitempty"`
+	Details          []byte          `json:"details,omitempty"`
+	FailureOptions   *FailureOptions `json:"failureOptions,omitempty"`
+	Identity         *string         `json:"identity,omitempty"`
+	HeartbeatDetails []byte          `json:"heartbeatDetails,omitempty"`
 }
 
 // ToWire translates a RespondActivityTaskFailedByIDRequest struct into a Thrift-level intermediate
@@ -85638,7 +86400,7 @@ type RespondActivityTaskFailedByIDRequest struct {
 //	}
 func (v *RespondActivityTaskFailedByIDRequest) ToWire() (wire.Value, error) {
 	var (
-		fields [7]wire.Field
+		fields [9]wire.Field
 		i      int = 0
 		w      wire.Value
 		err    error
@@ -85692,12 +86454,28 @@ func (v *RespondActivityTaskFailedByIDRequest) ToWire() (wire.Value, error) {
 		fields[i] = wire.Field{ID: 60, Value: w}
 		i++
 	}
+	if v.FailureOptions != nil {
+		w, err = v.FailureOptions.ToWire()
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 65, Value: w}
+		i++
+	}
 	if v.Identity != nil {
 		w, err = wire.NewValueString(*(v.Identity)), error(nil)
 		if err != nil {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 70, Value: w}
+		i++
+	}
+	if v.HeartbeatDetails != nil {
+		w, err = wire.NewValueBinary(v.HeartbeatDetails), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 80, Value: w}
 		i++
 	}
 
@@ -85784,11 +86562,27 @@ func (v *RespondActivityTaskFailedByIDRequest) FromWire(w wire.Value) error {
 				}
 
 			}
+		case 65:
+			if field.Value.Type() == wire.TStruct {
+				v.FailureOptions, err = _FailureOptions_Read(field.Value)
+				if err != nil {
+					return err
+				}
+
+			}
 		case 70:
 			if field.Value.Type() == wire.TBinary {
 				var x string
 				x, err = field.Value.GetString(), error(nil)
 				v.Identity = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 80:
+			if field.Value.Type() == wire.TBinary {
+				v.HeartbeatDetails, err = field.Value.GetBinary(), error(nil)
 				if err != nil {
 					return err
 				}
@@ -85881,11 +86675,35 @@ func (v *RespondActivityTaskFailedByIDRequest) Encode(sw stream.Writer) error {
 		}
 	}
 
+	if v.FailureOptions != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 65, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.FailureOptions.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
 	if v.Identity != nil {
 		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 70, Type: wire.TBinary}); err != nil {
 			return err
 		}
 		if err := sw.WriteString(*(v.Identity)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.HeartbeatDetails != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 80, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteBinary(v.HeartbeatDetails); err != nil {
 			return err
 		}
 		if err := sw.WriteFieldEnd(); err != nil {
@@ -85960,10 +86778,22 @@ func (v *RespondActivityTaskFailedByIDRequest) Decode(sr stream.Reader) error {
 				return err
 			}
 
+		case fh.ID == 65 && fh.Type == wire.TStruct:
+			v.FailureOptions, err = _FailureOptions_Decode(sr)
+			if err != nil {
+				return err
+			}
+
 		case fh.ID == 70 && fh.Type == wire.TBinary:
 			var x string
 			x, err = sr.ReadString()
 			v.Identity = &x
+			if err != nil {
+				return err
+			}
+
+		case fh.ID == 80 && fh.Type == wire.TBinary:
+			v.HeartbeatDetails, err = sr.ReadBinary()
 			if err != nil {
 				return err
 			}
@@ -85997,7 +86827,7 @@ func (v *RespondActivityTaskFailedByIDRequest) String() string {
 		return "<nil>"
 	}
 
-	var fields [7]string
+	var fields [9]string
 	i := 0
 	if v.Domain != nil {
 		fields[i] = fmt.Sprintf("Domain: %v", *(v.Domain))
@@ -86023,8 +86853,16 @@ func (v *RespondActivityTaskFailedByIDRequest) String() string {
 		fields[i] = fmt.Sprintf("Details: %v", v.Details)
 		i++
 	}
+	if v.FailureOptions != nil {
+		fields[i] = fmt.Sprintf("FailureOptions: %v", v.FailureOptions)
+		i++
+	}
 	if v.Identity != nil {
 		fields[i] = fmt.Sprintf("Identity: %v", *(v.Identity))
+		i++
+	}
+	if v.HeartbeatDetails != nil {
+		fields[i] = fmt.Sprintf("HeartbeatDetails: %v", v.HeartbeatDetails)
 		i++
 	}
 
@@ -86059,7 +86897,13 @@ func (v *RespondActivityTaskFailedByIDRequest) Equals(rhs *RespondActivityTaskFa
 	if !((v.Details == nil && rhs.Details == nil) || (v.Details != nil && rhs.Details != nil && bytes.Equal(v.Details, rhs.Details))) {
 		return false
 	}
+	if !((v.FailureOptions == nil && rhs.FailureOptions == nil) || (v.FailureOptions != nil && rhs.FailureOptions != nil && v.FailureOptions.Equals(rhs.FailureOptions))) {
+		return false
+	}
 	if !_String_EqualsPtr(v.Identity, rhs.Identity) {
+		return false
+	}
+	if !((v.HeartbeatDetails == nil && rhs.HeartbeatDetails == nil) || (v.HeartbeatDetails != nil && rhs.HeartbeatDetails != nil && bytes.Equal(v.HeartbeatDetails, rhs.HeartbeatDetails))) {
 		return false
 	}
 
@@ -86090,8 +86934,14 @@ func (v *RespondActivityTaskFailedByIDRequest) MarshalLogObject(enc zapcore.Obje
 	if v.Details != nil {
 		enc.AddString("details", base64.StdEncoding.EncodeToString(v.Details))
 	}
+	if v.FailureOptions != nil {
+		err = multierr.Append(err, enc.AddObject("failureOptions", v.FailureOptions))
+	}
 	if v.Identity != nil {
 		enc.AddString("identity", *v.Identity)
+	}
+	if v.HeartbeatDetails != nil {
+		enc.AddString("heartbeatDetails", base64.StdEncoding.EncodeToString(v.HeartbeatDetails))
 	}
 	return err
 }
@@ -86186,6 +87036,21 @@ func (v *RespondActivityTaskFailedByIDRequest) IsSetDetails() bool {
 	return v != nil && v.Details != nil
 }
 
+// GetFailureOptions returns the value of FailureOptions if it is set or its
+// zero value if it is unset.
+func (v *RespondActivityTaskFailedByIDRequest) GetFailureOptions() (o *FailureOptions) {
+	if v != nil && v.FailureOptions != nil {
+		return v.FailureOptions
+	}
+
+	return
+}
+
+// IsSetFailureOptions returns true if FailureOptions is not nil.
+func (v *RespondActivityTaskFailedByIDRequest) IsSetFailureOptions() bool {
+	return v != nil && v.FailureOptions != nil
+}
+
 // GetIdentity returns the value of Identity if it is set or its
 // zero value if it is unset.
 func (v *RespondActivityTaskFailedByIDRequest) GetIdentity() (o string) {
@@ -86201,11 +87066,28 @@ func (v *RespondActivityTaskFailedByIDRequest) IsSetIdentity() bool {
 	return v != nil && v.Identity != nil
 }
 
+// GetHeartbeatDetails returns the value of HeartbeatDetails if it is set or its
+// zero value if it is unset.
+func (v *RespondActivityTaskFailedByIDRequest) GetHeartbeatDetails() (o []byte) {
+	if v != nil && v.HeartbeatDetails != nil {
+		return v.HeartbeatDetails
+	}
+
+	return
+}
+
+// IsSetHeartbeatDetails returns true if HeartbeatDetails is not nil.
+func (v *RespondActivityTaskFailedByIDRequest) IsSetHeartbeatDetails() bool {
+	return v != nil && v.HeartbeatDetails != nil
+}
+
 type RespondActivityTaskFailedRequest struct {
-	TaskToken []byte  `json:"taskToken,omitempty"`
-	Reason    *string `json:"reason,omitempty"`
-	Details   []byte  `json:"details,omitempty"`
-	Identity  *string `json:"identity,omitempty"`
+	TaskToken        []byte          `json:"taskToken,omitempty"`
+	Reason           *string         `json:"reason,omitempty"`
+	Details          []byte          `json:"details,omitempty"`
+	Identity         *string         `json:"identity,omitempty"`
+	FailureOptions   *FailureOptions `json:"failureOptions,omitempty"`
+	HeartbeatDetails []byte          `json:"heartbeatDetails,omitempty"`
 }
 
 // ToWire translates a RespondActivityTaskFailedRequest struct into a Thrift-level intermediate
@@ -86225,7 +87107,7 @@ type RespondActivityTaskFailedRequest struct {
 //	}
 func (v *RespondActivityTaskFailedRequest) ToWire() (wire.Value, error) {
 	var (
-		fields [4]wire.Field
+		fields [6]wire.Field
 		i      int = 0
 		w      wire.Value
 		err    error
@@ -86261,6 +87143,22 @@ func (v *RespondActivityTaskFailedRequest) ToWire() (wire.Value, error) {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 40, Value: w}
+		i++
+	}
+	if v.FailureOptions != nil {
+		w, err = v.FailureOptions.ToWire()
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 45, Value: w}
+		i++
+	}
+	if v.HeartbeatDetails != nil {
+		w, err = wire.NewValueBinary(v.HeartbeatDetails), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 50, Value: w}
 		i++
 	}
 
@@ -86320,6 +87218,22 @@ func (v *RespondActivityTaskFailedRequest) FromWire(w wire.Value) error {
 				var x string
 				x, err = field.Value.GetString(), error(nil)
 				v.Identity = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 45:
+			if field.Value.Type() == wire.TStruct {
+				v.FailureOptions, err = _FailureOptions_Read(field.Value)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 50:
+			if field.Value.Type() == wire.TBinary {
+				v.HeartbeatDetails, err = field.Value.GetBinary(), error(nil)
 				if err != nil {
 					return err
 				}
@@ -86388,6 +87302,30 @@ func (v *RespondActivityTaskFailedRequest) Encode(sw stream.Writer) error {
 		}
 	}
 
+	if v.FailureOptions != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 45, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.FailureOptions.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.HeartbeatDetails != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 50, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteBinary(v.HeartbeatDetails); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
 	return sw.WriteStructEnd()
 }
 
@@ -86437,6 +87375,18 @@ func (v *RespondActivityTaskFailedRequest) Decode(sr stream.Reader) error {
 				return err
 			}
 
+		case fh.ID == 45 && fh.Type == wire.TStruct:
+			v.FailureOptions, err = _FailureOptions_Decode(sr)
+			if err != nil {
+				return err
+			}
+
+		case fh.ID == 50 && fh.Type == wire.TBinary:
+			v.HeartbeatDetails, err = sr.ReadBinary()
+			if err != nil {
+				return err
+			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -86466,7 +87416,7 @@ func (v *RespondActivityTaskFailedRequest) String() string {
 		return "<nil>"
 	}
 
-	var fields [4]string
+	var fields [6]string
 	i := 0
 	if v.TaskToken != nil {
 		fields[i] = fmt.Sprintf("TaskToken: %v", v.TaskToken)
@@ -86482,6 +87432,14 @@ func (v *RespondActivityTaskFailedRequest) String() string {
 	}
 	if v.Identity != nil {
 		fields[i] = fmt.Sprintf("Identity: %v", *(v.Identity))
+		i++
+	}
+	if v.FailureOptions != nil {
+		fields[i] = fmt.Sprintf("FailureOptions: %v", v.FailureOptions)
+		i++
+	}
+	if v.HeartbeatDetails != nil {
+		fields[i] = fmt.Sprintf("HeartbeatDetails: %v", v.HeartbeatDetails)
 		i++
 	}
 
@@ -86510,6 +87468,12 @@ func (v *RespondActivityTaskFailedRequest) Equals(rhs *RespondActivityTaskFailed
 	if !_String_EqualsPtr(v.Identity, rhs.Identity) {
 		return false
 	}
+	if !((v.FailureOptions == nil && rhs.FailureOptions == nil) || (v.FailureOptions != nil && rhs.FailureOptions != nil && v.FailureOptions.Equals(rhs.FailureOptions))) {
+		return false
+	}
+	if !((v.HeartbeatDetails == nil && rhs.HeartbeatDetails == nil) || (v.HeartbeatDetails != nil && rhs.HeartbeatDetails != nil && bytes.Equal(v.HeartbeatDetails, rhs.HeartbeatDetails))) {
+		return false
+	}
 
 	return true
 }
@@ -86531,6 +87495,12 @@ func (v *RespondActivityTaskFailedRequest) MarshalLogObject(enc zapcore.ObjectEn
 	}
 	if v.Identity != nil {
 		enc.AddString("identity", *v.Identity)
+	}
+	if v.FailureOptions != nil {
+		err = multierr.Append(err, enc.AddObject("failureOptions", v.FailureOptions))
+	}
+	if v.HeartbeatDetails != nil {
+		enc.AddString("heartbeatDetails", base64.StdEncoding.EncodeToString(v.HeartbeatDetails))
 	}
 	return err
 }
@@ -86593,6 +87563,36 @@ func (v *RespondActivityTaskFailedRequest) GetIdentity() (o string) {
 // IsSetIdentity returns true if Identity is not nil.
 func (v *RespondActivityTaskFailedRequest) IsSetIdentity() bool {
 	return v != nil && v.Identity != nil
+}
+
+// GetFailureOptions returns the value of FailureOptions if it is set or its
+// zero value if it is unset.
+func (v *RespondActivityTaskFailedRequest) GetFailureOptions() (o *FailureOptions) {
+	if v != nil && v.FailureOptions != nil {
+		return v.FailureOptions
+	}
+
+	return
+}
+
+// IsSetFailureOptions returns true if FailureOptions is not nil.
+func (v *RespondActivityTaskFailedRequest) IsSetFailureOptions() bool {
+	return v != nil && v.FailureOptions != nil
+}
+
+// GetHeartbeatDetails returns the value of HeartbeatDetails if it is set or its
+// zero value if it is unset.
+func (v *RespondActivityTaskFailedRequest) GetHeartbeatDetails() (o []byte) {
+	if v != nil && v.HeartbeatDetails != nil {
+		return v.HeartbeatDetails
+	}
+
+	return
+}
+
+// IsSetHeartbeatDetails returns true if HeartbeatDetails is not nil.
+func (v *RespondActivityTaskFailedRequest) IsSetHeartbeatDetails() bool {
+	return v != nil && v.HeartbeatDetails != nil
 }
 
 type RespondCrossClusterTasksCompletedRequest struct {
@@ -92887,14 +93887,16 @@ func (v *ScheduleCatchUpPolicy) UnmarshalJSON(text []byte) error {
 }
 
 type ScheduleInfo struct {
-	LastRunTimeNano    *int64          `json:"lastRunTimeNano,omitempty"`
-	NextRunTimeNano    *int64          `json:"nextRunTimeNano,omitempty"`
-	TotalRuns          *int64          `json:"totalRuns,omitempty"`
-	CreateTimeNano     *int64          `json:"createTimeNano,omitempty"`
-	LastUpdateTimeNano *int64          `json:"lastUpdateTimeNano,omitempty"`
-	OngoingBackfills   []*BackfillInfo `json:"ongoingBackfills,omitempty"`
-	MissedRuns         *int64          `json:"missedRuns,omitempty"`
-	SkippedRuns        *int64          `json:"skippedRuns,omitempty"`
+	LastRunTimeNano      *int64          `json:"lastRunTimeNano,omitempty"`
+	NextRunTimeNano      *int64          `json:"nextRunTimeNano,omitempty"`
+	TotalRuns            *int64          `json:"totalRuns,omitempty"`
+	CreateTimeNano       *int64          `json:"createTimeNano,omitempty"`
+	LastUpdateTimeNano   *int64          `json:"lastUpdateTimeNano,omitempty"`
+	OngoingBackfills     []*BackfillInfo `json:"ongoingBackfills,omitempty"`
+	MissedRuns           *int64          `json:"missedRuns,omitempty"`
+	SkippedRuns          *int64          `json:"skippedRuns,omitempty"`
+	BufferedFireCount    *int64          `json:"bufferedFireCount,omitempty"`
+	RunningWorkflowCount *int64          `json:"runningWorkflowCount,omitempty"`
 }
 
 type _List_BackfillInfo_ValueList []*BackfillInfo
@@ -92943,7 +93945,7 @@ func (_List_BackfillInfo_ValueList) Close() {}
 //	}
 func (v *ScheduleInfo) ToWire() (wire.Value, error) {
 	var (
-		fields [8]wire.Field
+		fields [10]wire.Field
 		i      int = 0
 		w      wire.Value
 		err    error
@@ -93011,6 +94013,22 @@ func (v *ScheduleInfo) ToWire() (wire.Value, error) {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 80, Value: w}
+		i++
+	}
+	if v.BufferedFireCount != nil {
+		w, err = wire.NewValueI64(*(v.BufferedFireCount)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 90, Value: w}
+		i++
+	}
+	if v.RunningWorkflowCount != nil {
+		w, err = wire.NewValueI64(*(v.RunningWorkflowCount)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 100, Value: w}
 		i++
 	}
 
@@ -93136,6 +94154,26 @@ func (v *ScheduleInfo) FromWire(w wire.Value) error {
 				var x int64
 				x, err = field.Value.GetI64(), error(nil)
 				v.SkippedRuns = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 90:
+			if field.Value.Type() == wire.TI64 {
+				var x int64
+				x, err = field.Value.GetI64(), error(nil)
+				v.BufferedFireCount = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 100:
+			if field.Value.Type() == wire.TI64 {
+				var x int64
+				x, err = field.Value.GetI64(), error(nil)
+				v.RunningWorkflowCount = &x
 				if err != nil {
 					return err
 				}
@@ -93273,6 +94311,30 @@ func (v *ScheduleInfo) Encode(sw stream.Writer) error {
 		}
 	}
 
+	if v.BufferedFireCount != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 90, Type: wire.TI64}); err != nil {
+			return err
+		}
+		if err := sw.WriteInt64(*(v.BufferedFireCount)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.RunningWorkflowCount != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 100, Type: wire.TI64}); err != nil {
+			return err
+		}
+		if err := sw.WriteInt64(*(v.RunningWorkflowCount)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
 	return sw.WriteStructEnd()
 }
 
@@ -93392,6 +94454,22 @@ func (v *ScheduleInfo) Decode(sr stream.Reader) error {
 				return err
 			}
 
+		case fh.ID == 90 && fh.Type == wire.TI64:
+			var x int64
+			x, err = sr.ReadInt64()
+			v.BufferedFireCount = &x
+			if err != nil {
+				return err
+			}
+
+		case fh.ID == 100 && fh.Type == wire.TI64:
+			var x int64
+			x, err = sr.ReadInt64()
+			v.RunningWorkflowCount = &x
+			if err != nil {
+				return err
+			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -93421,7 +94499,7 @@ func (v *ScheduleInfo) String() string {
 		return "<nil>"
 	}
 
-	var fields [8]string
+	var fields [10]string
 	i := 0
 	if v.LastRunTimeNano != nil {
 		fields[i] = fmt.Sprintf("LastRunTimeNano: %v", *(v.LastRunTimeNano))
@@ -93453,6 +94531,14 @@ func (v *ScheduleInfo) String() string {
 	}
 	if v.SkippedRuns != nil {
 		fields[i] = fmt.Sprintf("SkippedRuns: %v", *(v.SkippedRuns))
+		i++
+	}
+	if v.BufferedFireCount != nil {
+		fields[i] = fmt.Sprintf("BufferedFireCount: %v", *(v.BufferedFireCount))
+		i++
+	}
+	if v.RunningWorkflowCount != nil {
+		fields[i] = fmt.Sprintf("RunningWorkflowCount: %v", *(v.RunningWorkflowCount))
 		i++
 	}
 
@@ -93508,6 +94594,12 @@ func (v *ScheduleInfo) Equals(rhs *ScheduleInfo) bool {
 	if !_I64_EqualsPtr(v.SkippedRuns, rhs.SkippedRuns) {
 		return false
 	}
+	if !_I64_EqualsPtr(v.BufferedFireCount, rhs.BufferedFireCount) {
+		return false
+	}
+	if !_I64_EqualsPtr(v.RunningWorkflowCount, rhs.RunningWorkflowCount) {
+		return false
+	}
 
 	return true
 }
@@ -93552,6 +94644,12 @@ func (v *ScheduleInfo) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
 	}
 	if v.SkippedRuns != nil {
 		enc.AddInt64("skippedRuns", *v.SkippedRuns)
+	}
+	if v.BufferedFireCount != nil {
+		enc.AddInt64("bufferedFireCount", *v.BufferedFireCount)
+	}
+	if v.RunningWorkflowCount != nil {
+		enc.AddInt64("runningWorkflowCount", *v.RunningWorkflowCount)
 	}
 	return err
 }
@@ -93674,6 +94772,36 @@ func (v *ScheduleInfo) GetSkippedRuns() (o int64) {
 // IsSetSkippedRuns returns true if SkippedRuns is not nil.
 func (v *ScheduleInfo) IsSetSkippedRuns() bool {
 	return v != nil && v.SkippedRuns != nil
+}
+
+// GetBufferedFireCount returns the value of BufferedFireCount if it is set or its
+// zero value if it is unset.
+func (v *ScheduleInfo) GetBufferedFireCount() (o int64) {
+	if v != nil && v.BufferedFireCount != nil {
+		return *v.BufferedFireCount
+	}
+
+	return
+}
+
+// IsSetBufferedFireCount returns true if BufferedFireCount is not nil.
+func (v *ScheduleInfo) IsSetBufferedFireCount() bool {
+	return v != nil && v.BufferedFireCount != nil
+}
+
+// GetRunningWorkflowCount returns the value of RunningWorkflowCount if it is set or its
+// zero value if it is unset.
+func (v *ScheduleInfo) GetRunningWorkflowCount() (o int64) {
+	if v != nil && v.RunningWorkflowCount != nil {
+		return *v.RunningWorkflowCount
+	}
+
+	return
+}
+
+// IsSetRunningWorkflowCount returns true if RunningWorkflowCount is not nil.
+func (v *ScheduleInfo) IsSetRunningWorkflowCount() bool {
+	return v != nil && v.RunningWorkflowCount != nil
 }
 
 type ScheduleListEntry struct {
@@ -128856,8 +129984,8 @@ var ThriftModule = &thriftreflect.ThriftModule{
 	Name:     "shared",
 	Package:  "go.uber.org/cadence/.gen/go/shared",
 	FilePath: "shared.thrift",
-	SHA1:     "3b85e1c91dafe9cffd4d0f9e4b959d9820dadc6b",
+	SHA1:     "d11c0097b90d08a8dba9a0214cc308d2618df8ba",
 	Raw:      rawIDL,
 }
 
-const rawIDL = "// Copyright (c) 2017 Uber Technologies, Inc.\n//\n// Permission is hereby granted, free of charge, to any person obtaining a copy\n// of this software and associated documentation files (the \"Software\"), to deal\n// in the Software without restriction, including without limitation the rights\n// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n// copies of the Software, and to permit persons to whom the Software is\n// furnished to do so, subject to the following conditions:\n//\n// The above copyright notice and this permission notice shall be included in\n// all copies or substantial portions of the Software.\n//\n// THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\n// THE SOFTWARE.\n\nnamespace java com.uber.cadence\n\nexception BadRequestError {\n  1: required string message\n} (rpc.code = \"INVALID_ARGUMENT\")\n\nexception InternalServiceError {\n  1: required string message\n} (rpc.code = \"INTERNAL\")\n\nexception InternalDataInconsistencyError {\n  1: required string message\n} (rpc.code = \"DATA_LOSS\")\n\nexception DomainAlreadyExistsError {\n  1: required string message\n} (rpc.code = \"ALREADY_EXISTS\")\n\nexception WorkflowExecutionAlreadyStartedError {\n  10: optional string message\n  20: optional string startRequestId\n  30: optional string runId\n} (rpc.code = \"ALREADY_EXISTS\")\n\nexception WorkflowExecutionAlreadyCompletedError {\n  1: required string message\n} (rpc.code = \"NOT_FOUND\")\n\nexception EntityNotExistsError {\n  1: required string message\n  2: optional string currentCluster\n  3: optional string activeCluster\n  4: required list<string> activeClusters // todo(david.porter) remove as its disused\n} (rpc.code = \"NOT_FOUND\")\n\nexception ServiceBusyError {\n  1: required string message\n  2: optional string reason\n} (rpc.code = \"RESOURCE_EXHAUSTED\")\n\nexception CancellationAlreadyRequestedError {\n  1: required string message\n} (rpc.code = \"ALREADY_EXISTS\")\n\nexception QueryFailedError {\n  1: required string message\n} (rpc.code = \"INVALID_ARGUMENT\")\n\nexception DomainNotActiveError {\n  1: required string message\n  2: required string domainName\n  3: required string currentCluster\n  4: required string activeCluster\n  5: required list<string> activeClusters // todo (david.porter) remove this field as it's disused\n} (rpc.code = \"FAILED_PRECONDITION\")\n\nexception LimitExceededError {\n  1: required string message\n} (rpc.code = \"RESOURCE_EXHAUSTED\")\n\nexception AccessDeniedError {\n  1: required string message\n} (rpc.code = \"PERMISSION_DENIED\")\n\nexception RetryTaskV2Error {\n  1: required string message\n  2: optional string domainId\n  3: optional string workflowId\n  4: optional string runId\n  5: optional i64 (js.type = \"Long\") startEventId\n  6: optional i64 (js.type = \"Long\") startEventVersion\n  7: optional i64 (js.type = \"Long\") endEventId\n  8: optional i64 (js.type = \"Long\") endEventVersion\n} (rpc.code = \"ABORTED\")\n\nexception ClientVersionNotSupportedError {\n  1: required string featureVersion\n  2: required string clientImpl\n  3: required string supportedVersions\n} (rpc.code = \"FAILED_PRECONDITION\")\n\nexception FeatureNotEnabledError {\n  1: required string featureFlag\n} (rpc.code = \"FAILED_PRECONDITION\")\n\nexception CurrentBranchChangedError {\n  10: required string message\n  20: required binary currentBranchToken\n} (rpc.code = \"ABORTED\")\n\nexception RemoteSyncMatchedError {\n  10: required string message\n} (rpc.code = \"UNAVAILABLE\")\n\nexception StickyWorkerUnavailableError {\n  1: required string message\n} (rpc.code = \"UNAVAILABLE\")\n\nexception TaskListNotOwnedByHostError {\n    1: required string ownedByIdentity\n    2: required string myIdentity\n    3: required string tasklistName\n} (rpc.code = \"ABORTED\")\n\nenum WorkflowIdReusePolicy {\n  /*\n   * allow start a workflow execution using the same workflow ID,\n   * when workflow not running, and the last execution close state is in\n   * [terminated, cancelled, timeouted, failed].\n   */\n  AllowDuplicateFailedOnly,\n  /*\n   * allow start a workflow execution using the same workflow ID,\n   * when workflow not running.\n   */\n  AllowDuplicate,\n  /*\n   * do not allow start a workflow execution using the same workflow ID at all\n   */\n  RejectDuplicate,\n  /*\n   * if a workflow is running using the same workflow ID, terminate it and start a new one\n   */\n  TerminateIfRunning,\n}\n\nenum DomainStatus {\n  REGISTERED,\n  DEPRECATED,\n  DELETED,\n}\n\nenum TimeoutType {\n  START_TO_CLOSE,\n  SCHEDULE_TO_START,\n  SCHEDULE_TO_CLOSE,\n  HEARTBEAT,\n}\n\nenum ParentClosePolicy {\n  ABANDON,\n  REQUEST_CANCEL,\n  TERMINATE,\n}\n\n\n// whenever this list of decision is changed\n// do change the mutableStateBuilder.go\n// function shouldBufferEvent\n// to make sure wo do the correct event ordering\nenum DecisionType {\n  ScheduleActivityTask,\n  RequestCancelActivityTask,\n  StartTimer,\n  CompleteWorkflowExecution,\n  FailWorkflowExecution,\n  CancelTimer,\n  CancelWorkflowExecution,\n  RequestCancelExternalWorkflowExecution,\n  RecordMarker,\n  ContinueAsNewWorkflowExecution,\n  StartChildWorkflowExecution,\n  SignalExternalWorkflowExecution,\n  UpsertWorkflowSearchAttributes,\n}\n\nenum EventType {\n  WorkflowExecutionStarted,\n  WorkflowExecutionCompleted,\n  WorkflowExecutionFailed,\n  WorkflowExecutionTimedOut,\n  DecisionTaskScheduled,\n  DecisionTaskStarted,\n  DecisionTaskCompleted,\n  DecisionTaskTimedOut\n  DecisionTaskFailed,\n  ActivityTaskScheduled,\n  ActivityTaskStarted,\n  ActivityTaskCompleted,\n  ActivityTaskFailed,\n  ActivityTaskTimedOut,\n  ActivityTaskCancelRequested,\n  RequestCancelActivityTaskFailed,\n  ActivityTaskCanceled,\n  TimerStarted,\n  TimerFired,\n  CancelTimerFailed,\n  TimerCanceled,\n  WorkflowExecutionCancelRequested,\n  WorkflowExecutionCanceled,\n  RequestCancelExternalWorkflowExecutionInitiated,\n  RequestCancelExternalWorkflowExecutionFailed,\n  ExternalWorkflowExecutionCancelRequested,\n  MarkerRecorded,\n  WorkflowExecutionSignaled,\n  WorkflowExecutionTerminated,\n  WorkflowExecutionContinuedAsNew,\n  StartChildWorkflowExecutionInitiated,\n  StartChildWorkflowExecutionFailed,\n  ChildWorkflowExecutionStarted,\n  ChildWorkflowExecutionCompleted,\n  ChildWorkflowExecutionFailed,\n  ChildWorkflowExecutionCanceled,\n  ChildWorkflowExecutionTimedOut,\n  ChildWorkflowExecutionTerminated,\n  SignalExternalWorkflowExecutionInitiated,\n  SignalExternalWorkflowExecutionFailed,\n  ExternalWorkflowExecutionSignaled,\n  UpsertWorkflowSearchAttributes,\n}\n\nenum DecisionTaskFailedCause {\n  UNHANDLED_DECISION,\n  BAD_SCHEDULE_ACTIVITY_ATTRIBUTES,\n  BAD_REQUEST_CANCEL_ACTIVITY_ATTRIBUTES,\n  BAD_START_TIMER_ATTRIBUTES,\n  BAD_CANCEL_TIMER_ATTRIBUTES,\n  BAD_RECORD_MARKER_ATTRIBUTES,\n  BAD_COMPLETE_WORKFLOW_EXECUTION_ATTRIBUTES,\n  BAD_FAIL_WORKFLOW_EXECUTION_ATTRIBUTES,\n  BAD_CANCEL_WORKFLOW_EXECUTION_ATTRIBUTES,\n  BAD_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_ATTRIBUTES,\n  BAD_CONTINUE_AS_NEW_ATTRIBUTES,\n  START_TIMER_DUPLICATE_ID,\n  RESET_STICKY_TASKLIST,\n  WORKFLOW_WORKER_UNHANDLED_FAILURE,\n  BAD_SIGNAL_WORKFLOW_EXECUTION_ATTRIBUTES,\n  BAD_START_CHILD_EXECUTION_ATTRIBUTES,\n  FORCE_CLOSE_DECISION,\n  FAILOVER_CLOSE_DECISION,\n  BAD_SIGNAL_INPUT_SIZE,\n  RESET_WORKFLOW,\n  BAD_BINARY,\n  SCHEDULE_ACTIVITY_DUPLICATE_ID,\n  BAD_SEARCH_ATTRIBUTES,\n}\n\nenum DecisionTaskTimedOutCause {\n  TIMEOUT,\n  RESET,\n}\n\nenum CancelExternalWorkflowExecutionFailedCause {\n  UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION,\n  WORKFLOW_ALREADY_COMPLETED,\n}\n\nenum SignalExternalWorkflowExecutionFailedCause {\n  UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION,\n  WORKFLOW_ALREADY_COMPLETED,\n}\n\nenum ChildWorkflowExecutionFailedCause {\n  WORKFLOW_ALREADY_RUNNING,\n}\n\n// TODO: when migrating to gRPC, add a running / none status,\n//  currently, customer is using null / nil as an indication\n//  that workflow is still running\nenum WorkflowExecutionCloseStatus {\n  COMPLETED,\n  FAILED,\n  CANCELED,\n  TERMINATED,\n  CONTINUED_AS_NEW,\n  TIMED_OUT,\n}\n\nenum WorkflowExecutionStatus {\n  PENDING,\n  STARTED,\n  COMPLETED,\n  FAILED,\n  CANCELED,\n  TERMINATED,\n  CONTINUED_AS_NEW,\n  TIMED_OUT,\n}\n\nenum QueryTaskCompletedType {\n  COMPLETED,\n  FAILED,\n}\n\nenum QueryResultType {\n  ANSWERED,\n  FAILED,\n}\n\nenum PendingActivityState {\n  SCHEDULED,\n  STARTED,\n  CANCEL_REQUESTED,\n}\n\nenum PendingDecisionState {\n  SCHEDULED,\n  STARTED,\n}\n\nenum HistoryEventFilterType {\n  ALL_EVENT,\n  CLOSE_EVENT,\n}\n\nenum TaskListKind {\n  NORMAL,\n  STICKY,\n  EPHEMERAL,\n}\n\nenum ArchivalStatus {\n  DISABLED,\n  ENABLED,\n}\n\nenum CronOverlapPolicy {\n  SKIPPED,\n  BUFFERONE,\n}\n\nenum IndexedValueType {\n  STRING,\n  KEYWORD,\n  INT,\n  DOUBLE,\n  BOOL,\n  DATETIME,\n}\n\nstruct Header {\n    10: optional map<string, binary> fields\n}\n\nstruct WorkflowType {\n  10: optional string name\n}\n\nstruct ActivityType {\n  10: optional string name\n}\n\nstruct TaskList {\n  10: optional string name\n  20: optional TaskListKind kind\n  30: optional string baseName\n}\n\nenum EncodingType {\n  ThriftRW,\n  JSON,\n}\n\nenum QueryRejectCondition {\n  // NOT_OPEN indicates that query should be rejected if workflow is not open\n  NOT_OPEN\n  // NOT_COMPLETED_CLEANLY indicates that query should be rejected if workflow did not complete cleanly\n  NOT_COMPLETED_CLEANLY\n}\n\nenum QueryConsistencyLevel {\n  // EVENTUAL indicates that query should be eventually consistent\n  EVENTUAL\n  // STRONG indicates that any events that came before query should be reflected in workflow state before running query\n  STRONG\n}\n\nstruct DataBlob {\n  10: optional EncodingType EncodingType\n  20: optional binary Data\n}\n\nstruct TaskListMetadata {\n  10: optional double maxTasksPerSecond\n}\n\nstruct WorkflowExecution {\n  10: optional string workflowId\n  20: optional string runId\n}\n\nstruct Memo {\n  10: optional map<string,binary> fields\n}\n\nstruct SearchAttributes {\n  10: optional map<string,binary> indexedFields\n}\n\nstruct WorkerVersionInfo {\n  10: optional string impl\n  20: optional string featureVersion\n}\n\nstruct WorkflowExecutionInfo {\n  10: optional WorkflowExecution execution\n  20: optional WorkflowType type\n  30: optional i64 (js.type = \"Long\") startTime\n  40: optional i64 (js.type = \"Long\") closeTime\n  50: optional WorkflowExecutionCloseStatus closeStatus\n  60: optional i64 (js.type = \"Long\") historyLength\n  70: optional string parentDomainId\n  71: optional string parentDomainName\n  72: optional i64 parentInitatedId\n  80: optional WorkflowExecution parentExecution\n  90: optional i64 (js.type = \"Long\") executionTime\n  100: optional Memo memo\n  101: optional SearchAttributes searchAttributes\n  110: optional ResetPoints autoResetPoints\n  120: optional string taskList\n  121: optional TaskList taskListInfo\n  130: optional bool isCron\n  140: optional i64 (js.type = \"Long\") updateTime\n  150: optional map<string, string> partitionConfig\n  160: optional CronOverlapPolicy cronOverlapPolicy\n  170: optional ActiveClusterSelectionPolicy activeClusterSelectionPolicy\n  180: optional string cronSchedule\n  190: optional WorkflowExecutionStatus executionStatus\n  200: optional i64 (js.type = \"Long\") scheduledExecutionTime\n}\n\nstruct WorkflowExecutionConfiguration {\n  10: optional TaskList taskList\n  20: optional i32 executionStartToCloseTimeoutSeconds\n  30: optional i32 taskStartToCloseTimeoutSeconds\n//  40: optional ChildPolicy childPolicy -- Removed but reserve the IDL order number\n}\n\nstruct TransientDecisionInfo {\n  10: optional HistoryEvent scheduledEvent\n  20: optional HistoryEvent startedEvent\n}\n\nstruct ScheduleActivityTaskDecisionAttributes {\n  10: optional string activityId\n  20: optional ActivityType activityType\n  25: optional string domain\n  30: optional TaskList taskList\n  40: optional binary input\n  45: optional i32 scheduleToCloseTimeoutSeconds\n  50: optional i32 scheduleToStartTimeoutSeconds\n  55: optional i32 startToCloseTimeoutSeconds\n  60: optional i32 heartbeatTimeoutSeconds\n  70: optional RetryPolicy retryPolicy\n  80: optional Header header\n  90: optional bool requestLocalDispatch\n}\n\nstruct ActivityLocalDispatchInfo{\n  10: optional string activityId\n  20: optional i64 (js.type = \"Long\") scheduledTimestamp\n  30: optional i64 (js.type = \"Long\") startedTimestamp\n  40: optional i64 (js.type = \"Long\") scheduledTimestampOfThisAttempt\n  50: optional binary taskToken\n}\n\nstruct RequestCancelActivityTaskDecisionAttributes {\n  10: optional string activityId\n}\n\nstruct StartTimerDecisionAttributes {\n  10: optional string timerId\n  20: optional i64 (js.type = \"Long\") startToFireTimeoutSeconds\n}\n\nstruct CompleteWorkflowExecutionDecisionAttributes {\n  10: optional binary result\n}\n\nstruct FailWorkflowExecutionDecisionAttributes {\n  10: optional string reason\n  20: optional binary details\n}\n\nstruct CancelTimerDecisionAttributes {\n  10: optional string timerId\n}\n\nstruct CancelWorkflowExecutionDecisionAttributes {\n  10: optional binary details\n}\n\nstruct RequestCancelExternalWorkflowExecutionDecisionAttributes {\n  10: optional string domain\n  20: optional string workflowId\n  30: optional string runId\n  40: optional binary control\n  50: optional bool childWorkflowOnly\n}\n\nstruct SignalExternalWorkflowExecutionDecisionAttributes {\n  10: optional string domain\n  20: optional WorkflowExecution execution\n  30: optional string signalName\n  40: optional binary input\n  50: optional binary control\n  60: optional bool childWorkflowOnly\n}\n\nstruct UpsertWorkflowSearchAttributesDecisionAttributes {\n  10: optional SearchAttributes searchAttributes\n}\n\nstruct RecordMarkerDecisionAttributes {\n  10: optional string markerName\n  20: optional binary details\n  30: optional Header header\n}\n\nstruct ContinueAsNewWorkflowExecutionDecisionAttributes {\n  10: optional WorkflowType workflowType\n  20: optional TaskList taskList\n  30: optional binary input\n  40: optional i32 executionStartToCloseTimeoutSeconds\n  50: optional i32 taskStartToCloseTimeoutSeconds\n  60: optional i32 backoffStartIntervalInSeconds\n  70: optional RetryPolicy retryPolicy\n  80: optional ContinueAsNewInitiator initiator\n  90: optional string failureReason\n  100: optional binary failureDetails\n  110: optional binary lastCompletionResult\n  120: optional string cronSchedule\n  130: optional Header header\n  140: optional Memo memo\n  150: optional SearchAttributes searchAttributes\n  160: optional i32 jitterStartSeconds\n  170: optional CronOverlapPolicy cronOverlapPolicy\n  180: optional ActiveClusterSelectionPolicy activeClusterSelectionPolicy\n}\n\nstruct StartChildWorkflowExecutionDecisionAttributes {\n  10: optional string domain\n  20: optional string workflowId\n  30: optional WorkflowType workflowType\n  40: optional TaskList taskList\n  50: optional binary input\n  60: optional i32 executionStartToCloseTimeoutSeconds\n  70: optional i32 taskStartToCloseTimeoutSeconds\n//  80: optional ChildPolicy childPolicy -- Removed but reserve the IDL order number\n  81: optional ParentClosePolicy parentClosePolicy\n  90: optional binary control\n  100: optional WorkflowIdReusePolicy workflowIdReusePolicy\n  110: optional RetryPolicy retryPolicy\n  120: optional string cronSchedule\n  130: optional Header header\n  140: optional Memo memo\n  150: optional SearchAttributes searchAttributes\n  160: optional CronOverlapPolicy cronOverlapPolicy\n  170: optional ActiveClusterSelectionPolicy activeClusterSelectionPolicy\n}\n\nstruct Decision {\n  10:  optional DecisionType decisionType\n  20:  optional ScheduleActivityTaskDecisionAttributes scheduleActivityTaskDecisionAttributes\n  25:  optional StartTimerDecisionAttributes startTimerDecisionAttributes\n  30:  optional CompleteWorkflowExecutionDecisionAttributes completeWorkflowExecutionDecisionAttributes\n  35:  optional FailWorkflowExecutionDecisionAttributes failWorkflowExecutionDecisionAttributes\n  40:  optional RequestCancelActivityTaskDecisionAttributes requestCancelActivityTaskDecisionAttributes\n  50:  optional CancelTimerDecisionAttributes cancelTimerDecisionAttributes\n  60:  optional CancelWorkflowExecutionDecisionAttributes cancelWorkflowExecutionDecisionAttributes\n  70:  optional RequestCancelExternalWorkflowExecutionDecisionAttributes requestCancelExternalWorkflowExecutionDecisionAttributes\n  80:  optional RecordMarkerDecisionAttributes recordMarkerDecisionAttributes\n  90:  optional ContinueAsNewWorkflowExecutionDecisionAttributes continueAsNewWorkflowExecutionDecisionAttributes\n  100: optional StartChildWorkflowExecutionDecisionAttributes startChildWorkflowExecutionDecisionAttributes\n  110: optional SignalExternalWorkflowExecutionDecisionAttributes signalExternalWorkflowExecutionDecisionAttributes\n  120: optional UpsertWorkflowSearchAttributesDecisionAttributes upsertWorkflowSearchAttributesDecisionAttributes\n}\n\nstruct WorkflowExecutionStartedEventAttributes {\n  10: optional WorkflowType workflowType\n  12: optional string parentWorkflowDomain\n  14: optional WorkflowExecution parentWorkflowExecution\n  16: optional i64 (js.type = \"Long\") parentInitiatedEventId\n  20: optional TaskList taskList\n  30: optional binary input\n  40: optional i32 executionStartToCloseTimeoutSeconds\n  50: optional i32 taskStartToCloseTimeoutSeconds\n//  52: optional ChildPolicy childPolicy -- Removed but reserve the IDL order number\n  54: optional string continuedExecutionRunId\n  55: optional ContinueAsNewInitiator initiator\n  56: optional string continuedFailureReason\n  57: optional binary continuedFailureDetails\n  58: optional binary lastCompletionResult\n  59: optional string originalExecutionRunId // This is the runID when the WorkflowExecutionStarted event is written\n  60: optional string identity\n  61: optional string firstExecutionRunId // This is the very first runID along the chain of ContinueAsNew and Reset.\n  62: optional i64 (js.type = \"Long\") firstScheduledTimeNano\n  70: optional RetryPolicy retryPolicy\n  80: optional i32 attempt\n  90: optional i64 (js.type = \"Long\") expirationTimestamp\n  100: optional string cronSchedule\n  110: optional i32 firstDecisionTaskBackoffSeconds\n  120: optional Memo memo\n  121: optional SearchAttributes searchAttributes\n  130: optional ResetPoints prevAutoResetPoints\n  140: optional Header header\n  150: optional map<string, string> partitionConfig\n  160: optional string requestId\n  170: optional CronOverlapPolicy cronOverlapPolicy\n  180: optional ActiveClusterSelectionPolicy activeClusterSelectionPolicy\n}\n\nstruct ResetPoints{\n  10: optional list<ResetPointInfo> points\n}\n\n struct ResetPointInfo{\n  10: optional string binaryChecksum\n  20: optional string runId\n  30: optional i64 firstDecisionCompletedId\n  40: optional i64 (js.type = \"Long\") createdTimeNano\n  50: optional i64 (js.type = \"Long\") expiringTimeNano //the time that the run is deleted due to retention\n  60: optional bool resettable                         // false if the resset point has pending childWFs/reqCancels/signalExternals.\n}\n\nstruct WorkflowExecutionCompletedEventAttributes {\n  10: optional binary result\n  20: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n}\n\nstruct WorkflowExecutionFailedEventAttributes {\n  10: optional string reason\n  20: optional binary details\n  30: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n}\n\nstruct WorkflowExecutionTimedOutEventAttributes {\n  10: optional TimeoutType timeoutType\n}\n\nenum ContinueAsNewInitiator {\n  Decider,\n  RetryPolicy,\n  CronSchedule,\n}\n\nstruct WorkflowExecutionContinuedAsNewEventAttributes {\n  10: optional string newExecutionRunId\n  20: optional WorkflowType workflowType\n  30: optional TaskList taskList\n  40: optional binary input\n  50: optional i32 executionStartToCloseTimeoutSeconds\n  60: optional i32 taskStartToCloseTimeoutSeconds\n  70: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  80: optional i32 backoffStartIntervalInSeconds\n  90: optional ContinueAsNewInitiator initiator\n  100: optional string failureReason\n  110: optional binary failureDetails\n  120: optional binary lastCompletionResult\n  130: optional Header header\n  140: optional Memo memo\n  150: optional SearchAttributes searchAttributes\n  160: optional CronOverlapPolicy cronOverlapPolicy\n  170: optional ActiveClusterSelectionPolicy activeClusterSelectionPolicy\n}\n\nstruct DecisionTaskScheduledEventAttributes {\n  10: optional TaskList taskList\n  20: optional i32 startToCloseTimeoutSeconds\n  30: optional i64 (js.type = \"Long\") attempt\n}\n\nstruct DecisionTaskStartedEventAttributes {\n  10: optional i64 (js.type = \"Long\") scheduledEventId\n  20: optional string identity\n  30: optional string requestId\n}\n\nstruct DecisionTaskCompletedEventAttributes {\n  10: optional binary executionContext\n  20: optional i64 (js.type = \"Long\") scheduledEventId\n  30: optional i64 (js.type = \"Long\") startedEventId\n  40: optional string identity\n  50: optional string binaryChecksum\n}\n\nstruct DecisionTaskTimedOutEventAttributes {\n  10: optional i64 (js.type = \"Long\") scheduledEventId\n  20: optional i64 (js.type = \"Long\") startedEventId\n  30: optional TimeoutType timeoutType\n  // for reset workflow\n  40: optional string baseRunId\n  50: optional string newRunId\n  60: optional i64 (js.type = \"Long\") forkEventVersion\n  70: optional string reason\n  80: optional DecisionTaskTimedOutCause cause\n  90: optional string requestId\n}\n\nstruct DecisionTaskFailedEventAttributes {\n  10: optional i64 (js.type = \"Long\") scheduledEventId\n  20: optional i64 (js.type = \"Long\") startedEventId\n  30: optional DecisionTaskFailedCause cause\n  35: optional binary details\n  40: optional string identity\n  50: optional string reason\n  // for reset workflow\n  60: optional string baseRunId\n  70: optional string newRunId\n  80: optional i64 (js.type = \"Long\") forkEventVersion\n  90: optional string binaryChecksum\n  100: optional string requestId\n}\n\nstruct ActivityTaskScheduledEventAttributes {\n  10: optional string activityId\n  20: optional ActivityType activityType\n  25: optional string domain\n  30: optional TaskList taskList\n  40: optional binary input\n  45: optional i32 scheduleToCloseTimeoutSeconds\n  50: optional i32 scheduleToStartTimeoutSeconds\n  55: optional i32 startToCloseTimeoutSeconds\n  60: optional i32 heartbeatTimeoutSeconds\n  90: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  110: optional RetryPolicy retryPolicy\n  120: optional Header header\n}\n\nstruct ActivityTaskStartedEventAttributes {\n  10: optional i64 (js.type = \"Long\") scheduledEventId\n  20: optional string identity\n  30: optional string requestId\n  40: optional i32 attempt\n  50: optional string lastFailureReason\n  60: optional binary lastFailureDetails\n}\n\nstruct ActivityTaskCompletedEventAttributes {\n  10: optional binary result\n  20: optional i64 (js.type = \"Long\") scheduledEventId\n  30: optional i64 (js.type = \"Long\") startedEventId\n  40: optional string identity\n}\n\nstruct ActivityTaskFailedEventAttributes {\n  10: optional string reason\n  20: optional binary details\n  30: optional i64 (js.type = \"Long\") scheduledEventId\n  40: optional i64 (js.type = \"Long\") startedEventId\n  50: optional string identity\n}\n\nstruct ActivityTaskTimedOutEventAttributes {\n  05: optional binary details\n  10: optional i64 (js.type = \"Long\") scheduledEventId\n  20: optional i64 (js.type = \"Long\") startedEventId\n  30: optional TimeoutType timeoutType\n  // For retry activity, it may have a failure before timeout. It's important to keep those information for debug.\n  // Client can also provide the info for making next decision\n  40: optional string lastFailureReason\n  50: optional binary lastFailureDetails\n}\n\nstruct ActivityTaskCancelRequestedEventAttributes {\n  10: optional string activityId\n  20: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n}\n\nstruct RequestCancelActivityTaskFailedEventAttributes{\n  10: optional string activityId\n  20: optional string cause\n  30: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n}\n\nstruct ActivityTaskCanceledEventAttributes {\n  10: optional binary details\n  20: optional i64 (js.type = \"Long\") latestCancelRequestedEventId\n  30: optional i64 (js.type = \"Long\") scheduledEventId\n  40: optional i64 (js.type = \"Long\") startedEventId\n  50: optional string identity\n}\n\nstruct TimerStartedEventAttributes {\n  10: optional string timerId\n  20: optional i64 (js.type = \"Long\") startToFireTimeoutSeconds\n  30: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n}\n\nstruct TimerFiredEventAttributes {\n  10: optional string timerId\n  20: optional i64 (js.type = \"Long\") startedEventId\n}\n\nstruct TimerCanceledEventAttributes {\n  10: optional string timerId\n  20: optional i64 (js.type = \"Long\") startedEventId\n  30: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  40: optional string identity\n}\n\nstruct CancelTimerFailedEventAttributes {\n  10: optional string timerId\n  20: optional string cause\n  30: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  40: optional string identity\n}\n\nstruct WorkflowExecutionCancelRequestedEventAttributes {\n  10: optional string cause\n  20: optional i64 (js.type = \"Long\") externalInitiatedEventId\n  30: optional WorkflowExecution externalWorkflowExecution\n  40: optional string identity\n  50: optional string requestId\n}\n\nstruct WorkflowExecutionCanceledEventAttributes {\n  10: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  20: optional binary details\n}\n\nstruct MarkerRecordedEventAttributes {\n  10: optional string markerName\n  20: optional binary details\n  30: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  40: optional Header header\n}\n\nstruct WorkflowExecutionSignaledEventAttributes {\n  10: optional string signalName\n  20: optional binary input\n  30: optional string identity\n  40: optional string requestId\n}\n\nstruct WorkflowExecutionTerminatedEventAttributes {\n  10: optional string reason\n  20: optional binary details\n  30: optional string identity\n}\n\nstruct RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {\n  10: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  20: optional string domain\n  30: optional WorkflowExecution workflowExecution\n  40: optional binary control\n  50: optional bool childWorkflowOnly\n}\n\nstruct RequestCancelExternalWorkflowExecutionFailedEventAttributes {\n  10: optional CancelExternalWorkflowExecutionFailedCause cause\n  20: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  30: optional string domain\n  40: optional WorkflowExecution workflowExecution\n  50: optional i64 (js.type = \"Long\") initiatedEventId\n  60: optional binary control\n}\n\nstruct ExternalWorkflowExecutionCancelRequestedEventAttributes {\n  10: optional i64 (js.type = \"Long\") initiatedEventId\n  20: optional string domain\n  30: optional WorkflowExecution workflowExecution\n}\n\nstruct SignalExternalWorkflowExecutionInitiatedEventAttributes {\n  10: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  20: optional string domain\n  30: optional WorkflowExecution workflowExecution\n  40: optional string signalName\n  50: optional binary input\n  60: optional binary control\n  70: optional bool childWorkflowOnly\n}\n\nstruct SignalExternalWorkflowExecutionFailedEventAttributes {\n  10: optional SignalExternalWorkflowExecutionFailedCause cause\n  20: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  30: optional string domain\n  40: optional WorkflowExecution workflowExecution\n  50: optional i64 (js.type = \"Long\") initiatedEventId\n  60: optional binary control\n}\n\nstruct ExternalWorkflowExecutionSignaledEventAttributes {\n  10: optional i64 (js.type = \"Long\") initiatedEventId\n  20: optional string domain\n  30: optional WorkflowExecution workflowExecution\n  40: optional binary control\n}\n\nstruct UpsertWorkflowSearchAttributesEventAttributes {\n  10: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  20: optional SearchAttributes searchAttributes\n}\n\nstruct StartChildWorkflowExecutionInitiatedEventAttributes {\n  10:  optional string domain\n  20:  optional string workflowId\n  30:  optional WorkflowType workflowType\n  40:  optional TaskList taskList\n  50:  optional binary input\n  60:  optional i32 executionStartToCloseTimeoutSeconds\n  70:  optional i32 taskStartToCloseTimeoutSeconds\n//  80:  optional ChildPolicy childPolicy -- Removed but reserve the IDL order number\n  81:  optional ParentClosePolicy parentClosePolicy\n  90:  optional binary control\n  100: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  110: optional WorkflowIdReusePolicy workflowIdReusePolicy\n  120: optional RetryPolicy retryPolicy\n  130: optional string cronSchedule\n  140: optional Header header\n  150: optional Memo memo\n  160: optional SearchAttributes searchAttributes\n  170: optional i32 delayStartSeconds\n  180: optional i32 jitterStartSeconds\n  190: optional i64 (js.type = \"Long\") firstRunAtTimestamp\n  200: optional CronOverlapPolicy cronOverlapPolicy\n  210: optional ActiveClusterSelectionPolicy activeClusterSelectionPolicy\n}\n\nstruct StartChildWorkflowExecutionFailedEventAttributes {\n  10: optional string domain\n  20: optional string workflowId\n  30: optional WorkflowType workflowType\n  40: optional ChildWorkflowExecutionFailedCause cause\n  50: optional binary control\n  60: optional i64 (js.type = \"Long\") initiatedEventId\n  70: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n}\n\nstruct ChildWorkflowExecutionStartedEventAttributes {\n  10: optional string domain\n  20: optional i64 (js.type = \"Long\") initiatedEventId\n  30: optional WorkflowExecution workflowExecution\n  40: optional WorkflowType workflowType\n  50: optional Header header\n}\n\nstruct ChildWorkflowExecutionCompletedEventAttributes {\n  10: optional binary result\n  20: optional string domain\n  30: optional WorkflowExecution workflowExecution\n  40: optional WorkflowType workflowType\n  50: optional i64 (js.type = \"Long\") initiatedEventId\n  60: optional i64 (js.type = \"Long\") startedEventId\n}\n\nstruct ChildWorkflowExecutionFailedEventAttributes {\n  10: optional string reason\n  20: optional binary details\n  30: optional string domain\n  40: optional WorkflowExecution workflowExecution\n  50: optional WorkflowType workflowType\n  60: optional i64 (js.type = \"Long\") initiatedEventId\n  70: optional i64 (js.type = \"Long\") startedEventId\n}\n\nstruct ChildWorkflowExecutionCanceledEventAttributes {\n  10: optional binary details\n  20: optional string domain\n  30: optional WorkflowExecution workflowExecution\n  40: optional WorkflowType workflowType\n  50: optional i64 (js.type = \"Long\") initiatedEventId\n  60: optional i64 (js.type = \"Long\") startedEventId\n}\n\nstruct ChildWorkflowExecutionTimedOutEventAttributes {\n  10: optional TimeoutType timeoutType\n  20: optional string domain\n  30: optional WorkflowExecution workflowExecution\n  40: optional WorkflowType workflowType\n  50: optional i64 (js.type = \"Long\") initiatedEventId\n  60: optional i64 (js.type = \"Long\") startedEventId\n}\n\nstruct ChildWorkflowExecutionTerminatedEventAttributes {\n  10: optional string domain\n  20: optional WorkflowExecution workflowExecution\n  30: optional WorkflowType workflowType\n  40: optional i64 (js.type = \"Long\") initiatedEventId\n  50: optional i64 (js.type = \"Long\") startedEventId\n}\n\nstruct HistoryEvent {\n  10:  optional i64 (js.type = \"Long\") eventId\n  20:  optional i64 (js.type = \"Long\") timestamp\n  30:  optional EventType eventType\n  35:  optional i64 (js.type = \"Long\") version\n  36:  optional i64 (js.type = \"Long\") taskId\n  40:  optional WorkflowExecutionStartedEventAttributes workflowExecutionStartedEventAttributes\n  50:  optional WorkflowExecutionCompletedEventAttributes workflowExecutionCompletedEventAttributes\n  60:  optional WorkflowExecutionFailedEventAttributes workflowExecutionFailedEventAttributes\n  70:  optional WorkflowExecutionTimedOutEventAttributes workflowExecutionTimedOutEventAttributes\n  80:  optional DecisionTaskScheduledEventAttributes decisionTaskScheduledEventAttributes\n  90:  optional DecisionTaskStartedEventAttributes decisionTaskStartedEventAttributes\n  100: optional DecisionTaskCompletedEventAttributes decisionTaskCompletedEventAttributes\n  110: optional DecisionTaskTimedOutEventAttributes decisionTaskTimedOutEventAttributes\n  120: optional DecisionTaskFailedEventAttributes decisionTaskFailedEventAttributes\n  130: optional ActivityTaskScheduledEventAttributes activityTaskScheduledEventAttributes\n  140: optional ActivityTaskStartedEventAttributes activityTaskStartedEventAttributes\n  150: optional ActivityTaskCompletedEventAttributes activityTaskCompletedEventAttributes\n  160: optional ActivityTaskFailedEventAttributes activityTaskFailedEventAttributes\n  170: optional ActivityTaskTimedOutEventAttributes activityTaskTimedOutEventAttributes\n  180: optional TimerStartedEventAttributes timerStartedEventAttributes\n  190: optional TimerFiredEventAttributes timerFiredEventAttributes\n  200: optional ActivityTaskCancelRequestedEventAttributes activityTaskCancelRequestedEventAttributes\n  210: optional RequestCancelActivityTaskFailedEventAttributes requestCancelActivityTaskFailedEventAttributes\n  220: optional ActivityTaskCanceledEventAttributes activityTaskCanceledEventAttributes\n  230: optional TimerCanceledEventAttributes timerCanceledEventAttributes\n  240: optional CancelTimerFailedEventAttributes cancelTimerFailedEventAttributes\n  250: optional MarkerRecordedEventAttributes markerRecordedEventAttributes\n  260: optional WorkflowExecutionSignaledEventAttributes workflowExecutionSignaledEventAttributes\n  270: optional WorkflowExecutionTerminatedEventAttributes workflowExecutionTerminatedEventAttributes\n  280: optional WorkflowExecutionCancelRequestedEventAttributes workflowExecutionCancelRequestedEventAttributes\n  290: optional WorkflowExecutionCanceledEventAttributes workflowExecutionCanceledEventAttributes\n  300: optional RequestCancelExternalWorkflowExecutionInitiatedEventAttributes requestCancelExternalWorkflowExecutionInitiatedEventAttributes\n  310: optional RequestCancelExternalWorkflowExecutionFailedEventAttributes requestCancelExternalWorkflowExecutionFailedEventAttributes\n  320: optional ExternalWorkflowExecutionCancelRequestedEventAttributes externalWorkflowExecutionCancelRequestedEventAttributes\n  330: optional WorkflowExecutionContinuedAsNewEventAttributes workflowExecutionContinuedAsNewEventAttributes\n  340: optional StartChildWorkflowExecutionInitiatedEventAttributes startChildWorkflowExecutionInitiatedEventAttributes\n  350: optional StartChildWorkflowExecutionFailedEventAttributes startChildWorkflowExecutionFailedEventAttributes\n  360: optional ChildWorkflowExecutionStartedEventAttributes childWorkflowExecutionStartedEventAttributes\n  370: optional ChildWorkflowExecutionCompletedEventAttributes childWorkflowExecutionCompletedEventAttributes\n  380: optional ChildWorkflowExecutionFailedEventAttributes childWorkflowExecutionFailedEventAttributes\n  390: optional ChildWorkflowExecutionCanceledEventAttributes childWorkflowExecutionCanceledEventAttributes\n  400: optional ChildWorkflowExecutionTimedOutEventAttributes childWorkflowExecutionTimedOutEventAttributes\n  410: optional ChildWorkflowExecutionTerminatedEventAttributes childWorkflowExecutionTerminatedEventAttributes\n  420: optional SignalExternalWorkflowExecutionInitiatedEventAttributes signalExternalWorkflowExecutionInitiatedEventAttributes\n  430: optional SignalExternalWorkflowExecutionFailedEventAttributes signalExternalWorkflowExecutionFailedEventAttributes\n  440: optional ExternalWorkflowExecutionSignaledEventAttributes externalWorkflowExecutionSignaledEventAttributes\n  450: optional UpsertWorkflowSearchAttributesEventAttributes upsertWorkflowSearchAttributesEventAttributes\n}\n\nstruct History {\n  10: optional list<HistoryEvent> events\n}\n\nstruct WorkflowExecutionFilter {\n  10: optional string workflowId\n  20: optional string runId\n}\n\nstruct WorkflowTypeFilter {\n  10: optional string name\n}\n\nstruct StartTimeFilter {\n  10: optional i64 (js.type = \"Long\") earliestTime\n  20: optional i64 (js.type = \"Long\") latestTime\n}\n\nstruct DomainInfo {\n  10: optional string name\n  20: optional DomainStatus status\n  30: optional string description\n  40: optional string ownerEmail\n  // A key-value map for any customized purpose\n  50: optional map<string,string> data\n  60: optional string uuid\n}\n\nstruct DomainConfiguration {\n  10: optional i32 workflowExecutionRetentionPeriodInDays\n  20: optional bool emitMetric\n  60: optional IsolationGroupConfiguration isolationgroups\n  70: optional BadBinaries badBinaries\n  80: optional ArchivalStatus historyArchivalStatus\n  90: optional string historyArchivalURI\n  100: optional ArchivalStatus visibilityArchivalStatus\n  110: optional string visibilityArchivalURI\n  120: optional AsyncWorkflowConfiguration AsyncWorkflowConfiguration\n}\n\nstruct FailoverInfo {\n    10: optional i64 (js.type = \"Long\") failoverVersion\n    20: optional i64 (js.type = \"Long\") failoverStartTimestamp\n    30: optional i64 (js.type = \"Long\") failoverExpireTimestamp\n    40: optional i32 completedShardCount\n    50: optional list<i32> pendingShards\n}\n\nstruct BadBinaries{\n  10: optional map<string, BadBinaryInfo> binaries\n}\n\nstruct BadBinaryInfo{\n  10: optional string reason\n  20: optional string operator\n  30: optional i64 (js.type = \"Long\") createdTimeNano\n}\n\nstruct UpdateDomainInfo {\n  10: optional string description\n  20: optional string ownerEmail\n  // A key-value map for any customized purpose\n  30: optional map<string,string> data\n}\n\nstruct ClusterReplicationConfiguration {\n 10: optional string clusterName\n}\n\nstruct DomainReplicationConfiguration {\n // activeClusterName is the name of the active cluster for active-passive domain\n 10: optional string activeClusterName\n\n //  clusters is list of all active and passive clusters of domain\n 20: optional list<ClusterReplicationConfiguration> clusters\n\n // activeClusters contains active cluster(s) information for active-active domain\n 30: optional ActiveClusters activeClusters\n}\n\n// ClusterAttributeScope is a mapping of the cluster atribute to the scope's\n// current stae and failover version, indicating how recently the change was made\nstruct ClusterAttributeScope {\n  10: optional map<string, ActiveClusterInfo> clusterAttributes;\n}\n\n// activeClustersByClusterAttribute is a map of whatever subdivision of the domain chosen\n// to active cluster info for active-active domains. The key refers to the type of\n// cluster attribute and the value refers to its cluster mappings.\n//\n// For example, a request to update the domain for two locations\n//\n// UpdateDomainRequest{\n//    ReplicationConfiguration: {\n//       ActiveClusters: {\n//           ActiveClustersByClusterAttribute: {\n//             \"location\": ClusterAttributeScope{\n//                   \"Tokyo\": {ActiveClusterInfo: \"cluster0, FailoverVersion: 123},\n//                   \"Morocco\": {ActiveClusterInfo: \"cluster1\", FailoverVersion: 100},\n//             }\n//          }\n//       }\n//    }\n//  }\nstruct ActiveClusters {\n  10: optional map<string, ActiveClusterInfo> activeClustersByRegion // todo (david.porter) remove this as it's no longer used\n  11: optional map<string, ClusterAttributeScope> activeClustersByClusterAttribute\n}\n\n// ActiveClusterInfo contains the configuration of active-active domain's active\n// cluster & failover version for a specific region\nstruct ActiveClusterInfo {\n  10: optional string activeClusterName\n  20: optional i64 (js.type = \"Long\") failoverVersion\n}\n\nstruct RegisterDomainRequest {\n  10: optional string name\n  20: optional string description\n  30: optional string ownerEmail\n  40: optional i32 workflowExecutionRetentionPeriodInDays\n  50: optional bool emitMetric = true\n  60: optional list<ClusterReplicationConfiguration> clusters\n  70: optional string activeClusterName\n  // todo (david.porter) remove this field as it's not going to be used\n  75: optional map<string, string> activeClustersByRegion\n  // activeClusters is a map of cluster-attribute name to active cluster name for active-active domain\n  76: optional ActiveClusters activeClusters\n  // A key-value map for any customized purpose\n  80: optional map<string,string> data\n  90: optional string securityToken\n  120: optional bool isGlobalDomain\n  130: optional ArchivalStatus historyArchivalStatus\n  140: optional string historyArchivalURI\n  150: optional ArchivalStatus visibilityArchivalStatus\n  160: optional string visibilityArchivalURI\n}\n\nstruct ListDomainsRequest {\n  10: optional i32 pageSize\n  20: optional binary nextPageToken\n}\n\nstruct ListDomainsResponse {\n  10: optional list<DescribeDomainResponse> domains\n  20: optional binary nextPageToken\n}\n\nstruct DescribeDomainRequest {\n  10: optional string name\n  20: optional string uuid\n}\n\nstruct DescribeDomainResponse {\n  10: optional DomainInfo domainInfo\n  20: optional DomainConfiguration configuration\n  30: optional DomainReplicationConfiguration replicationConfiguration\n  40: optional i64 (js.type = \"Long\") failoverVersion\n  50: optional bool isGlobalDomain\n  60: optional FailoverInfo failoverInfo\n}\n\nstruct UpdateDomainRequest {\n 10: optional string name\n 20: optional UpdateDomainInfo updatedInfo\n 30: optional DomainConfiguration configuration\n 40: optional DomainReplicationConfiguration replicationConfiguration\n 50: optional string securityToken\n 60: optional string deleteBadBinary\n 70: optional i32 failoverTimeoutInSeconds\n}\n\nstruct UpdateDomainResponse {\n  10: optional DomainInfo domainInfo\n  20: optional DomainConfiguration configuration\n  30: optional DomainReplicationConfiguration replicationConfiguration\n  40: optional i64 (js.type = \"Long\") failoverVersion\n  50: optional bool isGlobalDomain\n}\n\nstruct FailoverDomainRequest {\n 10: optional string domainName\n 20: optional string domainActiveClusterName\n // only applicable to active-active domains where\n // specific cluster-attributes are being failed over\n 30: optional ActiveClusters activeClusters\n // user-requested addition \"reason\" variable created to increase transparency around failovers\n 40: optional string reason\n 50: optional i32 failoverTimeoutInSeconds\n}\n\nstruct FailoverDomainResponse {\n  10: optional DomainInfo domainInfo\n  20: optional DomainConfiguration configuration\n  30: optional DomainReplicationConfiguration replicationConfiguration\n  40: optional i64 (js.type = \"Long\") failoverVersion\n  50: optional bool isGlobalDomain\n}\n\nstruct DeprecateDomainRequest {\n 10: optional string name\n 20: optional string securityToken\n}\n\nstruct DeleteDomainRequest {\n 10: optional string name\n 20: optional string securityToken\n}\n\nstruct ListFailoverHistoryRequest {\n  // ListFailoverHistoryRequestFilters specifies the filters to apply to the request.\n  // If not provided all failover events will be returned.\n  10: optional ListFailoverHistoryRequestFilters filters\n  // PaginationOptions will be used to paginate the results.\n  // If not provided the first 5 events will be returned.\n  20: optional PaginationOptions pagination\n}\n\n// ListFailoverHistoryRequestFilters is used to filter the failover history.\n// It will be extended with additional filters (e.g ClusterAttributes) as the active-active feature is developed.\nstruct ListFailoverHistoryRequestFilters {\n  // domain_id is the id of the domain to list failover history for.\n  10: optional string domainID\n}\n\nstruct ListFailoverHistoryResponse {\n  10: optional list<FailoverEvent> failoverEvents\n  // next_page_token can be passed in a subsequent request to fetch the next set of events.\n  20: optional binary nextPageToken\n}\n\nstruct FailoverEvent {\n  // id of the failover event\n  // Can be passed with the created time to fetch a specific event.\n  10: optional string id\n  // created_time is the time the failover event was created.\n  // Can be passed with the ID to fetch a specific event.\n  20: optional i64 (js.type = \"Long\") createdTime\n  30: optional FailoverType failoverType\n  40: optional list<ClusterFailover> clusterFailovers\n}\n\nstruct ClusterFailover {\n  10: optional ActiveClusterInfo fromCluster\n  20: optional ActiveClusterInfo toCluster\n  // cluster_attribute is the scope and name for the attribute that was failed over.\n  // If the cluster_attribute is not defined this failover can be assumed to be the default ActiveCluster.\n  30: optional ClusterAttribute clusterAttribute\n}\n\nstruct StartWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional string workflowId\n  30: optional WorkflowType workflowType\n  40: optional TaskList taskList\n  50: optional binary input\n  60: optional i32 executionStartToCloseTimeoutSeconds\n  70: optional i32 taskStartToCloseTimeoutSeconds\n  80: optional string identity\n  90: optional string requestId\n  100: optional WorkflowIdReusePolicy workflowIdReusePolicy\n//  110: optional ChildPolicy childPolicy -- Removed but reserve the IDL order number\n  120: optional RetryPolicy retryPolicy\n  130: optional string cronSchedule\n  140: optional Memo memo\n  141: optional SearchAttributes searchAttributes\n  150: optional Header header\n  160: optional i32 delayStartSeconds\n  170: optional i32 jitterStartSeconds\n  180: optional i64 (js.type = \"Long\") firstRunAtTimestamp\n  190: optional CronOverlapPolicy cronOverlapPolicy\n  200: optional ActiveClusterSelectionPolicy activeClusterSelectionPolicy\n}\n\nstruct StartWorkflowExecutionResponse {\n  10: optional string runId\n}\n\nstruct StartWorkflowExecutionAsyncRequest {\n  10: optional StartWorkflowExecutionRequest request\n}\n\nstruct StartWorkflowExecutionAsyncResponse {\n}\n\nstruct RestartWorkflowExecutionResponse {\n  10: optional string runId\n}\n\nstruct DiagnoseWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional WorkflowExecution workflowExecution\n  30: optional string identity\n}\n\nstruct DiagnoseWorkflowExecutionResponse {\n  10: optional string domain\n  20: optional WorkflowExecution diagnosticWorkflowExecution\n}\n\nstruct PollForDecisionTaskRequest {\n  10: optional string domain\n  20: optional TaskList taskList\n  30: optional string identity\n  40: optional string binaryChecksum\n}\n\nstruct PollForDecisionTaskResponse {\n  10: optional binary taskToken\n  20: optional WorkflowExecution workflowExecution\n  30: optional WorkflowType workflowType\n  40: optional i64 (js.type = \"Long\") previousStartedEventId\n  50: optional i64 (js.type = \"Long\") startedEventId\n  51: optional i64 (js.type = 'Long') attempt\n  54: optional i64 (js.type = \"Long\") backlogCountHint\n  60: optional History history\n  70: optional binary nextPageToken\n  80: optional WorkflowQuery query\n  90: optional TaskList WorkflowExecutionTaskList\n  100: optional i64 (js.type = \"Long\") scheduledTimestamp\n  110: optional i64 (js.type = \"Long\") startedTimestamp\n  120: optional map<string, WorkflowQuery> queries\n  130: optional i64 (js.type = 'Long') nextEventId\n  140: optional i64 (js.type = 'Long') totalHistoryBytes\n  150: optional AutoConfigHint autoConfigHint\n}\n\nstruct StickyExecutionAttributes {\n  10: optional TaskList workerTaskList\n  20: optional i32 scheduleToStartTimeoutSeconds\n}\n\nstruct RespondDecisionTaskCompletedRequest {\n  10: optional binary taskToken\n  20: optional list<Decision> decisions\n  30: optional binary executionContext\n  40: optional string identity\n  50: optional StickyExecutionAttributes stickyAttributes\n  60: optional bool returnNewDecisionTask\n  70: optional bool forceCreateNewDecisionTask\n  80: optional string binaryChecksum\n  90: optional map<string, WorkflowQueryResult> queryResults\n}\n\nstruct RespondDecisionTaskCompletedResponse {\n  10: optional PollForDecisionTaskResponse decisionTask\n  20: optional map<string,ActivityLocalDispatchInfo> activitiesToDispatchLocally\n}\n\nstruct RespondDecisionTaskFailedRequest {\n  10: optional binary taskToken\n  20: optional DecisionTaskFailedCause cause\n  30: optional binary details\n  40: optional string identity\n  50: optional string binaryChecksum\n}\n\nstruct PollForActivityTaskRequest {\n  10: optional string domain\n  20: optional TaskList taskList\n  30: optional string identity\n  40: optional TaskListMetadata taskListMetadata\n}\n\nstruct PollForActivityTaskResponse {\n  10:  optional binary taskToken\n  20:  optional WorkflowExecution workflowExecution\n  30:  optional string activityId\n  40:  optional ActivityType activityType\n  50:  optional binary input\n  70:  optional i64 (js.type = \"Long\") scheduledTimestamp\n  80:  optional i32 scheduleToCloseTimeoutSeconds\n  90:  optional i64 (js.type = \"Long\") startedTimestamp\n  100: optional i32 startToCloseTimeoutSeconds\n  110: optional i32 heartbeatTimeoutSeconds\n  120: optional i32 attempt\n  130: optional i64 (js.type = \"Long\") scheduledTimestampOfThisAttempt\n  140: optional binary heartbeatDetails\n  150: optional WorkflowType workflowType\n  160: optional string workflowDomain\n  170: optional Header header\n  180: optional AutoConfigHint autoConfigHint\n}\n\nstruct RecordActivityTaskHeartbeatRequest {\n  10: optional binary taskToken\n  20: optional binary details\n  30: optional string identity\n}\n\nstruct RecordActivityTaskHeartbeatByIDRequest {\n  10: optional string domain\n  20: optional string workflowID\n  30: optional string runID\n  40: optional string activityID\n  50: optional binary details\n  60: optional string identity\n}\n\nstruct RecordActivityTaskHeartbeatResponse {\n  10: optional bool cancelRequested\n}\n\nstruct RespondActivityTaskCompletedRequest {\n  10: optional binary taskToken\n  20: optional binary result\n  30: optional string identity\n}\n\nstruct RespondActivityTaskFailedRequest {\n  10: optional binary taskToken\n  20: optional string reason\n  30: optional binary details\n  40: optional string identity\n}\n\nstruct RespondActivityTaskCanceledRequest {\n  10: optional binary taskToken\n  20: optional binary details\n  30: optional string identity\n}\n\nstruct RespondActivityTaskCompletedByIDRequest {\n  10: optional string domain\n  20: optional string workflowID\n  30: optional string runID\n  40: optional string activityID\n  50: optional binary result\n  60: optional string identity\n}\n\nstruct RespondActivityTaskFailedByIDRequest {\n  10: optional string domain\n  20: optional string workflowID\n  30: optional string runID\n  40: optional string activityID\n  50: optional string reason\n  60: optional binary details\n  70: optional string identity\n}\n\nstruct RespondActivityTaskCanceledByIDRequest {\n  10: optional string domain\n  20: optional string workflowID\n  30: optional string runID\n  40: optional string activityID\n  50: optional binary details\n  60: optional string identity\n}\n\nstruct RequestCancelWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional WorkflowExecution workflowExecution\n  30: optional string identity\n  40: optional string requestId\n  50: optional string cause\n  60: optional string firstExecutionRunID\n}\n\nstruct GetWorkflowExecutionHistoryRequest {\n  10: optional string domain\n  20: optional WorkflowExecution execution\n  30: optional i32 maximumPageSize\n  40: optional binary nextPageToken\n  50: optional bool waitForNewEvent\n  60: optional HistoryEventFilterType HistoryEventFilterType\n  70: optional bool skipArchival\n  80: optional QueryConsistencyLevel queryConsistencyLevel\n}\n\nstruct GetWorkflowExecutionHistoryResponse {\n  10: optional History history\n  11: optional list<DataBlob> rawHistory\n  20: optional binary nextPageToken\n  30: optional bool archived\n}\n\nstruct SignalWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional WorkflowExecution workflowExecution\n  30: optional string signalName\n  40: optional binary input\n  50: optional string identity\n  60: optional string requestId\n  70: optional binary control\n}\n\nstruct SignalWithStartWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional string workflowId\n  30: optional WorkflowType workflowType\n  40: optional TaskList taskList\n  50: optional binary input\n  60: optional i32 executionStartToCloseTimeoutSeconds\n  70: optional i32 taskStartToCloseTimeoutSeconds\n  80: optional string identity\n  90: optional string requestId\n  100: optional WorkflowIdReusePolicy workflowIdReusePolicy\n  110: optional string signalName\n  120: optional binary signalInput\n  130: optional binary control\n  140: optional RetryPolicy retryPolicy\n  150: optional string cronSchedule\n  160: optional Memo memo\n  161: optional SearchAttributes searchAttributes\n  170: optional Header header\n  180: optional i32 delayStartSeconds\n  190: optional i32 jitterStartSeconds\n  200: optional i64 (js.type = \"Long\") firstRunAtTimestamp\n  210: optional CronOverlapPolicy cronOverlapPolicy\n  220: optional ActiveClusterSelectionPolicy activeClusterSelectionPolicy\n}\n\nstruct SignalWithStartWorkflowExecutionAsyncRequest {\n  10: optional SignalWithStartWorkflowExecutionRequest request\n}\n\nstruct SignalWithStartWorkflowExecutionAsyncResponse {\n}\n\nstruct RestartWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional WorkflowExecution workflowExecution\n  30: optional string reason\n  40: optional string identity\n}\nstruct TerminateWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional WorkflowExecution workflowExecution\n  30: optional string reason\n  40: optional binary details\n  50: optional string identity\n  60: optional string firstExecutionRunID\n}\n\nstruct ResetWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional WorkflowExecution workflowExecution\n  30: optional string reason\n  40: optional i64 (js.type = \"Long\") decisionFinishEventId\n  50: optional string requestId\n  60: optional bool skipSignalReapply\n}\n\nstruct ResetWorkflowExecutionResponse {\n  10: optional string runId\n}\n\nstruct ListOpenWorkflowExecutionsRequest {\n  10: optional string domain\n  20: optional i32 maximumPageSize\n  30: optional binary nextPageToken\n  40: optional StartTimeFilter StartTimeFilter\n  50: optional WorkflowExecutionFilter executionFilter\n  60: optional WorkflowTypeFilter typeFilter\n}\n\nstruct ListOpenWorkflowExecutionsResponse {\n  10: optional list<WorkflowExecutionInfo> executions\n  20: optional binary nextPageToken\n}\n\nstruct ListClosedWorkflowExecutionsRequest {\n  10: optional string domain\n  20: optional i32 maximumPageSize\n  30: optional binary nextPageToken\n  40: optional StartTimeFilter StartTimeFilter\n  50: optional WorkflowExecutionFilter executionFilter\n  60: optional WorkflowTypeFilter typeFilter\n  70: optional WorkflowExecutionCloseStatus statusFilter\n}\n\nstruct ListClosedWorkflowExecutionsResponse {\n  10: optional list<WorkflowExecutionInfo> executions\n  20: optional binary nextPageToken\n}\n\nstruct ListWorkflowExecutionsRequest {\n  10: optional string domain\n  20: optional i32 pageSize\n  30: optional binary nextPageToken\n  40: optional string query\n}\n\nstruct ListWorkflowExecutionsResponse {\n  10: optional list<WorkflowExecutionInfo> executions\n  20: optional binary nextPageToken\n}\n\nstruct ListArchivedWorkflowExecutionsRequest {\n  10: optional string domain\n  20: optional i32 pageSize\n  30: optional binary nextPageToken\n  40: optional string query\n}\n\nstruct ListArchivedWorkflowExecutionsResponse {\n  10: optional list<WorkflowExecutionInfo> executions\n  20: optional binary nextPageToken\n}\n\nstruct CountWorkflowExecutionsRequest {\n  10: optional string domain\n  20: optional string query\n}\n\nstruct CountWorkflowExecutionsResponse {\n  10: optional i64 count\n}\n\nstruct GetSearchAttributesResponse {\n  10: optional map<string, IndexedValueType> keys\n}\n\nstruct QueryWorkflowRequest {\n  10: optional string domain\n  20: optional WorkflowExecution execution\n  30: optional WorkflowQuery query\n  // QueryRejectCondition can used to reject the query if workflow state does not satisify condition\n  40: optional QueryRejectCondition queryRejectCondition\n  50: optional QueryConsistencyLevel queryConsistencyLevel\n}\n\nstruct QueryRejected {\n  10: optional WorkflowExecutionCloseStatus closeStatus\n}\n\nstruct QueryWorkflowResponse {\n  10: optional binary queryResult\n  20: optional QueryRejected queryRejected\n}\n\nstruct WorkflowQuery {\n  10: optional string queryType\n  20: optional binary queryArgs\n}\n\nstruct ResetStickyTaskListRequest {\n  10: optional string domain\n  20: optional WorkflowExecution execution\n}\n\nstruct ResetStickyTaskListResponse {\n    // The reason to keep this response is to allow returning\n    // information in the future.\n}\n\nstruct RespondQueryTaskCompletedRequest {\n  10: optional binary taskToken\n  20: optional QueryTaskCompletedType completedType\n  30: optional binary queryResult\n  40: optional string errorMessage\n  50: optional WorkerVersionInfo workerVersionInfo\n}\n\nstruct WorkflowQueryResult {\n  10: optional QueryResultType resultType\n  20: optional binary answer\n  30: optional string errorMessage\n}\n\nstruct DescribeWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional WorkflowExecution execution\n  30: optional QueryConsistencyLevel queryConsistencyLevel\n}\n\nstruct PendingActivityInfo {\n  10: optional string activityID\n  20: optional ActivityType activityType\n  30: optional PendingActivityState state\n  40: optional binary heartbeatDetails\n  50: optional i64 (js.type = \"Long\") lastHeartbeatTimestamp\n  60: optional i64 (js.type = \"Long\") lastStartedTimestamp\n  70: optional i32 attempt\n  80: optional i32 maximumAttempts\n  90: optional i64 (js.type = \"Long\") scheduledTimestamp\n  100: optional i64 (js.type = \"Long\") expirationTimestamp\n  110: optional string lastFailureReason\n  120: optional string lastWorkerIdentity\n  130: optional binary lastFailureDetails\n  140: optional string startedWorkerIdentity\n  150: optional i64 (js.type = \"Long\") scheduleID\n}\n\nstruct PendingDecisionInfo {\n  10: optional PendingDecisionState state\n  20: optional i64 (js.type = \"Long\") scheduledTimestamp\n  30: optional i64 (js.type = \"Long\") startedTimestamp\n  40: optional i64 attempt\n  50: optional i64 (js.type = \"Long\") originalScheduledTimestamp\n  60: optional i64 (js.type = \"Long\") scheduleID\n}\n\nstruct PendingChildExecutionInfo {\n  1: optional string domain\n  10: optional string workflowID\n  20: optional string runID\n  30: optional string workflowTypName\n  40: optional i64 (js.type = \"Long\") initiatedID\n  50: optional ParentClosePolicy parentClosePolicy\n}\n\nstruct DescribeWorkflowExecutionResponse {\n  10: optional WorkflowExecutionConfiguration executionConfiguration\n  20: optional WorkflowExecutionInfo workflowExecutionInfo\n  30: optional list<PendingActivityInfo> pendingActivities\n  40: optional list<PendingChildExecutionInfo> pendingChildren\n  50: optional PendingDecisionInfo pendingDecision\n}\n\nstruct DescribeTaskListRequest {\n  10: optional string domain\n  20: optional TaskList taskList\n  30: optional TaskListType taskListType\n  40: optional bool includeTaskListStatus\n}\n\nstruct DescribeTaskListResponse {\n  10: optional list<PollerInfo> pollers\n  20: optional TaskListStatus taskListStatus\n  // The TaskList being described\n  30: optional TaskList taskList\n}\n\nstruct GetTaskListsByDomainRequest {\n  10: optional string domainName\n}\n\nstruct GetTaskListsByDomainResponse {\n  10: optional map<string,DescribeTaskListResponse> decisionTaskListMap\n  20: optional map<string,DescribeTaskListResponse> activityTaskListMap\n}\n\nstruct ListTaskListPartitionsRequest {\n  10: optional string domain\n  20: optional TaskList taskList\n}\n\nstruct TaskListPartitionMetadata {\n  10: optional string key\n  20: optional string ownerHostName\n}\n\nstruct ListTaskListPartitionsResponse {\n  10: optional list<TaskListPartitionMetadata> activityTaskListPartitions\n  20: optional list<TaskListPartitionMetadata> decisionTaskListPartitions\n}\n\nstruct IsolationGroupMetrics {\n  10: optional double newTasksPerSecond\n  20: optional i64 (js.type = \"Long\") pollerCount\n}\n\nstruct TaskListStatus {\n  10: optional i64 (js.type = \"Long\") backlogCountHint\n  20: optional i64 (js.type = \"Long\") readLevel\n  30: optional i64 (js.type = \"Long\") ackLevel\n  35: optional double ratePerSecond\n  40: optional TaskIDBlock taskIDBlock\n  50: optional map<string, IsolationGroupMetrics> isolationGroupMetrics\n  60: optional double newTasksPerSecond\n  70: optional bool empty\n}\n\nstruct TaskIDBlock {\n  10: optional i64 (js.type = \"Long\")  startID\n  20: optional i64 (js.type = \"Long\")  endID\n}\n\n//At least one of the parameters needs to be provided\nstruct DescribeHistoryHostRequest {\n  10: optional string               hostAddress //ip:port\n  20: optional i32                  shardIdForHost\n  30: optional WorkflowExecution    executionForHost\n}\n\nstruct RemoveTaskRequest {\n  10: optional i32                      shardID\n  20: optional i32                      type\n  30: optional i64 (js.type = \"Long\")   taskID\n  40: optional i64 (js.type = \"Long\")   visibilityTimestamp\n  50: optional string                   clusterName\n}\n\nstruct CloseShardRequest {\n  10: optional i32               shardID\n}\n\nstruct ResetQueueRequest {\n  10: optional i32    shardID\n  20: optional string clusterName\n  30: optional i32    type\n}\n\nstruct DescribeQueueRequest {\n  10: optional i32    shardID\n  20: optional string clusterName\n  30: optional i32    type\n}\n\nstruct DescribeQueueResponse {\n  10: optional list<string> processingQueueStates\n}\n\nstruct DescribeShardDistributionRequest {\n  10: optional i32 pageSize\n  20: optional i32 pageID\n}\n\nstruct DescribeShardDistributionResponse {\n  10: optional i32              numberOfShards\n\n  // ShardID to Address (ip:port) map\n  20: optional map<i32, string> shards\n}\n\nstruct DescribeHistoryHostResponse{\n  10: optional i32                  numberOfShards\n  20: optional list<i32>            shardIDs\n  30: optional DomainCacheInfo      domainCache\n  40: optional string               shardControllerStatus\n  50: optional string               address\n}\n\nstruct DomainCacheInfo{\n  10: optional i64 numOfItemsInCacheByID\n  20: optional i64 numOfItemsInCacheByName\n}\n\nenum TaskListType {\n  /*\n   * Decision type of tasklist\n   */\n  Decision,\n  /*\n   * Activity type of tasklist\n   */\n  Activity,\n}\n\nstruct PollerInfo {\n  // Unix Nano\n  10: optional i64 (js.type = \"Long\")  lastAccessTime\n  20: optional string identity\n  30: optional double ratePerSecond\n}\n\nstruct RetryPolicy {\n  // Interval of the first retry. If coefficient is 1.0 then it is used for all retries.\n  10: optional i32 initialIntervalInSeconds\n\n  // Coefficient used to calculate the next retry interval.\n  // The next retry interval is previous interval multiplied by the coefficient.\n  // Must be 1 or larger.\n  20: optional double backoffCoefficient\n\n  // Maximum interval between retries. Exponential backoff leads to interval increase.\n  // This value is the cap of the increase. Default is 100x of initial interval.\n  30: optional i32 maximumIntervalInSeconds\n\n  // Maximum number of attempts. When exceeded the retries stop even if not expired yet.\n  // Must be 1 or bigger. Default is unlimited.\n  40: optional i32 maximumAttempts\n\n  // Non-Retriable errors. Will stop retrying if error matches this list.\n  50: optional list<string> nonRetriableErrorReasons\n\n  // Expiration time for the whole retry process.\n  60: optional i32 expirationIntervalInSeconds\n}\n\n// HistoryBranchRange represents a piece of range for a branch.\nstruct HistoryBranchRange{\n  // branchID of original branch forked from\n  10: optional string branchID\n  // beinning node for the range, inclusive\n  20: optional i64 beginNodeID\n  // ending node for the range, exclusive\n  30: optional i64 endNodeID\n}\n\n// For history persistence to serialize/deserialize branch details\nstruct HistoryBranch{\n  10: optional string treeID\n  20: optional string branchID\n  30: optional list<HistoryBranchRange> ancestors\n}\n\n// VersionHistoryItem contains signal eventID and the corresponding version\nstruct VersionHistoryItem{\n  10: optional i64 (js.type = \"Long\") eventID\n  20: optional i64 (js.type = \"Long\") version\n}\n\n// VersionHistory contains the version history of a branch\nstruct VersionHistory{\n  10: optional binary branchToken\n  20: optional list<VersionHistoryItem> items\n}\n\n// VersionHistories contains all version histories from all branches\nstruct VersionHistories{\n  10: optional i32 currentVersionHistoryIndex\n  20: optional list<VersionHistory> histories\n}\n\n// ReapplyEventsRequest is the request for reapply events API\nstruct ReapplyEventsRequest{\n  10: optional string domainName\n  20: optional WorkflowExecution workflowExecution\n  30: optional DataBlob events\n}\n\n// SupportedClientVersions contains the support versions for client library\nstruct SupportedClientVersions{\n  10: optional string goSdk\n  20: optional string javaSdk\n}\n\n// ClusterInfo contains information about cadence cluster\nstruct ClusterInfo{\n  10: optional SupportedClientVersions supportedClientVersions\n}\n\nstruct RefreshWorkflowTasksRequest {\n  10: optional string domain\n  20: optional WorkflowExecution execution\n}\n\n// DEPRECATED: use proto definition instead\nstruct FeatureFlags {\n  10: optional bool WorkflowExecutionAlreadyCompletedErrorEnabled\n  20: optional bool AutoForwardingEnabled\n}\n\nenum CrossClusterTaskType {\n  StartChildExecution\n  CancelExecution\n  SignalExecution\n  RecordChildWorkflowExecutionComplete\n  ApplyParentClosePolicy\n}\n\nenum CrossClusterTaskFailedCause {\n  DOMAIN_NOT_ACTIVE\n  DOMAIN_NOT_EXISTS\n  WORKFLOW_ALREADY_RUNNING\n  WORKFLOW_NOT_EXISTS\n  WORKFLOW_ALREADY_COMPLETED\n  UNCATEGORIZED\n}\n\nenum GetTaskFailedCause {\n  SERVICE_BUSY\n  TIMEOUT\n  SHARD_OWNERSHIP_LOST\n  UNCATEGORIZED\n}\n\nstruct CrossClusterTaskInfo {\n  10: optional string domainID\n  20: optional string workflowID\n  30: optional string runID\n  40: optional CrossClusterTaskType taskType\n  50: optional i16 taskState\n  60: optional i64 (js.type = \"Long\") taskID\n  70: optional i64 (js.type = \"Long\") visibilityTimestamp\n}\n\nstruct CrossClusterStartChildExecutionRequestAttributes {\n  10: optional string targetDomainID\n  20: optional string requestID\n  30: optional i64 (js.type = \"Long\") initiatedEventID\n  40: optional StartChildWorkflowExecutionInitiatedEventAttributes initiatedEventAttributes\n  // targetRunID is for scheduling first decision task\n  // targetWorkflowID is available in initiatedEventAttributes\n  50: optional string targetRunID\n  60: optional map<string, string> partitionConfig\n}\n\nstruct CrossClusterStartChildExecutionResponseAttributes {\n  10: optional string runID\n}\n\nstruct CrossClusterCancelExecutionRequestAttributes {\n  10: optional string targetDomainID\n  20: optional string targetWorkflowID\n  30: optional string targetRunID\n  40: optional string requestID\n  50: optional i64 (js.type = \"Long\") initiatedEventID\n  60: optional bool childWorkflowOnly\n}\n\nstruct CrossClusterCancelExecutionResponseAttributes {\n}\n\nstruct CrossClusterSignalExecutionRequestAttributes {\n  10: optional string targetDomainID\n  20: optional string targetWorkflowID\n  30: optional string targetRunID\n  40: optional string requestID\n  50: optional i64 (js.type = \"Long\") initiatedEventID\n  60: optional bool childWorkflowOnly\n  70: optional string signalName\n  80: optional binary signalInput\n  90: optional binary control\n}\n\nstruct CrossClusterSignalExecutionResponseAttributes {\n}\n\nstruct CrossClusterRecordChildWorkflowExecutionCompleteRequestAttributes {\n  10: optional string targetDomainID\n  20: optional string targetWorkflowID\n  30: optional string targetRunID\n  40: optional i64 (js.type = \"Long\") initiatedEventID\n  50: optional HistoryEvent completionEvent\n}\n\nstruct CrossClusterRecordChildWorkflowExecutionCompleteResponseAttributes {\n}\n\nstruct ApplyParentClosePolicyAttributes {\n  10: optional string childDomainID\n  20: optional string childWorkflowID\n  30: optional string childRunID\n  40: optional ParentClosePolicy parentClosePolicy\n}\n\nstruct ApplyParentClosePolicyStatus {\n  10: optional bool completed\n  20: optional CrossClusterTaskFailedCause failedCause\n}\n\nstruct ApplyParentClosePolicyRequest {\n  10: optional ApplyParentClosePolicyAttributes child\n  20: optional ApplyParentClosePolicyStatus status\n}\n\nstruct CrossClusterApplyParentClosePolicyRequestAttributes {\n  10: optional list<ApplyParentClosePolicyRequest> children\n}\n\nstruct ApplyParentClosePolicyResult {\n  10: optional ApplyParentClosePolicyAttributes child\n  20: optional CrossClusterTaskFailedCause failedCause\n}\n\nstruct CrossClusterApplyParentClosePolicyResponseAttributes {\n  10: optional list<ApplyParentClosePolicyResult> childrenStatus\n}\n\nstruct CrossClusterTaskRequest {\n  10: optional CrossClusterTaskInfo taskInfo\n  20: optional CrossClusterStartChildExecutionRequestAttributes startChildExecutionAttributes\n  30: optional CrossClusterCancelExecutionRequestAttributes cancelExecutionAttributes\n  40: optional CrossClusterSignalExecutionRequestAttributes signalExecutionAttributes\n  50: optional CrossClusterRecordChildWorkflowExecutionCompleteRequestAttributes recordChildWorkflowExecutionCompleteAttributes\n  60: optional CrossClusterApplyParentClosePolicyRequestAttributes applyParentClosePolicyAttributes\n}\n\nstruct CrossClusterTaskResponse {\n  10: optional i64 (js.type = \"Long\") taskID\n  20: optional CrossClusterTaskType taskType\n  30: optional i16 taskState\n  40: optional CrossClusterTaskFailedCause failedCause\n  50: optional CrossClusterStartChildExecutionResponseAttributes startChildExecutionAttributes\n  60: optional CrossClusterCancelExecutionResponseAttributes cancelExecutionAttributes\n  70: optional CrossClusterSignalExecutionResponseAttributes signalExecutionAttributes\n  80: optional CrossClusterRecordChildWorkflowExecutionCompleteResponseAttributes recordChildWorkflowExecutionCompleteAttributes\n  90: optional CrossClusterApplyParentClosePolicyResponseAttributes applyParentClosePolicyAttributes\n}\n\nstruct GetCrossClusterTasksRequest {\n  10: optional list<i32> shardIDs\n  20: optional string targetCluster\n}\n\nstruct GetCrossClusterTasksResponse {\n  10: optional map<i32, list<CrossClusterTaskRequest>> tasksByShard\n  20: optional map<i32, GetTaskFailedCause> failedCauseByShard\n}\n\nstruct RespondCrossClusterTasksCompletedRequest {\n  10: optional i32 shardID\n  20: optional string targetCluster\n  30: optional list<CrossClusterTaskResponse> taskResponses\n  40: optional bool fetchNewTasks\n}\n\nstruct RespondCrossClusterTasksCompletedResponse {\n  10: optional list<CrossClusterTaskRequest> tasks\n}\n\nenum IsolationGroupState {\n  INVALID,\n  HEALTHY,\n  DRAINED,\n}\n\nstruct IsolationGroupPartition {\n  10: optional string name\n  20: optional IsolationGroupState state\n}\n\nstruct IsolationGroupConfiguration {\n  10: optional list<IsolationGroupPartition> isolationGroups\n}\n\nstruct AsyncWorkflowConfiguration {\n  10: optional bool enabled\n  // PredefinedQueueName is the name of the predefined queue in cadence server config's asyncWorkflowQueues\n  20: optional string predefinedQueueName\n  // queueType is the type of the queue if predefined_queue_name is not used\n  30: optional string queueType\n  // queueConfig is the configuration for the queue if predefined_queue_name is not used\n  40: optional DataBlob queueConfig\n}\n\n/**\n* Any is a logical duplicate of google.protobuf.Any.\n*\n* The intent of the type is the same, but it is not intended to be directly\n* compatible with google.protobuf.Any or any Thrift equivalent - this blob is\n* RPC-type agnostic by design (as the underlying data may be transported over\n* proto or thrift), and the data-bytes may be in any encoding.\n*\n* This is intentionally different from DataBlob, which supports only a handful\n* of known encodings so it can be interpreted everywhere.  Any supports literally\n* any contents, and needs to be considered opaque until it is given to something\n* that is expecting it.\n*\n* See ValueType to interpret the contents.\n**/\nstruct Any {\n  // Type-string describing value's contents, and intentionally avoiding the\n  // name \"type\" as it is often a special term.\n  // This should usually be a hard-coded string of some kind.\n  10: optional string ValueType\n  // Arbitrarily-encoded bytes, to be deserialized by a runtime implementation.\n  // The contents are described by ValueType.\n  20: optional binary Value\n}\n\nstruct AutoConfigHint {\n  10: optional bool enableAutoConfig\n  20: optional i64 pollerWaitTimeInMs\n}\n\nstruct QueueState {\n  10: optional map<i64, VirtualQueueState> virtualQueueStates\n  20: optional TaskKey exclusiveMaxReadLevel\n}\n\nstruct VirtualQueueState {\n  10: optional list<VirtualSliceState> virtualSliceStates\n}\n\nstruct VirtualSliceState {\n  10: optional TaskRange taskRange\n  20: optional Predicate predicate\n}\n\nstruct TaskRange {\n  10: optional TaskKey inclusiveMin\n  20: optional TaskKey exclusiveMax\n}\n\nstruct TaskKey {\n  10: optional i64 scheduledTimeNano\n  20: optional i64 taskID\n}\n\n// ActiveClusterSelectionPolicy is for active-active domains, it serves as a means to select\n// the active cluster, by specifying the attribute by which to divide the workflows\n// in that domain.\nstruct ActiveClusterSelectionPolicy {\n  1: optional ClusterAttribute clusterAttribute\n}\n\n// ClusterAttribute is used for subdividing workflows in a domain into their active\n// and passive clusters. Examples of this might be 'region' and 'cluster1' as\n// respective region and scope fields.\n//\n// for example, a workflow may specify this in it's start request:\n//\n//   StartWorkflowRequest{\n//     ActiveClusterSelectionPolicy: {\n//       ClusterAttribute: {\n//            Scope: \"cityID\",\n//            Name: \"Lisbon\"\n//        }\n//     }\n//   }\n//\n// and this means that this workflow will be associate with the domain's cluster attribute 'Lisbon',\n// be active in the cluster that has Lisbon active and\n// failover when that cluster-attribute is set to failover.\nstruct ClusterAttribute {\n  1: optional string scope\n  2: optional string name\n}\n\n// FailoverType describes how a failover operation will be performed.\nenum FailoverType {\n  INVALID\n  FORCE\n  GRACEFUL\n}\n\n// PaginationOptions provides common options for paginated RPCs.\nstruct PaginationOptions {\n  // page_size configures the number of results to be returned as part of each page\n  10: optional i32 pageSize\n  // next_page_token should be provided from a previous response to fetch the next page.\n  // if empty, the first page will be returned.\n  20: optional binary nextPageToken\n}\n\nenum PredicateType {\n  Universal,\n  Empty,\n  DomainID,\n}\n\nstruct UniversalPredicateAttributes {}\n\nstruct EmptyPredicateAttributes {}\n\nstruct DomainIDPredicateAttributes {\n  10: optional list<string> domainIDs\n  20: optional bool isExclusive\n}\n\nstruct Predicate {\n  10: optional PredicateType predicateType\n  20: optional UniversalPredicateAttributes universalPredicateAttributes\n  30: optional EmptyPredicateAttributes emptyPredicateAttributes\n  40: optional DomainIDPredicateAttributes domainIDPredicateAttributes\n}\n\n// ── Schedule API ──────────────────────────────────────────────────────────────\n\n// ScheduleOverlapPolicy defines behavior when a new run is triggered while a previous run is still active.\nenum ScheduleOverlapPolicy {\n  INVALID\n  SKIP_NEW\n  BUFFER\n  CONCURRENT\n  CANCEL_PREVIOUS\n  TERMINATE_PREVIOUS\n}\n\n// ScheduleCatchUpPolicy defines how missed runs are handled when a schedule resumes.\nenum ScheduleCatchUpPolicy {\n  INVALID\n  SKIP\n  ONE\n  ALL\n}\n\n// ScheduleSpec defines when a schedule triggers.\nstruct ScheduleSpec {\n  // Standard cron expression (e.g., \"0 6 * * *\").\n  // Prefix with CRON_TZ to set timezone (e.g., \"CRON_TZ=America/Los_Angeles 0 6 * * *\").\n  10: optional string cronExpression\n  // Earliest time the schedule may trigger. If not set, starts immediately.\n  20: optional i64 (js.type = \"Long\") startTimeNano\n  // Latest time the schedule may trigger. If not set, runs indefinitely.\n  30: optional i64 (js.type = \"Long\") endTimeNano\n  // Random jitter applied to each trigger time to spread load.\n  // Thrift duration convention: whole seconds only (proto uses nanosecond-precision Duration).\n  // Sub-second jitter from proto is truncated to the nearest second.\n  40: optional i32 jitterInSeconds\n}\n\n// ScheduleStartWorkflowAction describes the workflow to start when the schedule triggers.\nstruct ScheduleStartWorkflowAction {\n  10: optional WorkflowType workflowType\n  20: optional TaskList taskList\n  30: optional binary input\n  40: optional string workflowIdPrefix\n  50: optional i32 executionStartToCloseTimeoutSeconds\n  60: optional i32 taskStartToCloseTimeoutSeconds\n  70: optional RetryPolicy retryPolicy\n  80: optional Memo memo\n  90: optional SearchAttributes searchAttributes\n}\n\n// ScheduleAction defines what the schedule does when it triggers.\n// Exactly one field must be set.\nstruct ScheduleAction {\n  10: optional ScheduleStartWorkflowAction startWorkflow\n}\n\n// SchedulePolicies controls the runtime behavior of a schedule.\nstruct SchedulePolicies {\n  10: optional ScheduleOverlapPolicy overlapPolicy\n  20: optional ScheduleCatchUpPolicy catchUpPolicy\n  // Maximum time to look back for missed runs on resume. Runs older than this window are skipped.\n  // Thrift duration convention: whole seconds only (proto uses nanosecond-precision Duration).\n  // Sub-second windows from proto are truncated to the nearest second.\n  30: optional i32 catchUpWindowInSeconds\n  // If true, pause the schedule when a triggered workflow fails.\n  40: optional bool pauseOnFailure\n  // Maximum number of buffered runs. 0 means unlimited. Only used with BUFFER overlap policy.\n  50: optional i32 bufferLimit\n  // Maximum number of concurrent runs. 0 means unlimited. Only used with CONCURRENT overlap policy.\n  60: optional i32 concurrencyLimit\n}\n\n// SchedulePauseInfo records when and why a schedule was paused.\nstruct SchedulePauseInfo {\n  10: optional string reason\n  20: optional i64 (js.type = \"Long\") pausedTimeNano\n  30: optional string pausedBy\n}\n\n// ScheduleState is the runtime pause/unpause state of a schedule.\nstruct ScheduleState {\n  10: optional bool paused\n  20: optional SchedulePauseInfo pauseInfo\n}\n\n// BackfillInfo tracks the progress of an active or completed backfill operation.\nstruct BackfillInfo {\n  10: optional string backfillId\n  20: optional i64 (js.type = \"Long\") startTimeNano\n  30: optional i64 (js.type = \"Long\") endTimeNano\n  40: optional i32 runsCompleted\n  50: optional i32 runsTotal\n}\n\n// ScheduleInfo contains runtime statistics for a schedule.\nstruct ScheduleInfo {\n  10: optional i64 (js.type = \"Long\") lastRunTimeNano\n  20: optional i64 (js.type = \"Long\") nextRunTimeNano\n  // Total number of workflows started by this schedule.\n  30: optional i64 (js.type = \"Long\") totalRuns\n  40: optional i64 (js.type = \"Long\") createTimeNano\n  50: optional i64 (js.type = \"Long\") lastUpdateTimeNano\n  // Currently active backfill operations. Removed when complete.\n  60: optional list<BackfillInfo> ongoingBackfills\n  // Number of runs that were missed (e.g. due to downtime) and then skipped by catch-up policy.\n  70: optional i64 (js.type = \"Long\") missedRuns\n  // Number of runs that were skipped due to the overlap policy (e.g. SkipNew).\n  80: optional i64 (js.type = \"Long\") skippedRuns\n}\n\n// ScheduleListEntry is a summary of a schedule returned by ListSchedules.\nstruct ScheduleListEntry {\n  10: optional string scheduleId\n  20: optional WorkflowType workflowType\n  30: optional ScheduleState state\n  40: optional string cronExpression\n}\n\nstruct CreateScheduleRequest {\n  10: optional string domain\n  20: optional string scheduleId\n  30: optional ScheduleSpec spec\n  40: optional ScheduleAction action\n  50: optional SchedulePolicies policies\n  60: optional Memo memo\n  70: optional SearchAttributes searchAttributes\n}\n\nstruct CreateScheduleResponse {\n  10: optional string scheduleId\n}\n\nstruct DescribeScheduleRequest {\n  10: optional string domain\n  20: optional string scheduleId\n}\n\nstruct DescribeScheduleResponse {\n  10: optional ScheduleSpec spec\n  20: optional ScheduleAction action\n  30: optional SchedulePolicies policies\n  40: optional ScheduleState state\n  50: optional ScheduleInfo info\n  60: optional Memo memo\n  70: optional SearchAttributes searchAttributes\n}\n\nstruct ListSchedulesRequest {\n  10: optional string domain\n  20: optional i32 pageSize\n  30: optional binary nextPageToken\n}\n\nstruct ListSchedulesResponse {\n  10: optional list<ScheduleListEntry> schedules\n  20: optional binary nextPageToken\n}\n\nstruct DeleteScheduleRequest {\n  10: optional string domain\n  20: optional string scheduleId\n}\n\nstruct DeleteScheduleResponse {}\n\nstruct PauseScheduleRequest {\n  10: optional string domain\n  20: optional string scheduleId\n  30: optional string reason\n  40: optional string identity\n}\n\nstruct PauseScheduleResponse {}\n\nstruct UnpauseScheduleRequest {\n  10: optional string domain\n  20: optional string scheduleId\n  30: optional string reason\n  // Override the schedule's catch-up policy for this unpause only.\n  // If not set, uses the catch_up_policy from SchedulePolicies.\n  40: optional ScheduleCatchUpPolicy catchUpPolicy\n}\n\nstruct UnpauseScheduleResponse {}\n\nstruct BackfillScheduleRequest {\n  10: optional string domain\n  20: optional string scheduleId\n  30: optional i64 (js.type = \"Long\") startTimeNano\n  40: optional i64 (js.type = \"Long\") endTimeNano\n  50: optional ScheduleOverlapPolicy overlapPolicy\n  // Client-provided identifier for idempotency and progress tracking.\n  // If not set, the server generates a UUID. Retries with the same backfillId are deduplicated.\n  60: optional string backfillId\n}\n\nstruct BackfillScheduleResponse {}\n\nstruct UpdateScheduleRequest {\n  10: optional string domain\n  20: optional string scheduleId\n  30: optional ScheduleSpec spec\n  40: optional ScheduleAction action\n  50: optional SchedulePolicies policies\n  60: optional SearchAttributes searchAttributes\n}\n\nstruct UpdateScheduleResponse {}\n"
+const rawIDL = "// Copyright (c) 2017 Uber Technologies, Inc.\n//\n// Permission is hereby granted, free of charge, to any person obtaining a copy\n// of this software and associated documentation files (the \"Software\"), to deal\n// in the Software without restriction, including without limitation the rights\n// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n// copies of the Software, and to permit persons to whom the Software is\n// furnished to do so, subject to the following conditions:\n//\n// The above copyright notice and this permission notice shall be included in\n// all copies or substantial portions of the Software.\n//\n// THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\n// THE SOFTWARE.\n\nnamespace java com.uber.cadence\n\nexception BadRequestError {\n  1: required string message\n} (rpc.code = \"INVALID_ARGUMENT\")\n\nexception InternalServiceError {\n  1: required string message\n} (rpc.code = \"INTERNAL\")\n\nexception InternalDataInconsistencyError {\n  1: required string message\n} (rpc.code = \"DATA_LOSS\")\n\nexception DomainAlreadyExistsError {\n  1: required string message\n} (rpc.code = \"ALREADY_EXISTS\")\n\nexception WorkflowExecutionAlreadyStartedError {\n  10: optional string message\n  20: optional string startRequestId\n  30: optional string runId\n} (rpc.code = \"ALREADY_EXISTS\")\n\nexception WorkflowExecutionAlreadyCompletedError {\n  1: required string message\n} (rpc.code = \"NOT_FOUND\")\n\nexception EntityNotExistsError {\n  1: required string message\n  2: optional string currentCluster\n  3: optional string activeCluster\n  4: required list<string> activeClusters // todo(david.porter) remove as its disused\n} (rpc.code = \"NOT_FOUND\")\n\nexception ServiceBusyError {\n  1: required string message\n  2: optional string reason\n} (rpc.code = \"RESOURCE_EXHAUSTED\")\n\nexception CancellationAlreadyRequestedError {\n  1: required string message\n} (rpc.code = \"ALREADY_EXISTS\")\n\nexception QueryFailedError {\n  1: required string message\n} (rpc.code = \"INVALID_ARGUMENT\")\n\nexception DomainNotActiveError {\n  1: required string message\n  2: required string domainName\n  3: required string currentCluster\n  4: required string activeCluster\n  5: required list<string> activeClusters // todo (david.porter) remove this field as it's disused\n} (rpc.code = \"FAILED_PRECONDITION\")\n\nexception LimitExceededError {\n  1: required string message\n} (rpc.code = \"RESOURCE_EXHAUSTED\")\n\nexception AccessDeniedError {\n  1: required string message\n} (rpc.code = \"PERMISSION_DENIED\")\n\nexception RetryTaskV2Error {\n  1: required string message\n  2: optional string domainId\n  3: optional string workflowId\n  4: optional string runId\n  5: optional i64 (js.type = \"Long\") startEventId\n  6: optional i64 (js.type = \"Long\") startEventVersion\n  7: optional i64 (js.type = \"Long\") endEventId\n  8: optional i64 (js.type = \"Long\") endEventVersion\n} (rpc.code = \"ABORTED\")\n\nexception ClientVersionNotSupportedError {\n  1: required string featureVersion\n  2: required string clientImpl\n  3: required string supportedVersions\n} (rpc.code = \"FAILED_PRECONDITION\")\n\nexception FeatureNotEnabledError {\n  1: required string featureFlag\n} (rpc.code = \"FAILED_PRECONDITION\")\n\nexception CurrentBranchChangedError {\n  10: required string message\n  20: required binary currentBranchToken\n} (rpc.code = \"ABORTED\")\n\nexception RemoteSyncMatchedError {\n  10: required string message\n} (rpc.code = \"UNAVAILABLE\")\n\nexception StickyWorkerUnavailableError {\n  1: required string message\n} (rpc.code = \"UNAVAILABLE\")\n\nexception TaskListNotOwnedByHostError {\n    1: required string ownedByIdentity\n    2: required string myIdentity\n    3: required string tasklistName\n} (rpc.code = \"ABORTED\")\n\nenum WorkflowIdReusePolicy {\n  /*\n   * allow start a workflow execution using the same workflow ID,\n   * when workflow not running, and the last execution close state is in\n   * [terminated, cancelled, timeouted, failed].\n   */\n  AllowDuplicateFailedOnly,\n  /*\n   * allow start a workflow execution using the same workflow ID,\n   * when workflow not running.\n   */\n  AllowDuplicate,\n  /*\n   * do not allow start a workflow execution using the same workflow ID at all\n   */\n  RejectDuplicate,\n  /*\n   * if a workflow is running using the same workflow ID, terminate it and start a new one\n   */\n  TerminateIfRunning,\n}\n\nenum DomainStatus {\n  REGISTERED,\n  DEPRECATED,\n  DELETED,\n}\n\nenum TimeoutType {\n  START_TO_CLOSE,\n  SCHEDULE_TO_START,\n  SCHEDULE_TO_CLOSE,\n  HEARTBEAT,\n}\n\nenum ParentClosePolicy {\n  ABANDON,\n  REQUEST_CANCEL,\n  TERMINATE,\n}\n\n\n// whenever this list of decision is changed\n// do change the mutableStateBuilder.go\n// function shouldBufferEvent\n// to make sure wo do the correct event ordering\nenum DecisionType {\n  ScheduleActivityTask,\n  RequestCancelActivityTask,\n  StartTimer,\n  CompleteWorkflowExecution,\n  FailWorkflowExecution,\n  CancelTimer,\n  CancelWorkflowExecution,\n  RequestCancelExternalWorkflowExecution,\n  RecordMarker,\n  ContinueAsNewWorkflowExecution,\n  StartChildWorkflowExecution,\n  SignalExternalWorkflowExecution,\n  UpsertWorkflowSearchAttributes,\n}\n\nenum EventType {\n  WorkflowExecutionStarted,\n  WorkflowExecutionCompleted,\n  WorkflowExecutionFailed,\n  WorkflowExecutionTimedOut,\n  DecisionTaskScheduled,\n  DecisionTaskStarted,\n  DecisionTaskCompleted,\n  DecisionTaskTimedOut\n  DecisionTaskFailed,\n  ActivityTaskScheduled,\n  ActivityTaskStarted,\n  ActivityTaskCompleted,\n  ActivityTaskFailed,\n  ActivityTaskTimedOut,\n  ActivityTaskCancelRequested,\n  RequestCancelActivityTaskFailed,\n  ActivityTaskCanceled,\n  TimerStarted,\n  TimerFired,\n  CancelTimerFailed,\n  TimerCanceled,\n  WorkflowExecutionCancelRequested,\n  WorkflowExecutionCanceled,\n  RequestCancelExternalWorkflowExecutionInitiated,\n  RequestCancelExternalWorkflowExecutionFailed,\n  ExternalWorkflowExecutionCancelRequested,\n  MarkerRecorded,\n  WorkflowExecutionSignaled,\n  WorkflowExecutionTerminated,\n  WorkflowExecutionContinuedAsNew,\n  StartChildWorkflowExecutionInitiated,\n  StartChildWorkflowExecutionFailed,\n  ChildWorkflowExecutionStarted,\n  ChildWorkflowExecutionCompleted,\n  ChildWorkflowExecutionFailed,\n  ChildWorkflowExecutionCanceled,\n  ChildWorkflowExecutionTimedOut,\n  ChildWorkflowExecutionTerminated,\n  SignalExternalWorkflowExecutionInitiated,\n  SignalExternalWorkflowExecutionFailed,\n  ExternalWorkflowExecutionSignaled,\n  UpsertWorkflowSearchAttributes,\n}\n\nenum DecisionTaskFailedCause {\n  UNHANDLED_DECISION,\n  BAD_SCHEDULE_ACTIVITY_ATTRIBUTES,\n  BAD_REQUEST_CANCEL_ACTIVITY_ATTRIBUTES,\n  BAD_START_TIMER_ATTRIBUTES,\n  BAD_CANCEL_TIMER_ATTRIBUTES,\n  BAD_RECORD_MARKER_ATTRIBUTES,\n  BAD_COMPLETE_WORKFLOW_EXECUTION_ATTRIBUTES,\n  BAD_FAIL_WORKFLOW_EXECUTION_ATTRIBUTES,\n  BAD_CANCEL_WORKFLOW_EXECUTION_ATTRIBUTES,\n  BAD_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_ATTRIBUTES,\n  BAD_CONTINUE_AS_NEW_ATTRIBUTES,\n  START_TIMER_DUPLICATE_ID,\n  RESET_STICKY_TASKLIST,\n  WORKFLOW_WORKER_UNHANDLED_FAILURE,\n  BAD_SIGNAL_WORKFLOW_EXECUTION_ATTRIBUTES,\n  BAD_START_CHILD_EXECUTION_ATTRIBUTES,\n  FORCE_CLOSE_DECISION,\n  FAILOVER_CLOSE_DECISION,\n  BAD_SIGNAL_INPUT_SIZE,\n  RESET_WORKFLOW,\n  BAD_BINARY,\n  SCHEDULE_ACTIVITY_DUPLICATE_ID,\n  BAD_SEARCH_ATTRIBUTES,\n}\n\nenum DecisionTaskTimedOutCause {\n  TIMEOUT,\n  RESET,\n}\n\nenum CancelExternalWorkflowExecutionFailedCause {\n  UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION,\n  WORKFLOW_ALREADY_COMPLETED,\n}\n\nenum SignalExternalWorkflowExecutionFailedCause {\n  UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION,\n  WORKFLOW_ALREADY_COMPLETED,\n}\n\nenum ChildWorkflowExecutionFailedCause {\n  WORKFLOW_ALREADY_RUNNING,\n}\n\n// TODO: when migrating to gRPC, add a running / none status,\n//  currently, customer is using null / nil as an indication\n//  that workflow is still running\nenum WorkflowExecutionCloseStatus {\n  COMPLETED,\n  FAILED,\n  CANCELED,\n  TERMINATED,\n  CONTINUED_AS_NEW,\n  TIMED_OUT,\n}\n\nenum WorkflowExecutionStatus {\n  PENDING,\n  STARTED,\n  COMPLETED,\n  FAILED,\n  CANCELED,\n  TERMINATED,\n  CONTINUED_AS_NEW,\n  TIMED_OUT,\n}\n\nenum QueryTaskCompletedType {\n  COMPLETED,\n  FAILED,\n}\n\nenum QueryResultType {\n  ANSWERED,\n  FAILED,\n}\n\nenum PendingActivityState {\n  SCHEDULED,\n  STARTED,\n  CANCEL_REQUESTED,\n}\n\nenum PendingDecisionState {\n  SCHEDULED,\n  STARTED,\n}\n\nenum HistoryEventFilterType {\n  ALL_EVENT,\n  CLOSE_EVENT,\n}\n\nenum TaskListKind {\n  NORMAL,\n  STICKY,\n  EPHEMERAL,\n}\n\nenum ArchivalStatus {\n  DISABLED,\n  ENABLED,\n}\n\nenum CronOverlapPolicy {\n  SKIPPED,\n  BUFFERONE,\n}\n\nenum IndexedValueType {\n  STRING,\n  KEYWORD,\n  INT,\n  DOUBLE,\n  BOOL,\n  DATETIME,\n}\n\nstruct Header {\n    10: optional map<string, binary> fields\n}\n\nstruct WorkflowType {\n  10: optional string name\n}\n\nstruct ActivityType {\n  10: optional string name\n}\n\nstruct TaskList {\n  10: optional string name\n  20: optional TaskListKind kind\n  30: optional string baseName\n}\n\nenum EncodingType {\n  ThriftRW,\n  JSON,\n}\n\nenum QueryRejectCondition {\n  // NOT_OPEN indicates that query should be rejected if workflow is not open\n  NOT_OPEN\n  // NOT_COMPLETED_CLEANLY indicates that query should be rejected if workflow did not complete cleanly\n  NOT_COMPLETED_CLEANLY\n}\n\nenum QueryConsistencyLevel {\n  // EVENTUAL indicates that query should be eventually consistent\n  EVENTUAL\n  // STRONG indicates that any events that came before query should be reflected in workflow state before running query\n  STRONG\n}\n\nstruct DataBlob {\n  10: optional EncodingType EncodingType\n  20: optional binary Data\n}\n\nstruct TaskListMetadata {\n  10: optional double maxTasksPerSecond\n}\n\nstruct WorkflowExecution {\n  10: optional string workflowId\n  20: optional string runId\n}\n\nstruct Memo {\n  10: optional map<string,binary> fields\n}\n\nstruct SearchAttributes {\n  10: optional map<string,binary> indexedFields\n}\n\nstruct WorkerVersionInfo {\n  10: optional string impl\n  20: optional string featureVersion\n}\n\nstruct WorkflowExecutionInfo {\n  10: optional WorkflowExecution execution\n  20: optional WorkflowType type\n  30: optional i64 (js.type = \"Long\") startTime\n  40: optional i64 (js.type = \"Long\") closeTime\n  50: optional WorkflowExecutionCloseStatus closeStatus\n  60: optional i64 (js.type = \"Long\") historyLength\n  70: optional string parentDomainId\n  71: optional string parentDomainName\n  72: optional i64 parentInitatedId\n  80: optional WorkflowExecution parentExecution\n  90: optional i64 (js.type = \"Long\") executionTime\n  100: optional Memo memo\n  101: optional SearchAttributes searchAttributes\n  110: optional ResetPoints autoResetPoints\n  120: optional string taskList\n  121: optional TaskList taskListInfo\n  130: optional bool isCron\n  140: optional i64 (js.type = \"Long\") updateTime\n  150: optional map<string, string> partitionConfig\n  160: optional CronOverlapPolicy cronOverlapPolicy\n  170: optional ActiveClusterSelectionPolicy activeClusterSelectionPolicy\n  180: optional string cronSchedule\n  190: optional WorkflowExecutionStatus executionStatus\n  200: optional i64 (js.type = \"Long\") scheduledExecutionTime\n}\n\nstruct WorkflowExecutionConfiguration {\n  10: optional TaskList taskList\n  20: optional i32 executionStartToCloseTimeoutSeconds\n  30: optional i32 taskStartToCloseTimeoutSeconds\n//  40: optional ChildPolicy childPolicy -- Removed but reserve the IDL order number\n}\n\nstruct TransientDecisionInfo {\n  10: optional HistoryEvent scheduledEvent\n  20: optional HistoryEvent startedEvent\n}\n\nstruct ScheduleActivityTaskDecisionAttributes {\n  10: optional string activityId\n  20: optional ActivityType activityType\n  25: optional string domain\n  30: optional TaskList taskList\n  40: optional binary input\n  45: optional i32 scheduleToCloseTimeoutSeconds\n  50: optional i32 scheduleToStartTimeoutSeconds\n  55: optional i32 startToCloseTimeoutSeconds\n  60: optional i32 heartbeatTimeoutSeconds\n  70: optional RetryPolicy retryPolicy\n  80: optional Header header\n  90: optional bool requestLocalDispatch\n}\n\nstruct ActivityLocalDispatchInfo{\n  10: optional string activityId\n  20: optional i64 (js.type = \"Long\") scheduledTimestamp\n  30: optional i64 (js.type = \"Long\") startedTimestamp\n  40: optional i64 (js.type = \"Long\") scheduledTimestampOfThisAttempt\n  50: optional binary taskToken\n}\n\nstruct RequestCancelActivityTaskDecisionAttributes {\n  10: optional string activityId\n}\n\nstruct StartTimerDecisionAttributes {\n  10: optional string timerId\n  20: optional i64 (js.type = \"Long\") startToFireTimeoutSeconds\n}\n\nstruct CompleteWorkflowExecutionDecisionAttributes {\n  10: optional binary result\n}\n\nstruct FailWorkflowExecutionDecisionAttributes {\n  10: optional string reason\n  20: optional binary details\n}\n\nstruct CancelTimerDecisionAttributes {\n  10: optional string timerId\n}\n\nstruct CancelWorkflowExecutionDecisionAttributes {\n  10: optional binary details\n}\n\nstruct RequestCancelExternalWorkflowExecutionDecisionAttributes {\n  10: optional string domain\n  20: optional string workflowId\n  30: optional string runId\n  40: optional binary control\n  50: optional bool childWorkflowOnly\n}\n\nstruct SignalExternalWorkflowExecutionDecisionAttributes {\n  10: optional string domain\n  20: optional WorkflowExecution execution\n  30: optional string signalName\n  40: optional binary input\n  50: optional binary control\n  60: optional bool childWorkflowOnly\n}\n\nstruct UpsertWorkflowSearchAttributesDecisionAttributes {\n  10: optional SearchAttributes searchAttributes\n}\n\nstruct RecordMarkerDecisionAttributes {\n  10: optional string markerName\n  20: optional binary details\n  30: optional Header header\n}\n\nstruct ContinueAsNewWorkflowExecutionDecisionAttributes {\n  10: optional WorkflowType workflowType\n  20: optional TaskList taskList\n  30: optional binary input\n  40: optional i32 executionStartToCloseTimeoutSeconds\n  50: optional i32 taskStartToCloseTimeoutSeconds\n  60: optional i32 backoffStartIntervalInSeconds\n  70: optional RetryPolicy retryPolicy\n  80: optional ContinueAsNewInitiator initiator\n  90: optional string failureReason\n  100: optional binary failureDetails\n  110: optional binary lastCompletionResult\n  120: optional string cronSchedule\n  130: optional Header header\n  140: optional Memo memo\n  150: optional SearchAttributes searchAttributes\n  160: optional i32 jitterStartSeconds\n  170: optional CronOverlapPolicy cronOverlapPolicy\n  180: optional ActiveClusterSelectionPolicy activeClusterSelectionPolicy\n}\n\nstruct StartChildWorkflowExecutionDecisionAttributes {\n  10: optional string domain\n  20: optional string workflowId\n  30: optional WorkflowType workflowType\n  40: optional TaskList taskList\n  50: optional binary input\n  60: optional i32 executionStartToCloseTimeoutSeconds\n  70: optional i32 taskStartToCloseTimeoutSeconds\n//  80: optional ChildPolicy childPolicy -- Removed but reserve the IDL order number\n  81: optional ParentClosePolicy parentClosePolicy\n  90: optional binary control\n  100: optional WorkflowIdReusePolicy workflowIdReusePolicy\n  110: optional RetryPolicy retryPolicy\n  120: optional string cronSchedule\n  130: optional Header header\n  140: optional Memo memo\n  150: optional SearchAttributes searchAttributes\n  160: optional CronOverlapPolicy cronOverlapPolicy\n  170: optional ActiveClusterSelectionPolicy activeClusterSelectionPolicy\n}\n\nstruct Decision {\n  10:  optional DecisionType decisionType\n  20:  optional ScheduleActivityTaskDecisionAttributes scheduleActivityTaskDecisionAttributes\n  25:  optional StartTimerDecisionAttributes startTimerDecisionAttributes\n  30:  optional CompleteWorkflowExecutionDecisionAttributes completeWorkflowExecutionDecisionAttributes\n  35:  optional FailWorkflowExecutionDecisionAttributes failWorkflowExecutionDecisionAttributes\n  40:  optional RequestCancelActivityTaskDecisionAttributes requestCancelActivityTaskDecisionAttributes\n  50:  optional CancelTimerDecisionAttributes cancelTimerDecisionAttributes\n  60:  optional CancelWorkflowExecutionDecisionAttributes cancelWorkflowExecutionDecisionAttributes\n  70:  optional RequestCancelExternalWorkflowExecutionDecisionAttributes requestCancelExternalWorkflowExecutionDecisionAttributes\n  80:  optional RecordMarkerDecisionAttributes recordMarkerDecisionAttributes\n  90:  optional ContinueAsNewWorkflowExecutionDecisionAttributes continueAsNewWorkflowExecutionDecisionAttributes\n  100: optional StartChildWorkflowExecutionDecisionAttributes startChildWorkflowExecutionDecisionAttributes\n  110: optional SignalExternalWorkflowExecutionDecisionAttributes signalExternalWorkflowExecutionDecisionAttributes\n  120: optional UpsertWorkflowSearchAttributesDecisionAttributes upsertWorkflowSearchAttributesDecisionAttributes\n}\n\nstruct WorkflowExecutionStartedEventAttributes {\n  10: optional WorkflowType workflowType\n  12: optional string parentWorkflowDomain\n  14: optional WorkflowExecution parentWorkflowExecution\n  16: optional i64 (js.type = \"Long\") parentInitiatedEventId\n  20: optional TaskList taskList\n  30: optional binary input\n  40: optional i32 executionStartToCloseTimeoutSeconds\n  50: optional i32 taskStartToCloseTimeoutSeconds\n//  52: optional ChildPolicy childPolicy -- Removed but reserve the IDL order number\n  54: optional string continuedExecutionRunId\n  55: optional ContinueAsNewInitiator initiator\n  56: optional string continuedFailureReason\n  57: optional binary continuedFailureDetails\n  58: optional binary lastCompletionResult\n  59: optional string originalExecutionRunId // This is the runID when the WorkflowExecutionStarted event is written\n  60: optional string identity\n  61: optional string firstExecutionRunId // This is the very first runID along the chain of ContinueAsNew and Reset.\n  62: optional i64 (js.type = \"Long\") firstScheduledTimeNano\n  70: optional RetryPolicy retryPolicy\n  80: optional i32 attempt\n  90: optional i64 (js.type = \"Long\") expirationTimestamp\n  100: optional string cronSchedule\n  110: optional i32 firstDecisionTaskBackoffSeconds\n  120: optional Memo memo\n  121: optional SearchAttributes searchAttributes\n  130: optional ResetPoints prevAutoResetPoints\n  140: optional Header header\n  150: optional map<string, string> partitionConfig\n  160: optional string requestId\n  170: optional CronOverlapPolicy cronOverlapPolicy\n  180: optional ActiveClusterSelectionPolicy activeClusterSelectionPolicy\n}\n\nstruct ResetPoints{\n  10: optional list<ResetPointInfo> points\n}\n\n struct ResetPointInfo{\n  10: optional string binaryChecksum\n  20: optional string runId\n  30: optional i64 firstDecisionCompletedId\n  40: optional i64 (js.type = \"Long\") createdTimeNano\n  50: optional i64 (js.type = \"Long\") expiringTimeNano //the time that the run is deleted due to retention\n  60: optional bool resettable                         // false if the resset point has pending childWFs/reqCancels/signalExternals.\n}\n\nstruct WorkflowExecutionCompletedEventAttributes {\n  10: optional binary result\n  20: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n}\n\nstruct WorkflowExecutionFailedEventAttributes {\n  10: optional string reason\n  20: optional binary details\n  30: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n}\n\nstruct WorkflowExecutionTimedOutEventAttributes {\n  10: optional TimeoutType timeoutType\n}\n\nenum ContinueAsNewInitiator {\n  Decider,\n  RetryPolicy,\n  CronSchedule,\n}\n\nstruct WorkflowExecutionContinuedAsNewEventAttributes {\n  10: optional string newExecutionRunId\n  20: optional WorkflowType workflowType\n  30: optional TaskList taskList\n  40: optional binary input\n  50: optional i32 executionStartToCloseTimeoutSeconds\n  60: optional i32 taskStartToCloseTimeoutSeconds\n  70: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  80: optional i32 backoffStartIntervalInSeconds\n  90: optional ContinueAsNewInitiator initiator\n  100: optional string failureReason\n  110: optional binary failureDetails\n  120: optional binary lastCompletionResult\n  130: optional Header header\n  140: optional Memo memo\n  150: optional SearchAttributes searchAttributes\n  160: optional CronOverlapPolicy cronOverlapPolicy\n  170: optional ActiveClusterSelectionPolicy activeClusterSelectionPolicy\n}\n\nstruct DecisionTaskScheduledEventAttributes {\n  10: optional TaskList taskList\n  20: optional i32 startToCloseTimeoutSeconds\n  30: optional i64 (js.type = \"Long\") attempt\n}\n\nstruct DecisionTaskStartedEventAttributes {\n  10: optional i64 (js.type = \"Long\") scheduledEventId\n  20: optional string identity\n  30: optional string requestId\n}\n\nstruct DecisionTaskCompletedEventAttributes {\n  10: optional binary executionContext\n  20: optional i64 (js.type = \"Long\") scheduledEventId\n  30: optional i64 (js.type = \"Long\") startedEventId\n  40: optional string identity\n  50: optional string binaryChecksum\n}\n\nstruct DecisionTaskTimedOutEventAttributes {\n  10: optional i64 (js.type = \"Long\") scheduledEventId\n  20: optional i64 (js.type = \"Long\") startedEventId\n  30: optional TimeoutType timeoutType\n  // for reset workflow\n  40: optional string baseRunId\n  50: optional string newRunId\n  60: optional i64 (js.type = \"Long\") forkEventVersion\n  70: optional string reason\n  80: optional DecisionTaskTimedOutCause cause\n  90: optional string requestId\n}\n\nstruct DecisionTaskFailedEventAttributes {\n  10: optional i64 (js.type = \"Long\") scheduledEventId\n  20: optional i64 (js.type = \"Long\") startedEventId\n  30: optional DecisionTaskFailedCause cause\n  35: optional binary details\n  40: optional string identity\n  50: optional string reason\n  // for reset workflow\n  60: optional string baseRunId\n  70: optional string newRunId\n  80: optional i64 (js.type = \"Long\") forkEventVersion\n  90: optional string binaryChecksum\n  100: optional string requestId\n}\n\nstruct ActivityTaskScheduledEventAttributes {\n  10: optional string activityId\n  20: optional ActivityType activityType\n  25: optional string domain\n  30: optional TaskList taskList\n  40: optional binary input\n  45: optional i32 scheduleToCloseTimeoutSeconds\n  50: optional i32 scheduleToStartTimeoutSeconds\n  55: optional i32 startToCloseTimeoutSeconds\n  60: optional i32 heartbeatTimeoutSeconds\n  90: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  110: optional RetryPolicy retryPolicy\n  120: optional Header header\n}\n\nstruct ActivityTaskStartedEventAttributes {\n  10: optional i64 (js.type = \"Long\") scheduledEventId\n  20: optional string identity\n  30: optional string requestId\n  40: optional i32 attempt\n  50: optional string lastFailureReason\n  60: optional binary lastFailureDetails\n  70: optional FailureOptions lastFailureOptions\n}\n\nstruct ActivityTaskCompletedEventAttributes {\n  10: optional binary result\n  20: optional i64 (js.type = \"Long\") scheduledEventId\n  30: optional i64 (js.type = \"Long\") startedEventId\n  40: optional string identity\n}\n\nstruct ActivityTaskFailedEventAttributes {\n  10: optional string reason\n  20: optional binary details\n  25: optional FailureOptions failureOptions\n  30: optional i64 (js.type = \"Long\") scheduledEventId\n  40: optional i64 (js.type = \"Long\") startedEventId\n  50: optional string identity\n}\n\nstruct ActivityTaskTimedOutEventAttributes {\n  05: optional binary details\n  10: optional i64 (js.type = \"Long\") scheduledEventId\n  20: optional i64 (js.type = \"Long\") startedEventId\n  30: optional TimeoutType timeoutType\n  // For retry activity, it may have a failure before timeout. It's important to keep those information for debug.\n  // Client can also provide the info for making next decision\n  40: optional string lastFailureReason\n  50: optional binary lastFailureDetails\n  60: optional FailureOptions lastFailureOptions\n}\n\nstruct ActivityTaskCancelRequestedEventAttributes {\n  10: optional string activityId\n  20: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n}\n\nstruct RequestCancelActivityTaskFailedEventAttributes{\n  10: optional string activityId\n  20: optional string cause\n  30: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n}\n\nstruct ActivityTaskCanceledEventAttributes {\n  10: optional binary details\n  20: optional i64 (js.type = \"Long\") latestCancelRequestedEventId\n  30: optional i64 (js.type = \"Long\") scheduledEventId\n  40: optional i64 (js.type = \"Long\") startedEventId\n  50: optional string identity\n}\n\nstruct TimerStartedEventAttributes {\n  10: optional string timerId\n  20: optional i64 (js.type = \"Long\") startToFireTimeoutSeconds\n  30: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n}\n\nstruct TimerFiredEventAttributes {\n  10: optional string timerId\n  20: optional i64 (js.type = \"Long\") startedEventId\n}\n\nstruct TimerCanceledEventAttributes {\n  10: optional string timerId\n  20: optional i64 (js.type = \"Long\") startedEventId\n  30: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  40: optional string identity\n}\n\nstruct CancelTimerFailedEventAttributes {\n  10: optional string timerId\n  20: optional string cause\n  30: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  40: optional string identity\n}\n\nstruct WorkflowExecutionCancelRequestedEventAttributes {\n  10: optional string cause\n  20: optional i64 (js.type = \"Long\") externalInitiatedEventId\n  30: optional WorkflowExecution externalWorkflowExecution\n  40: optional string identity\n  50: optional string requestId\n}\n\nstruct WorkflowExecutionCanceledEventAttributes {\n  10: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  20: optional binary details\n}\n\nstruct MarkerRecordedEventAttributes {\n  10: optional string markerName\n  20: optional binary details\n  30: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  40: optional Header header\n}\n\nstruct WorkflowExecutionSignaledEventAttributes {\n  10: optional string signalName\n  20: optional binary input\n  30: optional string identity\n  40: optional string requestId\n}\n\nstruct WorkflowExecutionTerminatedEventAttributes {\n  10: optional string reason\n  20: optional binary details\n  30: optional string identity\n}\n\nstruct RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {\n  10: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  20: optional string domain\n  30: optional WorkflowExecution workflowExecution\n  40: optional binary control\n  50: optional bool childWorkflowOnly\n}\n\nstruct RequestCancelExternalWorkflowExecutionFailedEventAttributes {\n  10: optional CancelExternalWorkflowExecutionFailedCause cause\n  20: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  30: optional string domain\n  40: optional WorkflowExecution workflowExecution\n  50: optional i64 (js.type = \"Long\") initiatedEventId\n  60: optional binary control\n}\n\nstruct ExternalWorkflowExecutionCancelRequestedEventAttributes {\n  10: optional i64 (js.type = \"Long\") initiatedEventId\n  20: optional string domain\n  30: optional WorkflowExecution workflowExecution\n}\n\nstruct SignalExternalWorkflowExecutionInitiatedEventAttributes {\n  10: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  20: optional string domain\n  30: optional WorkflowExecution workflowExecution\n  40: optional string signalName\n  50: optional binary input\n  60: optional binary control\n  70: optional bool childWorkflowOnly\n}\n\nstruct SignalExternalWorkflowExecutionFailedEventAttributes {\n  10: optional SignalExternalWorkflowExecutionFailedCause cause\n  20: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  30: optional string domain\n  40: optional WorkflowExecution workflowExecution\n  50: optional i64 (js.type = \"Long\") initiatedEventId\n  60: optional binary control\n}\n\nstruct ExternalWorkflowExecutionSignaledEventAttributes {\n  10: optional i64 (js.type = \"Long\") initiatedEventId\n  20: optional string domain\n  30: optional WorkflowExecution workflowExecution\n  40: optional binary control\n}\n\nstruct UpsertWorkflowSearchAttributesEventAttributes {\n  10: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  20: optional SearchAttributes searchAttributes\n}\n\nstruct StartChildWorkflowExecutionInitiatedEventAttributes {\n  10:  optional string domain\n  20:  optional string workflowId\n  30:  optional WorkflowType workflowType\n  40:  optional TaskList taskList\n  50:  optional binary input\n  60:  optional i32 executionStartToCloseTimeoutSeconds\n  70:  optional i32 taskStartToCloseTimeoutSeconds\n//  80:  optional ChildPolicy childPolicy -- Removed but reserve the IDL order number\n  81:  optional ParentClosePolicy parentClosePolicy\n  90:  optional binary control\n  100: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n  110: optional WorkflowIdReusePolicy workflowIdReusePolicy\n  120: optional RetryPolicy retryPolicy\n  130: optional string cronSchedule\n  140: optional Header header\n  150: optional Memo memo\n  160: optional SearchAttributes searchAttributes\n  170: optional i32 delayStartSeconds\n  180: optional i32 jitterStartSeconds\n  190: optional i64 (js.type = \"Long\") firstRunAtTimestamp\n  200: optional CronOverlapPolicy cronOverlapPolicy\n  210: optional ActiveClusterSelectionPolicy activeClusterSelectionPolicy\n}\n\nstruct StartChildWorkflowExecutionFailedEventAttributes {\n  10: optional string domain\n  20: optional string workflowId\n  30: optional WorkflowType workflowType\n  40: optional ChildWorkflowExecutionFailedCause cause\n  50: optional binary control\n  60: optional i64 (js.type = \"Long\") initiatedEventId\n  70: optional i64 (js.type = \"Long\") decisionTaskCompletedEventId\n}\n\nstruct ChildWorkflowExecutionStartedEventAttributes {\n  10: optional string domain\n  20: optional i64 (js.type = \"Long\") initiatedEventId\n  30: optional WorkflowExecution workflowExecution\n  40: optional WorkflowType workflowType\n  50: optional Header header\n}\n\nstruct ChildWorkflowExecutionCompletedEventAttributes {\n  10: optional binary result\n  20: optional string domain\n  30: optional WorkflowExecution workflowExecution\n  40: optional WorkflowType workflowType\n  50: optional i64 (js.type = \"Long\") initiatedEventId\n  60: optional i64 (js.type = \"Long\") startedEventId\n}\n\nstruct ChildWorkflowExecutionFailedEventAttributes {\n  10: optional string reason\n  20: optional binary details\n  30: optional string domain\n  40: optional WorkflowExecution workflowExecution\n  50: optional WorkflowType workflowType\n  60: optional i64 (js.type = \"Long\") initiatedEventId\n  70: optional i64 (js.type = \"Long\") startedEventId\n}\n\nstruct ChildWorkflowExecutionCanceledEventAttributes {\n  10: optional binary details\n  20: optional string domain\n  30: optional WorkflowExecution workflowExecution\n  40: optional WorkflowType workflowType\n  50: optional i64 (js.type = \"Long\") initiatedEventId\n  60: optional i64 (js.type = \"Long\") startedEventId\n}\n\nstruct ChildWorkflowExecutionTimedOutEventAttributes {\n  10: optional TimeoutType timeoutType\n  20: optional string domain\n  30: optional WorkflowExecution workflowExecution\n  40: optional WorkflowType workflowType\n  50: optional i64 (js.type = \"Long\") initiatedEventId\n  60: optional i64 (js.type = \"Long\") startedEventId\n}\n\nstruct ChildWorkflowExecutionTerminatedEventAttributes {\n  10: optional string domain\n  20: optional WorkflowExecution workflowExecution\n  30: optional WorkflowType workflowType\n  40: optional i64 (js.type = \"Long\") initiatedEventId\n  50: optional i64 (js.type = \"Long\") startedEventId\n}\n\nstruct HistoryEvent {\n  10:  optional i64 (js.type = \"Long\") eventId\n  20:  optional i64 (js.type = \"Long\") timestamp\n  30:  optional EventType eventType\n  35:  optional i64 (js.type = \"Long\") version\n  36:  optional i64 (js.type = \"Long\") taskId\n  40:  optional WorkflowExecutionStartedEventAttributes workflowExecutionStartedEventAttributes\n  50:  optional WorkflowExecutionCompletedEventAttributes workflowExecutionCompletedEventAttributes\n  60:  optional WorkflowExecutionFailedEventAttributes workflowExecutionFailedEventAttributes\n  70:  optional WorkflowExecutionTimedOutEventAttributes workflowExecutionTimedOutEventAttributes\n  80:  optional DecisionTaskScheduledEventAttributes decisionTaskScheduledEventAttributes\n  90:  optional DecisionTaskStartedEventAttributes decisionTaskStartedEventAttributes\n  100: optional DecisionTaskCompletedEventAttributes decisionTaskCompletedEventAttributes\n  110: optional DecisionTaskTimedOutEventAttributes decisionTaskTimedOutEventAttributes\n  120: optional DecisionTaskFailedEventAttributes decisionTaskFailedEventAttributes\n  130: optional ActivityTaskScheduledEventAttributes activityTaskScheduledEventAttributes\n  140: optional ActivityTaskStartedEventAttributes activityTaskStartedEventAttributes\n  150: optional ActivityTaskCompletedEventAttributes activityTaskCompletedEventAttributes\n  160: optional ActivityTaskFailedEventAttributes activityTaskFailedEventAttributes\n  170: optional ActivityTaskTimedOutEventAttributes activityTaskTimedOutEventAttributes\n  180: optional TimerStartedEventAttributes timerStartedEventAttributes\n  190: optional TimerFiredEventAttributes timerFiredEventAttributes\n  200: optional ActivityTaskCancelRequestedEventAttributes activityTaskCancelRequestedEventAttributes\n  210: optional RequestCancelActivityTaskFailedEventAttributes requestCancelActivityTaskFailedEventAttributes\n  220: optional ActivityTaskCanceledEventAttributes activityTaskCanceledEventAttributes\n  230: optional TimerCanceledEventAttributes timerCanceledEventAttributes\n  240: optional CancelTimerFailedEventAttributes cancelTimerFailedEventAttributes\n  250: optional MarkerRecordedEventAttributes markerRecordedEventAttributes\n  260: optional WorkflowExecutionSignaledEventAttributes workflowExecutionSignaledEventAttributes\n  270: optional WorkflowExecutionTerminatedEventAttributes workflowExecutionTerminatedEventAttributes\n  280: optional WorkflowExecutionCancelRequestedEventAttributes workflowExecutionCancelRequestedEventAttributes\n  290: optional WorkflowExecutionCanceledEventAttributes workflowExecutionCanceledEventAttributes\n  300: optional RequestCancelExternalWorkflowExecutionInitiatedEventAttributes requestCancelExternalWorkflowExecutionInitiatedEventAttributes\n  310: optional RequestCancelExternalWorkflowExecutionFailedEventAttributes requestCancelExternalWorkflowExecutionFailedEventAttributes\n  320: optional ExternalWorkflowExecutionCancelRequestedEventAttributes externalWorkflowExecutionCancelRequestedEventAttributes\n  330: optional WorkflowExecutionContinuedAsNewEventAttributes workflowExecutionContinuedAsNewEventAttributes\n  340: optional StartChildWorkflowExecutionInitiatedEventAttributes startChildWorkflowExecutionInitiatedEventAttributes\n  350: optional StartChildWorkflowExecutionFailedEventAttributes startChildWorkflowExecutionFailedEventAttributes\n  360: optional ChildWorkflowExecutionStartedEventAttributes childWorkflowExecutionStartedEventAttributes\n  370: optional ChildWorkflowExecutionCompletedEventAttributes childWorkflowExecutionCompletedEventAttributes\n  380: optional ChildWorkflowExecutionFailedEventAttributes childWorkflowExecutionFailedEventAttributes\n  390: optional ChildWorkflowExecutionCanceledEventAttributes childWorkflowExecutionCanceledEventAttributes\n  400: optional ChildWorkflowExecutionTimedOutEventAttributes childWorkflowExecutionTimedOutEventAttributes\n  410: optional ChildWorkflowExecutionTerminatedEventAttributes childWorkflowExecutionTerminatedEventAttributes\n  420: optional SignalExternalWorkflowExecutionInitiatedEventAttributes signalExternalWorkflowExecutionInitiatedEventAttributes\n  430: optional SignalExternalWorkflowExecutionFailedEventAttributes signalExternalWorkflowExecutionFailedEventAttributes\n  440: optional ExternalWorkflowExecutionSignaledEventAttributes externalWorkflowExecutionSignaledEventAttributes\n  450: optional UpsertWorkflowSearchAttributesEventAttributes upsertWorkflowSearchAttributesEventAttributes\n}\n\nstruct History {\n  10: optional list<HistoryEvent> events\n}\n\nstruct WorkflowExecutionFilter {\n  10: optional string workflowId\n  20: optional string runId\n}\n\nstruct WorkflowTypeFilter {\n  10: optional string name\n}\n\nstruct StartTimeFilter {\n  10: optional i64 (js.type = \"Long\") earliestTime\n  20: optional i64 (js.type = \"Long\") latestTime\n}\n\nstruct DomainInfo {\n  10: optional string name\n  20: optional DomainStatus status\n  30: optional string description\n  40: optional string ownerEmail\n  // A key-value map for any customized purpose\n  50: optional map<string,string> data\n  60: optional string uuid\n}\n\nstruct DomainConfiguration {\n  10: optional i32 workflowExecutionRetentionPeriodInDays\n  20: optional bool emitMetric\n  60: optional IsolationGroupConfiguration isolationgroups\n  70: optional BadBinaries badBinaries\n  80: optional ArchivalStatus historyArchivalStatus\n  90: optional string historyArchivalURI\n  100: optional ArchivalStatus visibilityArchivalStatus\n  110: optional string visibilityArchivalURI\n  120: optional AsyncWorkflowConfiguration AsyncWorkflowConfiguration\n}\n\nstruct FailoverInfo {\n    10: optional i64 (js.type = \"Long\") failoverVersion\n    20: optional i64 (js.type = \"Long\") failoverStartTimestamp\n    30: optional i64 (js.type = \"Long\") failoverExpireTimestamp\n    40: optional i32 completedShardCount\n    50: optional list<i32> pendingShards\n}\n\nstruct BadBinaries{\n  10: optional map<string, BadBinaryInfo> binaries\n}\n\nstruct BadBinaryInfo{\n  10: optional string reason\n  20: optional string operator\n  30: optional i64 (js.type = \"Long\") createdTimeNano\n}\n\nstruct UpdateDomainInfo {\n  10: optional string description\n  20: optional string ownerEmail\n  // A key-value map for any customized purpose\n  30: optional map<string,string> data\n}\n\nstruct ClusterReplicationConfiguration {\n 10: optional string clusterName\n}\n\nstruct DomainReplicationConfiguration {\n // activeClusterName is the name of the active cluster for active-passive domain\n 10: optional string activeClusterName\n\n //  clusters is list of all active and passive clusters of domain\n 20: optional list<ClusterReplicationConfiguration> clusters\n\n // activeClusters contains active cluster(s) information for active-active domain\n 30: optional ActiveClusters activeClusters\n}\n\n// ClusterAttributeScope is a mapping of the cluster atribute to the scope's\n// current stae and failover version, indicating how recently the change was made\nstruct ClusterAttributeScope {\n  10: optional map<string, ActiveClusterInfo> clusterAttributes;\n}\n\n// activeClustersByClusterAttribute is a map of whatever subdivision of the domain chosen\n// to active cluster info for active-active domains. The key refers to the type of\n// cluster attribute and the value refers to its cluster mappings.\n//\n// For example, a request to update the domain for two locations\n//\n// UpdateDomainRequest{\n//    ReplicationConfiguration: {\n//       ActiveClusters: {\n//           ActiveClustersByClusterAttribute: {\n//             \"location\": ClusterAttributeScope{\n//                   \"Tokyo\": {ActiveClusterInfo: \"cluster0, FailoverVersion: 123},\n//                   \"Morocco\": {ActiveClusterInfo: \"cluster1\", FailoverVersion: 100},\n//             }\n//          }\n//       }\n//    }\n//  }\nstruct ActiveClusters {\n  10: optional map<string, ActiveClusterInfo> activeClustersByRegion // todo (david.porter) remove this as it's no longer used\n  11: optional map<string, ClusterAttributeScope> activeClustersByClusterAttribute\n}\n\n// ActiveClusterInfo contains the configuration of active-active domain's active\n// cluster & failover version for a specific region\nstruct ActiveClusterInfo {\n  10: optional string activeClusterName\n  20: optional i64 (js.type = \"Long\") failoverVersion\n}\n\nstruct RegisterDomainRequest {\n  10: optional string name\n  20: optional string description\n  30: optional string ownerEmail\n  40: optional i32 workflowExecutionRetentionPeriodInDays\n  50: optional bool emitMetric = true\n  60: optional list<ClusterReplicationConfiguration> clusters\n  70: optional string activeClusterName\n  // todo (david.porter) remove this field as it's not going to be used\n  75: optional map<string, string> activeClustersByRegion\n  // activeClusters is a map of cluster-attribute name to active cluster name for active-active domain\n  76: optional ActiveClusters activeClusters\n  // A key-value map for any customized purpose\n  80: optional map<string,string> data\n  90: optional string securityToken\n  120: optional bool isGlobalDomain\n  130: optional ArchivalStatus historyArchivalStatus\n  140: optional string historyArchivalURI\n  150: optional ArchivalStatus visibilityArchivalStatus\n  160: optional string visibilityArchivalURI\n}\n\nstruct ListDomainsRequest {\n  10: optional i32 pageSize\n  20: optional binary nextPageToken\n}\n\nstruct ListDomainsResponse {\n  10: optional list<DescribeDomainResponse> domains\n  20: optional binary nextPageToken\n}\n\nstruct DescribeDomainRequest {\n  10: optional string name\n  20: optional string uuid\n}\n\nstruct DescribeDomainResponse {\n  10: optional DomainInfo domainInfo\n  20: optional DomainConfiguration configuration\n  30: optional DomainReplicationConfiguration replicationConfiguration\n  40: optional i64 (js.type = \"Long\") failoverVersion\n  50: optional bool isGlobalDomain\n  60: optional FailoverInfo failoverInfo\n}\n\nstruct UpdateDomainRequest {\n 10: optional string name\n 20: optional UpdateDomainInfo updatedInfo\n 30: optional DomainConfiguration configuration\n 40: optional DomainReplicationConfiguration replicationConfiguration\n 50: optional string securityToken\n 60: optional string deleteBadBinary\n 70: optional i32 failoverTimeoutInSeconds\n}\n\nstruct UpdateDomainResponse {\n  10: optional DomainInfo domainInfo\n  20: optional DomainConfiguration configuration\n  30: optional DomainReplicationConfiguration replicationConfiguration\n  40: optional i64 (js.type = \"Long\") failoverVersion\n  50: optional bool isGlobalDomain\n}\n\nstruct FailoverDomainRequest {\n 10: optional string domainName\n 20: optional string domainActiveClusterName\n // only applicable to active-active domains where\n // specific cluster-attributes are being failed over\n 30: optional ActiveClusters activeClusters\n // user-requested addition \"reason\" variable created to increase transparency around failovers\n 40: optional string reason\n 50: optional i32 failoverTimeoutInSeconds\n}\n\nstruct FailoverDomainResponse {\n  10: optional DomainInfo domainInfo\n  20: optional DomainConfiguration configuration\n  30: optional DomainReplicationConfiguration replicationConfiguration\n  40: optional i64 (js.type = \"Long\") failoverVersion\n  50: optional bool isGlobalDomain\n}\n\nstruct DeprecateDomainRequest {\n 10: optional string name\n 20: optional string securityToken\n}\n\nstruct DeleteDomainRequest {\n 10: optional string name\n 20: optional string securityToken\n}\n\nstruct ListFailoverHistoryRequest {\n  // ListFailoverHistoryRequestFilters specifies the filters to apply to the request.\n  // If not provided all failover events will be returned.\n  10: optional ListFailoverHistoryRequestFilters filters\n  // PaginationOptions will be used to paginate the results.\n  // If not provided the first 5 events will be returned.\n  20: optional PaginationOptions pagination\n}\n\n// ListFailoverHistoryRequestFilters is used to filter the failover history.\n// It will be extended with additional filters (e.g ClusterAttributes) as the active-active feature is developed.\nstruct ListFailoverHistoryRequestFilters {\n  // domain_id is the id of the domain to list failover history for.\n  10: optional string domainID\n}\n\nstruct ListFailoverHistoryResponse {\n  10: optional list<FailoverEvent> failoverEvents\n  // next_page_token can be passed in a subsequent request to fetch the next set of events.\n  20: optional binary nextPageToken\n}\n\nstruct FailoverEvent {\n  // id of the failover event\n  // Can be passed with the created time to fetch a specific event.\n  10: optional string id\n  // created_time is the time the failover event was created.\n  // Can be passed with the ID to fetch a specific event.\n  20: optional i64 (js.type = \"Long\") createdTime\n  30: optional FailoverType failoverType\n  40: optional list<ClusterFailover> clusterFailovers\n}\n\nstruct ClusterFailover {\n  10: optional ActiveClusterInfo fromCluster\n  20: optional ActiveClusterInfo toCluster\n  // cluster_attribute is the scope and name for the attribute that was failed over.\n  // If the cluster_attribute is not defined this failover can be assumed to be the default ActiveCluster.\n  30: optional ClusterAttribute clusterAttribute\n}\n\nstruct StartWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional string workflowId\n  30: optional WorkflowType workflowType\n  40: optional TaskList taskList\n  50: optional binary input\n  60: optional i32 executionStartToCloseTimeoutSeconds\n  70: optional i32 taskStartToCloseTimeoutSeconds\n  80: optional string identity\n  90: optional string requestId\n  100: optional WorkflowIdReusePolicy workflowIdReusePolicy\n//  110: optional ChildPolicy childPolicy -- Removed but reserve the IDL order number\n  120: optional RetryPolicy retryPolicy\n  130: optional string cronSchedule\n  140: optional Memo memo\n  141: optional SearchAttributes searchAttributes\n  150: optional Header header\n  160: optional i32 delayStartSeconds\n  170: optional i32 jitterStartSeconds\n  180: optional i64 (js.type = \"Long\") firstRunAtTimestamp\n  190: optional CronOverlapPolicy cronOverlapPolicy\n  200: optional ActiveClusterSelectionPolicy activeClusterSelectionPolicy\n}\n\nstruct StartWorkflowExecutionResponse {\n  10: optional string runId\n}\n\nstruct StartWorkflowExecutionAsyncRequest {\n  10: optional StartWorkflowExecutionRequest request\n}\n\nstruct StartWorkflowExecutionAsyncResponse {\n}\n\nstruct RestartWorkflowExecutionResponse {\n  10: optional string runId\n}\n\nstruct DiagnoseWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional WorkflowExecution workflowExecution\n  30: optional string identity\n}\n\nstruct DiagnoseWorkflowExecutionResponse {\n  10: optional string domain\n  20: optional WorkflowExecution diagnosticWorkflowExecution\n}\n\nstruct PollForDecisionTaskRequest {\n  10: optional string domain\n  20: optional TaskList taskList\n  30: optional string identity\n  40: optional string binaryChecksum\n}\n\nstruct PollForDecisionTaskResponse {\n  10: optional binary taskToken\n  20: optional WorkflowExecution workflowExecution\n  30: optional WorkflowType workflowType\n  40: optional i64 (js.type = \"Long\") previousStartedEventId\n  50: optional i64 (js.type = \"Long\") startedEventId\n  51: optional i64 (js.type = 'Long') attempt\n  54: optional i64 (js.type = \"Long\") backlogCountHint\n  60: optional History history\n  70: optional binary nextPageToken\n  80: optional WorkflowQuery query\n  90: optional TaskList WorkflowExecutionTaskList\n  100: optional i64 (js.type = \"Long\") scheduledTimestamp\n  110: optional i64 (js.type = \"Long\") startedTimestamp\n  120: optional map<string, WorkflowQuery> queries\n  130: optional i64 (js.type = 'Long') nextEventId\n  140: optional i64 (js.type = 'Long') totalHistoryBytes\n  150: optional AutoConfigHint autoConfigHint\n}\n\nstruct StickyExecutionAttributes {\n  10: optional TaskList workerTaskList\n  20: optional i32 scheduleToStartTimeoutSeconds\n}\n\nstruct RespondDecisionTaskCompletedRequest {\n  10: optional binary taskToken\n  20: optional list<Decision> decisions\n  30: optional binary executionContext\n  40: optional string identity\n  50: optional StickyExecutionAttributes stickyAttributes\n  60: optional bool returnNewDecisionTask\n  70: optional bool forceCreateNewDecisionTask\n  80: optional string binaryChecksum\n  90: optional map<string, WorkflowQueryResult> queryResults\n}\n\nstruct RespondDecisionTaskCompletedResponse {\n  10: optional PollForDecisionTaskResponse decisionTask\n  20: optional map<string,ActivityLocalDispatchInfo> activitiesToDispatchLocally\n}\n\nstruct RespondDecisionTaskFailedRequest {\n  10: optional binary taskToken\n  20: optional DecisionTaskFailedCause cause\n  30: optional binary details\n  40: optional string identity\n  50: optional string binaryChecksum\n}\n\nstruct PollForActivityTaskRequest {\n  10: optional string domain\n  20: optional TaskList taskList\n  30: optional string identity\n  40: optional TaskListMetadata taskListMetadata\n}\n\nstruct PollForActivityTaskResponse {\n  10:  optional binary taskToken\n  20:  optional WorkflowExecution workflowExecution\n  30:  optional string activityId\n  40:  optional ActivityType activityType\n  50:  optional binary input\n  70:  optional i64 (js.type = \"Long\") scheduledTimestamp\n  80:  optional i32 scheduleToCloseTimeoutSeconds\n  90:  optional i64 (js.type = \"Long\") startedTimestamp\n  100: optional i32 startToCloseTimeoutSeconds\n  110: optional i32 heartbeatTimeoutSeconds\n  120: optional i32 attempt\n  130: optional i64 (js.type = \"Long\") scheduledTimestampOfThisAttempt\n  140: optional binary heartbeatDetails\n  150: optional WorkflowType workflowType\n  160: optional string workflowDomain\n  170: optional Header header\n  180: optional AutoConfigHint autoConfigHint\n}\n\nstruct RecordActivityTaskHeartbeatRequest {\n  10: optional binary taskToken\n  20: optional binary details\n  30: optional string identity\n}\n\nstruct RecordActivityTaskHeartbeatByIDRequest {\n  10: optional string domain\n  20: optional string workflowID\n  30: optional string runID\n  40: optional string activityID\n  50: optional binary details\n  60: optional string identity\n}\n\nstruct RecordActivityTaskHeartbeatResponse {\n  10: optional bool cancelRequested\n}\n\nstruct RespondActivityTaskCompletedRequest {\n  10: optional binary taskToken\n  20: optional binary result\n  30: optional string identity\n}\n\nstruct RespondActivityTaskFailedRequest {\n  10: optional binary taskToken\n  20: optional string reason\n  30: optional binary details\n  40: optional string identity\n  45: optional FailureOptions failureOptions\n  50: optional binary heartbeatDetails\n}\n\nstruct RespondActivityTaskCanceledRequest {\n  10: optional binary taskToken\n  20: optional binary details\n  30: optional string identity\n}\n\nstruct RespondActivityTaskCompletedByIDRequest {\n  10: optional string domain\n  20: optional string workflowID\n  30: optional string runID\n  40: optional string activityID\n  50: optional binary result\n  60: optional string identity\n}\n\nstruct RespondActivityTaskFailedByIDRequest {\n  10: optional string domain\n  20: optional string workflowID\n  30: optional string runID\n  40: optional string activityID\n  50: optional string reason\n  60: optional binary details\n  65: optional FailureOptions failureOptions\n  70: optional string identity\n  80: optional binary heartbeatDetails\n}\n\nstruct RespondActivityTaskCanceledByIDRequest {\n  10: optional string domain\n  20: optional string workflowID\n  30: optional string runID\n  40: optional string activityID\n  50: optional binary details\n  60: optional string identity\n}\n\nstruct RequestCancelWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional WorkflowExecution workflowExecution\n  30: optional string identity\n  40: optional string requestId\n  50: optional string cause\n  60: optional string firstExecutionRunID\n}\n\nstruct GetWorkflowExecutionHistoryRequest {\n  10: optional string domain\n  20: optional WorkflowExecution execution\n  30: optional i32 maximumPageSize\n  40: optional binary nextPageToken\n  50: optional bool waitForNewEvent\n  60: optional HistoryEventFilterType HistoryEventFilterType\n  70: optional bool skipArchival\n  80: optional QueryConsistencyLevel queryConsistencyLevel\n}\n\nstruct GetWorkflowExecutionHistoryResponse {\n  10: optional History history\n  11: optional list<DataBlob> rawHistory\n  20: optional binary nextPageToken\n  30: optional bool archived\n}\n\nstruct SignalWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional WorkflowExecution workflowExecution\n  30: optional string signalName\n  40: optional binary input\n  50: optional string identity\n  60: optional string requestId\n  70: optional binary control\n}\n\nstruct SignalWithStartWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional string workflowId\n  30: optional WorkflowType workflowType\n  40: optional TaskList taskList\n  50: optional binary input\n  60: optional i32 executionStartToCloseTimeoutSeconds\n  70: optional i32 taskStartToCloseTimeoutSeconds\n  80: optional string identity\n  90: optional string requestId\n  100: optional WorkflowIdReusePolicy workflowIdReusePolicy\n  110: optional string signalName\n  120: optional binary signalInput\n  130: optional binary control\n  140: optional RetryPolicy retryPolicy\n  150: optional string cronSchedule\n  160: optional Memo memo\n  161: optional SearchAttributes searchAttributes\n  170: optional Header header\n  180: optional i32 delayStartSeconds\n  190: optional i32 jitterStartSeconds\n  200: optional i64 (js.type = \"Long\") firstRunAtTimestamp\n  210: optional CronOverlapPolicy cronOverlapPolicy\n  220: optional ActiveClusterSelectionPolicy activeClusterSelectionPolicy\n}\n\nstruct SignalWithStartWorkflowExecutionAsyncRequest {\n  10: optional SignalWithStartWorkflowExecutionRequest request\n}\n\nstruct SignalWithStartWorkflowExecutionAsyncResponse {\n}\n\nstruct RestartWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional WorkflowExecution workflowExecution\n  30: optional string reason\n  40: optional string identity\n}\nstruct TerminateWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional WorkflowExecution workflowExecution\n  30: optional string reason\n  40: optional binary details\n  50: optional string identity\n  60: optional string firstExecutionRunID\n}\n\nstruct ResetWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional WorkflowExecution workflowExecution\n  30: optional string reason\n  40: optional i64 (js.type = \"Long\") decisionFinishEventId\n  50: optional string requestId\n  60: optional bool skipSignalReapply\n}\n\nstruct ResetWorkflowExecutionResponse {\n  10: optional string runId\n}\n\nstruct ListOpenWorkflowExecutionsRequest {\n  10: optional string domain\n  20: optional i32 maximumPageSize\n  30: optional binary nextPageToken\n  40: optional StartTimeFilter StartTimeFilter\n  50: optional WorkflowExecutionFilter executionFilter\n  60: optional WorkflowTypeFilter typeFilter\n}\n\nstruct ListOpenWorkflowExecutionsResponse {\n  10: optional list<WorkflowExecutionInfo> executions\n  20: optional binary nextPageToken\n}\n\nstruct ListClosedWorkflowExecutionsRequest {\n  10: optional string domain\n  20: optional i32 maximumPageSize\n  30: optional binary nextPageToken\n  40: optional StartTimeFilter StartTimeFilter\n  50: optional WorkflowExecutionFilter executionFilter\n  60: optional WorkflowTypeFilter typeFilter\n  70: optional WorkflowExecutionCloseStatus statusFilter\n}\n\nstruct ListClosedWorkflowExecutionsResponse {\n  10: optional list<WorkflowExecutionInfo> executions\n  20: optional binary nextPageToken\n}\n\nstruct ListWorkflowExecutionsRequest {\n  10: optional string domain\n  20: optional i32 pageSize\n  30: optional binary nextPageToken\n  40: optional string query\n}\n\nstruct ListWorkflowExecutionsResponse {\n  10: optional list<WorkflowExecutionInfo> executions\n  20: optional binary nextPageToken\n}\n\nstruct ListArchivedWorkflowExecutionsRequest {\n  10: optional string domain\n  20: optional i32 pageSize\n  30: optional binary nextPageToken\n  40: optional string query\n}\n\nstruct ListArchivedWorkflowExecutionsResponse {\n  10: optional list<WorkflowExecutionInfo> executions\n  20: optional binary nextPageToken\n}\n\nstruct CountWorkflowExecutionsRequest {\n  10: optional string domain\n  20: optional string query\n}\n\nstruct CountWorkflowExecutionsResponse {\n  10: optional i64 count\n}\n\nstruct GetSearchAttributesResponse {\n  10: optional map<string, IndexedValueType> keys\n}\n\nstruct QueryWorkflowRequest {\n  10: optional string domain\n  20: optional WorkflowExecution execution\n  30: optional WorkflowQuery query\n  // QueryRejectCondition can used to reject the query if workflow state does not satisify condition\n  40: optional QueryRejectCondition queryRejectCondition\n  50: optional QueryConsistencyLevel queryConsistencyLevel\n}\n\nstruct QueryRejected {\n  10: optional WorkflowExecutionCloseStatus closeStatus\n}\n\nstruct QueryWorkflowResponse {\n  10: optional binary queryResult\n  20: optional QueryRejected queryRejected\n}\n\nstruct WorkflowQuery {\n  10: optional string queryType\n  20: optional binary queryArgs\n}\n\nstruct ResetStickyTaskListRequest {\n  10: optional string domain\n  20: optional WorkflowExecution execution\n}\n\nstruct ResetStickyTaskListResponse {\n    // The reason to keep this response is to allow returning\n    // information in the future.\n}\n\nstruct RespondQueryTaskCompletedRequest {\n  10: optional binary taskToken\n  20: optional QueryTaskCompletedType completedType\n  30: optional binary queryResult\n  40: optional string errorMessage\n  50: optional WorkerVersionInfo workerVersionInfo\n}\n\nstruct WorkflowQueryResult {\n  10: optional QueryResultType resultType\n  20: optional binary answer\n  30: optional string errorMessage\n}\n\nstruct DescribeWorkflowExecutionRequest {\n  10: optional string domain\n  20: optional WorkflowExecution execution\n  30: optional QueryConsistencyLevel queryConsistencyLevel\n}\n\nstruct PendingActivityInfo {\n  10: optional string activityID\n  20: optional ActivityType activityType\n  30: optional PendingActivityState state\n  40: optional binary heartbeatDetails\n  50: optional i64 (js.type = \"Long\") lastHeartbeatTimestamp\n  60: optional i64 (js.type = \"Long\") lastStartedTimestamp\n  70: optional i32 attempt\n  80: optional i32 maximumAttempts\n  90: optional i64 (js.type = \"Long\") scheduledTimestamp\n  100: optional i64 (js.type = \"Long\") expirationTimestamp\n  110: optional string lastFailureReason\n  120: optional string lastWorkerIdentity\n  130: optional binary lastFailureDetails\n  135: optional FailureOptions lastFailureOptions\n  140: optional string startedWorkerIdentity\n  150: optional i64 (js.type = \"Long\") scheduleID\n}\n\nstruct PendingDecisionInfo {\n  10: optional PendingDecisionState state\n  20: optional i64 (js.type = \"Long\") scheduledTimestamp\n  30: optional i64 (js.type = \"Long\") startedTimestamp\n  40: optional i64 attempt\n  50: optional i64 (js.type = \"Long\") originalScheduledTimestamp\n  60: optional i64 (js.type = \"Long\") scheduleID\n}\n\nstruct PendingChildExecutionInfo {\n  1: optional string domain\n  10: optional string workflowID\n  20: optional string runID\n  30: optional string workflowTypName\n  40: optional i64 (js.type = \"Long\") initiatedID\n  50: optional ParentClosePolicy parentClosePolicy\n}\n\nstruct DescribeWorkflowExecutionResponse {\n  10: optional WorkflowExecutionConfiguration executionConfiguration\n  20: optional WorkflowExecutionInfo workflowExecutionInfo\n  30: optional list<PendingActivityInfo> pendingActivities\n  40: optional list<PendingChildExecutionInfo> pendingChildren\n  50: optional PendingDecisionInfo pendingDecision\n}\n\nstruct DescribeTaskListRequest {\n  10: optional string domain\n  20: optional TaskList taskList\n  30: optional TaskListType taskListType\n  40: optional bool includeTaskListStatus\n}\n\nstruct DescribeTaskListResponse {\n  10: optional list<PollerInfo> pollers\n  20: optional TaskListStatus taskListStatus\n  // The TaskList being described\n  30: optional TaskList taskList\n}\n\nstruct GetTaskListsByDomainRequest {\n  10: optional string domainName\n}\n\nstruct GetTaskListsByDomainResponse {\n  10: optional map<string,DescribeTaskListResponse> decisionTaskListMap\n  20: optional map<string,DescribeTaskListResponse> activityTaskListMap\n}\n\nstruct ListTaskListPartitionsRequest {\n  10: optional string domain\n  20: optional TaskList taskList\n}\n\nstruct TaskListPartitionMetadata {\n  10: optional string key\n  20: optional string ownerHostName\n}\n\nstruct ListTaskListPartitionsResponse {\n  10: optional list<TaskListPartitionMetadata> activityTaskListPartitions\n  20: optional list<TaskListPartitionMetadata> decisionTaskListPartitions\n}\n\nstruct IsolationGroupMetrics {\n  10: optional double newTasksPerSecond\n  20: optional i64 (js.type = \"Long\") pollerCount\n}\n\nstruct TaskListStatus {\n  10: optional i64 (js.type = \"Long\") backlogCountHint\n  20: optional i64 (js.type = \"Long\") readLevel\n  30: optional i64 (js.type = \"Long\") ackLevel\n  35: optional double ratePerSecond\n  40: optional TaskIDBlock taskIDBlock\n  50: optional map<string, IsolationGroupMetrics> isolationGroupMetrics\n  60: optional double newTasksPerSecond\n  70: optional bool empty\n}\n\nstruct TaskIDBlock {\n  10: optional i64 (js.type = \"Long\")  startID\n  20: optional i64 (js.type = \"Long\")  endID\n}\n\n//At least one of the parameters needs to be provided\nstruct DescribeHistoryHostRequest {\n  10: optional string               hostAddress //ip:port\n  20: optional i32                  shardIdForHost\n  30: optional WorkflowExecution    executionForHost\n}\n\nstruct RemoveTaskRequest {\n  10: optional i32                      shardID\n  20: optional i32                      type\n  30: optional i64 (js.type = \"Long\")   taskID\n  40: optional i64 (js.type = \"Long\")   visibilityTimestamp\n  50: optional string                   clusterName\n}\n\nstruct CloseShardRequest {\n  10: optional i32               shardID\n}\n\nstruct ResetQueueRequest {\n  10: optional i32    shardID\n  20: optional string clusterName\n  30: optional i32    type\n}\n\nstruct DescribeQueueRequest {\n  10: optional i32    shardID\n  20: optional string clusterName\n  30: optional i32    type\n}\n\nstruct DescribeQueueResponse {\n  10: optional list<string> processingQueueStates\n}\n\nstruct DescribeShardDistributionRequest {\n  10: optional i32 pageSize\n  20: optional i32 pageID\n}\n\nstruct DescribeShardDistributionResponse {\n  10: optional i32              numberOfShards\n\n  // ShardID to Address (ip:port) map\n  20: optional map<i32, string> shards\n}\n\nstruct DescribeHistoryHostResponse{\n  10: optional i32                  numberOfShards\n  20: optional list<i32>            shardIDs\n  30: optional DomainCacheInfo      domainCache\n  40: optional string               shardControllerStatus\n  50: optional string               address\n}\n\nstruct DomainCacheInfo{\n  10: optional i64 numOfItemsInCacheByID\n  20: optional i64 numOfItemsInCacheByName\n}\n\nenum TaskListType {\n  /*\n   * Decision type of tasklist\n   */\n  Decision,\n  /*\n   * Activity type of tasklist\n   */\n  Activity,\n}\n\nstruct PollerInfo {\n  // Unix Nano\n  10: optional i64 (js.type = \"Long\")  lastAccessTime\n  20: optional string identity\n  30: optional double ratePerSecond\n}\n\nstruct RetryPolicy {\n  // Interval of the first retry. If coefficient is 1.0 then it is used for all retries.\n  10: optional i32 initialIntervalInSeconds\n\n  // Coefficient used to calculate the next retry interval.\n  // The next retry interval is previous interval multiplied by the coefficient.\n  // Must be 1 or larger.\n  20: optional double backoffCoefficient\n\n  // Maximum interval between retries. Exponential backoff leads to interval increase.\n  // This value is the cap of the increase. Default is 100x of initial interval.\n  30: optional i32 maximumIntervalInSeconds\n\n  // Maximum number of attempts. When exceeded the retries stop even if not expired yet.\n  // Must be 1 or bigger. Default is unlimited.\n  40: optional i32 maximumAttempts\n\n  // Non-Retriable errors. Will stop retrying if error matches this list.\n  50: optional list<string> nonRetriableErrorReasons\n\n  // Expiration time for the whole retry process.\n  60: optional i32 expirationIntervalInSeconds\n}\n\n// HistoryBranchRange represents a piece of range for a branch.\nstruct HistoryBranchRange{\n  // branchID of original branch forked from\n  10: optional string branchID\n  // beinning node for the range, inclusive\n  20: optional i64 beginNodeID\n  // ending node for the range, exclusive\n  30: optional i64 endNodeID\n}\n\n// For history persistence to serialize/deserialize branch details\nstruct HistoryBranch{\n  10: optional string treeID\n  20: optional string branchID\n  30: optional list<HistoryBranchRange> ancestors\n}\n\n// VersionHistoryItem contains signal eventID and the corresponding version\nstruct VersionHistoryItem{\n  10: optional i64 (js.type = \"Long\") eventID\n  20: optional i64 (js.type = \"Long\") version\n}\n\n// VersionHistory contains the version history of a branch\nstruct VersionHistory{\n  10: optional binary branchToken\n  20: optional list<VersionHistoryItem> items\n}\n\n// VersionHistories contains all version histories from all branches\nstruct VersionHistories{\n  10: optional i32 currentVersionHistoryIndex\n  20: optional list<VersionHistory> histories\n}\n\n// ReapplyEventsRequest is the request for reapply events API\nstruct ReapplyEventsRequest{\n  10: optional string domainName\n  20: optional WorkflowExecution workflowExecution\n  30: optional DataBlob events\n}\n\n// SupportedClientVersions contains the support versions for client library\nstruct SupportedClientVersions{\n  10: optional string goSdk\n  20: optional string javaSdk\n}\n\n// ClusterInfo contains information about cadence cluster\nstruct ClusterInfo{\n  10: optional SupportedClientVersions supportedClientVersions\n}\n\nstruct RefreshWorkflowTasksRequest {\n  10: optional string domain\n  20: optional WorkflowExecution execution\n}\n\n// DEPRECATED: use proto definition instead\nstruct FeatureFlags {\n  10: optional bool WorkflowExecutionAlreadyCompletedErrorEnabled\n  20: optional bool AutoForwardingEnabled\n}\n\nenum CrossClusterTaskType {\n  StartChildExecution\n  CancelExecution\n  SignalExecution\n  RecordChildWorkflowExecutionComplete\n  ApplyParentClosePolicy\n}\n\nenum CrossClusterTaskFailedCause {\n  DOMAIN_NOT_ACTIVE\n  DOMAIN_NOT_EXISTS\n  WORKFLOW_ALREADY_RUNNING\n  WORKFLOW_NOT_EXISTS\n  WORKFLOW_ALREADY_COMPLETED\n  UNCATEGORIZED\n}\n\nenum GetTaskFailedCause {\n  SERVICE_BUSY\n  TIMEOUT\n  SHARD_OWNERSHIP_LOST\n  UNCATEGORIZED\n}\n\nstruct CrossClusterTaskInfo {\n  10: optional string domainID\n  20: optional string workflowID\n  30: optional string runID\n  40: optional CrossClusterTaskType taskType\n  50: optional i16 taskState\n  60: optional i64 (js.type = \"Long\") taskID\n  70: optional i64 (js.type = \"Long\") visibilityTimestamp\n}\n\nstruct CrossClusterStartChildExecutionRequestAttributes {\n  10: optional string targetDomainID\n  20: optional string requestID\n  30: optional i64 (js.type = \"Long\") initiatedEventID\n  40: optional StartChildWorkflowExecutionInitiatedEventAttributes initiatedEventAttributes\n  // targetRunID is for scheduling first decision task\n  // targetWorkflowID is available in initiatedEventAttributes\n  50: optional string targetRunID\n  60: optional map<string, string> partitionConfig\n}\n\nstruct CrossClusterStartChildExecutionResponseAttributes {\n  10: optional string runID\n}\n\nstruct CrossClusterCancelExecutionRequestAttributes {\n  10: optional string targetDomainID\n  20: optional string targetWorkflowID\n  30: optional string targetRunID\n  40: optional string requestID\n  50: optional i64 (js.type = \"Long\") initiatedEventID\n  60: optional bool childWorkflowOnly\n}\n\nstruct CrossClusterCancelExecutionResponseAttributes {\n}\n\nstruct CrossClusterSignalExecutionRequestAttributes {\n  10: optional string targetDomainID\n  20: optional string targetWorkflowID\n  30: optional string targetRunID\n  40: optional string requestID\n  50: optional i64 (js.type = \"Long\") initiatedEventID\n  60: optional bool childWorkflowOnly\n  70: optional string signalName\n  80: optional binary signalInput\n  90: optional binary control\n}\n\nstruct CrossClusterSignalExecutionResponseAttributes {\n}\n\nstruct CrossClusterRecordChildWorkflowExecutionCompleteRequestAttributes {\n  10: optional string targetDomainID\n  20: optional string targetWorkflowID\n  30: optional string targetRunID\n  40: optional i64 (js.type = \"Long\") initiatedEventID\n  50: optional HistoryEvent completionEvent\n}\n\nstruct CrossClusterRecordChildWorkflowExecutionCompleteResponseAttributes {\n}\n\nstruct ApplyParentClosePolicyAttributes {\n  10: optional string childDomainID\n  20: optional string childWorkflowID\n  30: optional string childRunID\n  40: optional ParentClosePolicy parentClosePolicy\n}\n\nstruct ApplyParentClosePolicyStatus {\n  10: optional bool completed\n  20: optional CrossClusterTaskFailedCause failedCause\n}\n\nstruct ApplyParentClosePolicyRequest {\n  10: optional ApplyParentClosePolicyAttributes child\n  20: optional ApplyParentClosePolicyStatus status\n}\n\nstruct CrossClusterApplyParentClosePolicyRequestAttributes {\n  10: optional list<ApplyParentClosePolicyRequest> children\n}\n\nstruct ApplyParentClosePolicyResult {\n  10: optional ApplyParentClosePolicyAttributes child\n  20: optional CrossClusterTaskFailedCause failedCause\n}\n\nstruct CrossClusterApplyParentClosePolicyResponseAttributes {\n  10: optional list<ApplyParentClosePolicyResult> childrenStatus\n}\n\nstruct CrossClusterTaskRequest {\n  10: optional CrossClusterTaskInfo taskInfo\n  20: optional CrossClusterStartChildExecutionRequestAttributes startChildExecutionAttributes\n  30: optional CrossClusterCancelExecutionRequestAttributes cancelExecutionAttributes\n  40: optional CrossClusterSignalExecutionRequestAttributes signalExecutionAttributes\n  50: optional CrossClusterRecordChildWorkflowExecutionCompleteRequestAttributes recordChildWorkflowExecutionCompleteAttributes\n  60: optional CrossClusterApplyParentClosePolicyRequestAttributes applyParentClosePolicyAttributes\n}\n\nstruct CrossClusterTaskResponse {\n  10: optional i64 (js.type = \"Long\") taskID\n  20: optional CrossClusterTaskType taskType\n  30: optional i16 taskState\n  40: optional CrossClusterTaskFailedCause failedCause\n  50: optional CrossClusterStartChildExecutionResponseAttributes startChildExecutionAttributes\n  60: optional CrossClusterCancelExecutionResponseAttributes cancelExecutionAttributes\n  70: optional CrossClusterSignalExecutionResponseAttributes signalExecutionAttributes\n  80: optional CrossClusterRecordChildWorkflowExecutionCompleteResponseAttributes recordChildWorkflowExecutionCompleteAttributes\n  90: optional CrossClusterApplyParentClosePolicyResponseAttributes applyParentClosePolicyAttributes\n}\n\nstruct GetCrossClusterTasksRequest {\n  10: optional list<i32> shardIDs\n  20: optional string targetCluster\n}\n\nstruct GetCrossClusterTasksResponse {\n  10: optional map<i32, list<CrossClusterTaskRequest>> tasksByShard\n  20: optional map<i32, GetTaskFailedCause> failedCauseByShard\n}\n\nstruct RespondCrossClusterTasksCompletedRequest {\n  10: optional i32 shardID\n  20: optional string targetCluster\n  30: optional list<CrossClusterTaskResponse> taskResponses\n  40: optional bool fetchNewTasks\n}\n\nstruct RespondCrossClusterTasksCompletedResponse {\n  10: optional list<CrossClusterTaskRequest> tasks\n}\n\nenum IsolationGroupState {\n  INVALID,\n  HEALTHY,\n  DRAINED,\n}\n\nstruct IsolationGroupPartition {\n  10: optional string name\n  20: optional IsolationGroupState state\n}\n\nstruct IsolationGroupConfiguration {\n  10: optional list<IsolationGroupPartition> isolationGroups\n}\n\nstruct AsyncWorkflowConfiguration {\n  10: optional bool enabled\n  // PredefinedQueueName is the name of the predefined queue in cadence server config's asyncWorkflowQueues\n  20: optional string predefinedQueueName\n  // queueType is the type of the queue if predefined_queue_name is not used\n  30: optional string queueType\n  // queueConfig is the configuration for the queue if predefined_queue_name is not used\n  40: optional DataBlob queueConfig\n}\n\n/**\n* Any is a logical duplicate of google.protobuf.Any.\n*\n* The intent of the type is the same, but it is not intended to be directly\n* compatible with google.protobuf.Any or any Thrift equivalent - this blob is\n* RPC-type agnostic by design (as the underlying data may be transported over\n* proto or thrift), and the data-bytes may be in any encoding.\n*\n* This is intentionally different from DataBlob, which supports only a handful\n* of known encodings so it can be interpreted everywhere.  Any supports literally\n* any contents, and needs to be considered opaque until it is given to something\n* that is expecting it.\n*\n* See ValueType to interpret the contents.\n**/\nstruct Any {\n  // Type-string describing value's contents, and intentionally avoiding the\n  // name \"type\" as it is often a special term.\n  // This should usually be a hard-coded string of some kind.\n  10: optional string ValueType\n  // Arbitrarily-encoded bytes, to be deserialized by a runtime implementation.\n  // The contents are described by ValueType.\n  20: optional binary Value\n}\n\nstruct AutoConfigHint {\n  10: optional bool enableAutoConfig\n  20: optional i64 pollerWaitTimeInMs\n}\n\nstruct QueueState {\n  10: optional map<i64, VirtualQueueState> virtualQueueStates\n  20: optional TaskKey exclusiveMaxReadLevel\n}\n\nstruct VirtualQueueState {\n  10: optional list<VirtualSliceState> virtualSliceStates\n}\n\nstruct VirtualSliceState {\n  10: optional TaskRange taskRange\n  20: optional Predicate predicate\n}\n\nstruct TaskRange {\n  10: optional TaskKey inclusiveMin\n  20: optional TaskKey exclusiveMax\n}\n\nstruct TaskKey {\n  10: optional i64 scheduledTimeNano\n  20: optional i64 taskID\n}\n\n// ActiveClusterSelectionPolicy is for active-active domains, it serves as a means to select\n// the active cluster, by specifying the attribute by which to divide the workflows\n// in that domain.\nstruct ActiveClusterSelectionPolicy {\n  1: optional ClusterAttribute clusterAttribute\n}\n\n// ClusterAttribute is used for subdividing workflows in a domain into their active\n// and passive clusters. Examples of this might be 'region' and 'cluster1' as\n// respective region and scope fields.\n//\n// for example, a workflow may specify this in it's start request:\n//\n//   StartWorkflowRequest{\n//     ActiveClusterSelectionPolicy: {\n//       ClusterAttribute: {\n//            Scope: \"cityID\",\n//            Name: \"Lisbon\"\n//        }\n//     }\n//   }\n//\n// and this means that this workflow will be associate with the domain's cluster attribute 'Lisbon',\n// be active in the cluster that has Lisbon active and\n// failover when that cluster-attribute is set to failover.\nstruct ClusterAttribute {\n  1: optional string scope\n  2: optional string name\n}\n\n// FailoverType describes how a failover operation will be performed.\nenum FailoverType {\n  INVALID\n  FORCE\n  GRACEFUL\n}\n\n// PaginationOptions provides common options for paginated RPCs.\nstruct PaginationOptions {\n  // page_size configures the number of results to be returned as part of each page\n  10: optional i32 pageSize\n  // next_page_token should be provided from a previous response to fetch the next page.\n  // if empty, the first page will be returned.\n  20: optional binary nextPageToken\n}\n\nenum PredicateType {\n  Universal,\n  Empty,\n  DomainID,\n}\n\nstruct UniversalPredicateAttributes {}\n\nstruct EmptyPredicateAttributes {}\n\nstruct DomainIDPredicateAttributes {\n  10: optional list<string> domainIDs\n  20: optional bool isExclusive\n}\n\nstruct Predicate {\n  10: optional PredicateType predicateType\n  20: optional UniversalPredicateAttributes universalPredicateAttributes\n  30: optional EmptyPredicateAttributes emptyPredicateAttributes\n  40: optional DomainIDPredicateAttributes domainIDPredicateAttributes\n}\n\n// ── Schedule API ──────────────────────────────────────────────────────────────\n\n// ScheduleOverlapPolicy defines behavior when a new run is triggered while a previous run is still active.\nenum ScheduleOverlapPolicy {\n  INVALID\n  SKIP_NEW\n  BUFFER\n  CONCURRENT\n  CANCEL_PREVIOUS\n  TERMINATE_PREVIOUS\n}\n\n// ScheduleCatchUpPolicy defines how missed runs are handled when a schedule resumes.\nenum ScheduleCatchUpPolicy {\n  INVALID\n  SKIP\n  ONE\n  ALL\n}\n\n// ScheduleSpec defines when a schedule triggers.\nstruct ScheduleSpec {\n  // Standard cron expression (e.g., \"0 6 * * *\").\n  // Prefix with CRON_TZ to set timezone (e.g., \"CRON_TZ=America/Los_Angeles 0 6 * * *\").\n  10: optional string cronExpression\n  // Earliest time the schedule may trigger. If not set, starts immediately.\n  20: optional i64 (js.type = \"Long\") startTimeNano\n  // Latest time the schedule may trigger. If not set, runs indefinitely.\n  30: optional i64 (js.type = \"Long\") endTimeNano\n  // Random jitter applied to each trigger time to spread load.\n  // Thrift duration convention: whole seconds only (proto uses nanosecond-precision Duration).\n  // Sub-second jitter from proto is truncated to the nearest second.\n  40: optional i32 jitterInSeconds\n}\n\n// ScheduleStartWorkflowAction describes the workflow to start when the schedule triggers.\nstruct ScheduleStartWorkflowAction {\n  10: optional WorkflowType workflowType\n  20: optional TaskList taskList\n  30: optional binary input\n  40: optional string workflowIdPrefix\n  50: optional i32 executionStartToCloseTimeoutSeconds\n  60: optional i32 taskStartToCloseTimeoutSeconds\n  70: optional RetryPolicy retryPolicy\n  80: optional Memo memo\n  90: optional SearchAttributes searchAttributes\n}\n\n// ScheduleAction defines what the schedule does when it triggers.\n// Exactly one field must be set.\nstruct ScheduleAction {\n  10: optional ScheduleStartWorkflowAction startWorkflow\n}\n\n// SchedulePolicies controls the runtime behavior of a schedule.\nstruct SchedulePolicies {\n  10: optional ScheduleOverlapPolicy overlapPolicy\n  20: optional ScheduleCatchUpPolicy catchUpPolicy\n  // Maximum time to look back for missed runs on resume. Runs older than this window are skipped.\n  // Thrift duration convention: whole seconds only (proto uses nanosecond-precision Duration).\n  // Sub-second windows from proto are truncated to the nearest second.\n  30: optional i32 catchUpWindowInSeconds\n  // If true, pause the schedule when a triggered workflow fails.\n  40: optional bool pauseOnFailure\n  // Maximum number of buffered runs. 0 means unlimited. Only used with BUFFER overlap policy.\n  50: optional i32 bufferLimit\n  // Maximum number of concurrent runs. 0 means unlimited. Only used with CONCURRENT overlap policy.\n  60: optional i32 concurrencyLimit\n}\n\n// SchedulePauseInfo records when and why a schedule was paused.\nstruct SchedulePauseInfo {\n  10: optional string reason\n  20: optional i64 (js.type = \"Long\") pausedTimeNano\n  30: optional string pausedBy\n}\n\n// ScheduleState is the runtime pause/unpause state of a schedule.\nstruct ScheduleState {\n  10: optional bool paused\n  20: optional SchedulePauseInfo pauseInfo\n}\n\n// BackfillInfo tracks the progress of an active or completed backfill operation.\nstruct BackfillInfo {\n  10: optional string backfillId\n  20: optional i64 (js.type = \"Long\") startTimeNano\n  30: optional i64 (js.type = \"Long\") endTimeNano\n  40: optional i32 runsCompleted\n  50: optional i32 runsTotal\n}\n\n// ScheduleInfo contains runtime statistics for a schedule.\nstruct ScheduleInfo {\n  10: optional i64 (js.type = \"Long\") lastRunTimeNano\n  20: optional i64 (js.type = \"Long\") nextRunTimeNano\n  // Total number of workflows started by this schedule.\n  30: optional i64 (js.type = \"Long\") totalRuns\n  40: optional i64 (js.type = \"Long\") createTimeNano\n  50: optional i64 (js.type = \"Long\") lastUpdateTimeNano\n  // Currently active backfill operations. Removed when complete.\n  60: optional list<BackfillInfo> ongoingBackfills\n  // Number of runs that were missed (e.g. due to downtime) and then skipped by catch-up policy.\n  70: optional i64 (js.type = \"Long\") missedRuns\n  // Number of runs that were skipped due to the overlap policy (e.g. SkipNew).\n  80: optional i64 (js.type = \"Long\") skippedRuns\n  // Number of fired actions currently queued in the buffer (BUFFER overlap policy only).\n  90: optional i64 (js.type = \"Long\") bufferedFireCount\n  // Number of target workflows currently running (CONCURRENT overlap policy only).\n  100: optional i64 (js.type = \"Long\") runningWorkflowCount\n}\n\n// ScheduleListEntry is a summary of a schedule returned by ListSchedules.\nstruct ScheduleListEntry {\n  10: optional string scheduleId\n  20: optional WorkflowType workflowType\n  30: optional ScheduleState state\n  40: optional string cronExpression\n}\n\nstruct CreateScheduleRequest {\n  10: optional string domain\n  20: optional string scheduleId\n  30: optional ScheduleSpec spec\n  40: optional ScheduleAction action\n  50: optional SchedulePolicies policies\n  60: optional Memo memo\n  70: optional SearchAttributes searchAttributes\n}\n\nstruct CreateScheduleResponse {\n  10: optional string scheduleId\n}\n\nstruct DescribeScheduleRequest {\n  10: optional string domain\n  20: optional string scheduleId\n}\n\nstruct DescribeScheduleResponse {\n  10: optional ScheduleSpec spec\n  20: optional ScheduleAction action\n  30: optional SchedulePolicies policies\n  40: optional ScheduleState state\n  50: optional ScheduleInfo info\n  60: optional Memo memo\n  70: optional SearchAttributes searchAttributes\n}\n\nstruct ListSchedulesRequest {\n  10: optional string domain\n  20: optional i32 pageSize\n  30: optional binary nextPageToken\n}\n\nstruct ListSchedulesResponse {\n  10: optional list<ScheduleListEntry> schedules\n  20: optional binary nextPageToken\n}\n\nstruct DeleteScheduleRequest {\n  10: optional string domain\n  20: optional string scheduleId\n}\n\nstruct DeleteScheduleResponse {}\n\nstruct PauseScheduleRequest {\n  10: optional string domain\n  20: optional string scheduleId\n  30: optional string reason\n  40: optional string identity\n}\n\nstruct PauseScheduleResponse {}\n\nstruct UnpauseScheduleRequest {\n  10: optional string domain\n  20: optional string scheduleId\n  30: optional string reason\n  // Override the schedule's catch-up policy for this unpause only.\n  // If not set, uses the catch_up_policy from SchedulePolicies.\n  40: optional ScheduleCatchUpPolicy catchUpPolicy\n}\n\nstruct UnpauseScheduleResponse {}\n\nstruct BackfillScheduleRequest {\n  10: optional string domain\n  20: optional string scheduleId\n  30: optional i64 (js.type = \"Long\") startTimeNano\n  40: optional i64 (js.type = \"Long\") endTimeNano\n  50: optional ScheduleOverlapPolicy overlapPolicy\n  // Client-provided identifier for idempotency and progress tracking.\n  // If not set, the server generates a UUID. Retries with the same backfillId are deduplicated.\n  60: optional string backfillId\n}\n\nstruct BackfillScheduleResponse {}\n\nstruct UpdateScheduleRequest {\n  10: optional string domain\n  20: optional string scheduleId\n  30: optional ScheduleSpec spec\n  40: optional ScheduleAction action\n  50: optional SchedulePolicies policies\n  60: optional SearchAttributes searchAttributes\n}\n\nstruct UpdateScheduleResponse {}\n\nenum FailureCategory {\n  Poll,\n  Standard,\n  Fatal,\n}\n\nstruct FailureOptions {\n  10: optional FailureCategory failureCategory\n  20: optional i32 (js.type = \"Long\") nextRetryIntervalSeconds\n}\n"

--- a/error.go
+++ b/error.go
@@ -21,6 +21,8 @@
 package cadence
 
 import (
+	"time"
+
 	"go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/internal"
 	"go.uber.org/cadence/workflow"
@@ -29,6 +31,8 @@ import (
 type (
 	// CustomError returned from workflow and activity implementations with reason and optional details.
 	CustomError = internal.CustomError
+
+	CustomErrorOption = internal.CustomErrorOption
 
 	// CanceledError returned when operation was canceled.
 	CanceledError = internal.CanceledError
@@ -44,6 +48,21 @@ var ErrNoData = internal.ErrNoData
 // Use CustomError for any use case specific errors that cross activity and child workflow boundaries.
 func NewCustomError(reason string, details ...interface{}) *CustomError {
 	return internal.NewCustomError(reason, details...)
+}
+
+// WithFailureCategory sets the failure category on a CustomError. The FailureCategory can influence retry and logging
+// behavior independently of the RetryPolicy. By default, the FailureCategory is shared.FailureCategoryStandard.
+// The result of this function should be passed to NewCustomError in order to include it.
+// This is currently only supported for Activity results
+func WithFailureCategory(failureCategory shared.FailureCategory) CustomErrorOption {
+	return internal.WithFailureCategory(failureCategory)
+}
+
+// WithNextRetryDelay overrides the delay until the next attempt of the activity returning this error. This does not
+// influence whether the activity itself will be retried, which is still determined by the RetryPolicy and FailureCategory.
+// The result of this function should be passed to NewCustomError in order to include it.
+func WithNextRetryDelay(delay time.Duration) CustomErrorOption {
+	return internal.WithNextRetryDelay(delay)
 }
 
 // NewCanceledError creates CanceledError instance.

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/robfig/cron v1.2.0
 	github.com/stretchr/testify v1.9.0
 	github.com/uber-go/tally v3.5.8+incompatible
-	github.com/uber/cadence-idl v0.0.0-20260609034356-3ee08a98cf70
+	github.com/uber/cadence-idl v0.0.0-20260701181909-ee96c0aebffa
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/uber/tchannel-go v1.34.4
 	go.uber.org/atomic v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/uber-go/mapdecode v1.0.0/go.mod h1:b5nP15FwXTgpjTjeA9A2uTHXV5UJCl4arw
 github.com/uber-go/tally v3.3.12+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyufu1cEi0jdVnRdxvjnmU=
 github.com/uber-go/tally v3.5.8+incompatible h1:Z2vK6ib6G/r6bAGu7lAI/98cLPLUOtdHrY2bBikk4wg=
 github.com/uber-go/tally v3.5.8+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyufu1cEi0jdVnRdxvjnmU=
-github.com/uber/cadence-idl v0.0.0-20260609034356-3ee08a98cf70 h1:V7OqXel/r2k62LekFL7dTOKG5FucZpkQB31IO0XikPY=
-github.com/uber/cadence-idl v0.0.0-20260609034356-3ee08a98cf70/go.mod h1:ux5U12WfKGx6AFibwe52/OMp51fjUKSvosh0/eiSzps=
+github.com/uber/cadence-idl v0.0.0-20260701181909-ee96c0aebffa h1:mxoB4AbP/NS7hMGa32nG2Y+KICEcoyaaijli76OJ4Pg=
+github.com/uber/cadence-idl v0.0.0-20260701181909-ee96c0aebffa/go.mod h1:ux5U12WfKGx6AFibwe52/OMp51fjUKSvosh0/eiSzps=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=

--- a/internal/activity_task_handler.go
+++ b/internal/activity_task_handler.go
@@ -205,10 +205,16 @@ func (ath *activityTaskHandlerImpl) Execute(taskList string, t *s.PollForActivit
 		logger.Warn("Activity timeout.")
 		return nil, ctx.Err()
 	}
-	if err != nil && err != ErrActivityResultPending {
+	if err != nil && err != ErrActivityResultPending && !isFailureCategoryPoll(err) {
 		logger.Error("Activity error.", zap.Error(err))
 	}
 	return convertActivityResultToRespondRequest(ath.identity, t.TaskToken, output, err, ath.dataConverter), nil
+}
+
+// errors with a FailureCategory of Poll indicate an expected failure. We don't log them as an activity error
+func isFailureCategoryPoll(err error) bool {
+	asCustom, ok := err.(*CustomError)
+	return ok && asCustom.GetFailureCategory() == s.FailureCategoryPoll
 }
 
 func (ath *activityTaskHandlerImpl) getActivity(name string) activity {

--- a/internal/activity_task_handler_test.go
+++ b/internal/activity_task_handler_test.go
@@ -44,7 +44,14 @@ import (
 
 func TestActivityTaskHandler_Execute_deadline(t *testing.T) {
 	now := time.Now()
-	deadlineTests := []deadlineTest{
+	deadlineTests := []struct {
+		actWaitDuration  time.Duration
+		ScheduleTS       time.Time
+		ScheduleDuration int32
+		StartTS          time.Time
+		StartDuration    int32
+		err              error
+	}{
 		{time.Duration(0), now, 3, now, 3, nil},
 		{time.Duration(0), now, 4, now, 3, nil},
 		{time.Duration(0), now, 3, now, 4, nil},
@@ -58,29 +65,24 @@ func TestActivityTaskHandler_Execute_deadline(t *testing.T) {
 
 	for i, d := range deadlineTests {
 		t.Run(fmt.Sprintf("testIndex: %v, testDetails: %v", i, d), func(t *testing.T) {
-			logger := testlogger.NewZap(t)
-			a := &testActivityDeadline{logger: logger}
-			registry := newRegistry()
-			registry.addActivityWithLock(a.ActivityType().Name, a)
-
-			mockCtrl := gomock.NewController(t)
-			mockService := workflowservicetest.NewMockClient(mockCtrl)
-			a.d = d.actWaitDuration
-			wep := workerExecutionParameters{
-				WorkerOptions: WorkerOptions{
-					Logger:        logger,
-					DataConverter: getDefaultDataConverter(),
-					Tracer:        opentracing.NoopTracer{},
-				},
+			activityDefn := func(ctx context.Context) error {
+				if deadline, _ := ctx.Deadline(); deadline.IsZero() {
+					panic("invalid deadline provided")
+				}
+				if d.actWaitDuration != 0 {
+					// Wait till deadline expires.
+					<-ctx.Done()
+					return ctx.Err()
+				}
+				return nil
 			}
-			ensureRequiredParams(&wep)
-			activityHandler := newActivityTaskHandler(mockService, wep, registry)
+			activityHandler := newHandlerForTest(t, workerExecutionParameters{}, activityDefn)
 			pats := &s.PollForActivityTaskResponse{
 				TaskToken: []byte("token"),
 				WorkflowExecution: &s.WorkflowExecution{
 					WorkflowId: common.StringPtr("wID"),
 					RunId:      common.StringPtr("rID")},
-				ActivityType:                    &s.ActivityType{Name: common.StringPtr("test")},
+				ActivityType:                    &s.ActivityType{Name: common.StringPtr("activityType")},
 				ActivityId:                      common.StringPtr(uuid.New()),
 				ScheduledTimestamp:              common.Int64Ptr(d.ScheduleTS.UnixNano()),
 				ScheduledTimestampOfThisAttempt: common.Int64Ptr(d.ScheduleTS.UnixNano()),
@@ -103,60 +105,38 @@ func TestActivityTaskHandler_Execute_deadline(t *testing.T) {
 }
 
 func TestActivityTaskHandler_Execute_worker_stop(t *testing.T) {
-	logger := testlogger.NewZap(t)
-
-	a := &testActivityDeadline{logger: logger}
-	registry := newRegistry()
-	registry.RegisterActivityWithOptions(
-		activityWithWorkerStop,
-		RegisterActivityOptions{Name: a.ActivityType().Name, DisableAlreadyRegisteredCheck: true},
-	)
-
-	now := time.Now()
-
-	mockCtrl := gomock.NewController(t)
-	mockService := workflowservicetest.NewMockClient(mockCtrl)
 	workerStopCh := make(chan struct{}, 1)
 	ctx, cancel := context.WithCancel(context.Background())
+	activityDefn := func(ctx context.Context) error {
+		workerStopCh := GetWorkerStopChannel(ctx)
+
+		select {
+		case <-workerStopCh:
+			return nil
+		case <-time.NewTimer(time.Second * 5).C:
+			return fmt.Errorf("Activity failed to handle worker stop event")
+		}
+	}
+
 	wep := workerExecutionParameters{
 		WorkerOptions: WorkerOptions{
-			Logger:        logger,
 			DataConverter: getDefaultDataConverter(),
 		},
 		UserContext:       ctx,
 		UserContextCancel: cancel,
 		WorkerStopChannel: workerStopCh,
 	}
-	activityHandler := newActivityTaskHandler(mockService, wep, registry)
-	pats := &s.PollForActivityTaskResponse{
-		TaskToken: []byte("token"),
-		WorkflowExecution: &s.WorkflowExecution{
-			WorkflowId: common.StringPtr("wID"),
-			RunId:      common.StringPtr("rID")},
-		ActivityType:                    &s.ActivityType{Name: common.StringPtr("test")},
-		ActivityId:                      common.StringPtr(uuid.New()),
-		ScheduledTimestamp:              common.Int64Ptr(now.UnixNano()),
-		ScheduledTimestampOfThisAttempt: common.Int64Ptr(now.UnixNano()),
-		ScheduleToCloseTimeoutSeconds:   common.Int32Ptr(1),
-		StartedTimestamp:                common.Int64Ptr(now.UnixNano()),
-		StartToCloseTimeoutSeconds:      common.Int32Ptr(1),
-		Attempt:                         common.Int32Ptr(0),
-		WorkflowType: &s.WorkflowType{
-			Name: common.StringPtr("wType"),
-		},
-		WorkflowDomain: common.StringPtr("domain"),
-	}
+	activityHandler := newHandlerForTest(t, wep, activityDefn)
+	pats := createBasicPollForActivityTaskResponse()
+
 	close(workerStopCh)
 	r, err := activityHandler.Execute(tasklist, pats)
+
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 }
 
 func TestActivityTaskHandler_Execute_with_propagators(t *testing.T) {
-	logger := testlogger.NewZap(t)
-
-	now := time.Now()
-
 	testKey, testValue := testHeader, "test_value"
 
 	// inline activity using value passing through user context.
@@ -167,44 +147,20 @@ func TestActivityTaskHandler_Execute_with_propagators(t *testing.T) {
 		}
 		return "", errors.New("value not found from ctx")
 	}
-	registry := newRegistry()
-	err := registry.registerActivityFunction(activityWithUserContext, RegisterActivityOptions{Name: "activityWithUserContext"})
-	require.NoError(t, err)
-
-	mockCtrl := gomock.NewController(t)
-	mockService := workflowservicetest.NewMockClient(mockCtrl)
 	wep := workerExecutionParameters{
 		WorkerOptions: WorkerOptions{
-			Logger:             logger,
-			DataConverter:      getDefaultDataConverter(),
-			Tracer:             opentracing.NoopTracer{},
 			ContextPropagators: []ContextPropagator{NewStringMapPropagator([]string{testHeader})},
 		},
 	}
-	ensureRequiredParams(&wep)
-	activityHandler := newActivityTaskHandler(mockService, wep, registry)
-	pats := &s.PollForActivityTaskResponse{
-		TaskToken: []byte("token"),
-		WorkflowExecution: &s.WorkflowExecution{
-			WorkflowId: common.StringPtr("wID"),
-			RunId:      common.StringPtr("rID")},
-		ActivityType:                    &s.ActivityType{Name: common.StringPtr("activityWithUserContext")},
-		ActivityId:                      common.StringPtr(uuid.New()),
-		ScheduledTimestamp:              common.Int64Ptr(now.UnixNano()),
-		ScheduledTimestampOfThisAttempt: common.Int64Ptr(now.UnixNano()),
-		ScheduleToCloseTimeoutSeconds:   common.Int32Ptr(1),
-		StartedTimestamp:                common.Int64Ptr(now.UnixNano()),
-		StartToCloseTimeoutSeconds:      common.Int32Ptr(1),
-		Attempt:                         common.Int32Ptr(0),
-		WorkflowType: &s.WorkflowType{
-			Name: common.StringPtr("wType"),
-		},
-		WorkflowDomain: common.StringPtr("domain"),
-		Header: &s.Header{
-			Fields: map[string][]byte{testHeader: []byte(testValue)},
-		},
+	activityHandler := newHandlerForTest(t, wep, activityWithUserContext)
+
+	pats := createBasicPollForActivityTaskResponse()
+	pats.Header = &s.Header{
+		Fields: map[string][]byte{testHeader: []byte(testValue)},
 	}
+
 	res, err := activityHandler.Execute(tasklist, pats)
+
 	require.NoError(t, err)
 	response, ok := res.(*s.RespondActivityTaskCompletedRequest)
 	require.True(t, ok, "response is not of type *s.RespondActivityTaskCompletedRequest")
@@ -212,57 +168,26 @@ func TestActivityTaskHandler_Execute_with_propagators(t *testing.T) {
 }
 
 func TestActivityTaskHandler_Execute_with_propagator_failure(t *testing.T) {
-	logger := testlogger.NewZap(t)
-
-	now := time.Now()
-
 	// inline activity using value passing through user context.
 	activityWithUserContext := func(ctx context.Context) (string, error) {
 		return "", nil
 	}
-	registry := newRegistry()
-	err := registry.registerActivityFunction(activityWithUserContext, RegisterActivityOptions{Name: "activityWithUserContext"})
-	require.NoError(t, err)
-
-	mockCtrl := gomock.NewController(t)
-	mockService := workflowservicetest.NewMockClient(mockCtrl)
 	wep := workerExecutionParameters{
 		WorkerOptions: WorkerOptions{
-			Logger:             logger,
 			DataConverter:      getDefaultDataConverter(),
 			Tracer:             opentracing.NoopTracer{},
 			ContextPropagators: []ContextPropagator{failingContextPropagator{err: assert.AnError}},
 		},
 	}
-	ensureRequiredParams(&wep)
-	activityHandler := newActivityTaskHandler(mockService, wep, registry)
-	pats := &s.PollForActivityTaskResponse{
-		TaskToken: []byte("token"),
-		WorkflowExecution: &s.WorkflowExecution{
-			WorkflowId: common.StringPtr("wID"),
-			RunId:      common.StringPtr("rID")},
-		ActivityType:                    &s.ActivityType{Name: common.StringPtr("activityWithUserContext")},
-		ActivityId:                      common.StringPtr(uuid.New()),
-		ScheduledTimestamp:              common.Int64Ptr(now.UnixNano()),
-		ScheduledTimestampOfThisAttempt: common.Int64Ptr(now.UnixNano()),
-		ScheduleToCloseTimeoutSeconds:   common.Int32Ptr(1),
-		StartedTimestamp:                common.Int64Ptr(now.UnixNano()),
-		StartToCloseTimeoutSeconds:      common.Int32Ptr(1),
-		Attempt:                         common.Int32Ptr(0),
-		WorkflowType: &s.WorkflowType{
-			Name: common.StringPtr("wType"),
-		},
-		WorkflowDomain: common.StringPtr("domain"),
-	}
-	_, err = activityHandler.Execute(tasklist, pats)
+	activityHandler := newHandlerForTest(t, wep, activityWithUserContext)
+
+	pats := createBasicPollForActivityTaskResponse()
+
+	_, err := activityHandler.Execute(tasklist, pats)
 	assert.ErrorIs(t, err, assert.AnError)
 }
 
 func TestActivityTaskHandler_Execute_with_auto_heartbeat(t *testing.T) {
-	logger := testlogger.NewZap(t)
-
-	now := time.Now()
-
 	clock := clockwork.NewFakeClock()
 
 	// inline activity using value passing through user context.
@@ -271,50 +196,78 @@ func TestActivityTaskHandler_Execute_with_auto_heartbeat(t *testing.T) {
 		clock.Advance(time.Second / 2)
 		return nil
 	}
-	registry := newRegistry()
-	err := registry.registerActivityFunction(activityWithUserContext, RegisterActivityOptions{
-		Name:                "activityWithUserContext",
-		EnableAutoHeartbeat: true,
-	})
-	require.NoError(t, err)
 
-	mockCtrl := gomock.NewController(t)
-	mockService := workflowservicetest.NewMockClient(mockCtrl)
-	wep := workerExecutionParameters{
-		WorkerOptions: WorkerOptions{
-			Logger:        logger,
-			DataConverter: getDefaultDataConverter(),
-			Tracer:        opentracing.NoopTracer{},
-		},
-	}
-	ensureRequiredParams(&wep)
-	activityHandler := newActivityTaskHandler(mockService, wep, registry)
+	activityHandler := newHandlerForTest(t, workerExecutionParameters{}, activityWithUserContext)
 	activityHandlerImpl := activityHandler.(*activityTaskHandlerImpl)
 	activityHandlerImpl.clock = clock
 
-	pats := &s.PollForActivityTaskResponse{
+	pats := createBasicPollForActivityTaskResponse()
+	pats.HeartbeatTimeoutSeconds = common.Int32Ptr(1)
+
+	res, err := activityHandler.Execute(tasklist, pats)
+	require.NoError(t, err)
+	_, ok := res.(*s.RespondActivityTaskCompletedRequest)
+	require.True(t, ok, "response is not of type *s.RespondActivityTaskCompletedRequest but of type %T", res)
+}
+
+func TestActivityTaskHandler_Execute_CustomError(t *testing.T) {
+	activityWithCustomError := func(ctx context.Context) error {
+		testFailureCategory := s.FailureCategoryFatal
+		testNextRetryDelay := 30 * time.Second
+		return NewCustomError(
+			"test-error",
+			WithFailureCategory(testFailureCategory),
+			WithNextRetryDelay(testNextRetryDelay),
+			"details",
+		)
+	}
+	activityHandler := newHandlerForTest(t, workerExecutionParameters{}, activityWithCustomError)
+
+	pats := createBasicPollForActivityTaskResponse()
+
+	// Execute
+	res, err := activityHandler.Execute(tasklist, pats)
+	require.NoError(t, err)
+
+	failedRequest, ok := res.(*s.RespondActivityTaskFailedRequest)
+	require.True(t, ok, "response is not of type *s.RespondActivityTaskFailedRequest but of type %T", res)
+	require.Equal(t, s.FailureCategoryFatal, failedRequest.GetFailureOptions().GetFailureCategory())
+	require.Equal(t, int32(30), failedRequest.GetFailureOptions().GetNextRetryIntervalSeconds())
+}
+
+func newHandlerForTest(t *testing.T, params workerExecutionParameters, activityFunction any) ActivityTaskHandler {
+	registry := newRegistry()
+	err := registry.registerActivityFunction(activityFunction, RegisterActivityOptions{Name: "activityType"})
+	require.NoError(t, err)
+
+	params.WorkerOptions.Logger = testlogger.NewZap(t)
+	ensureRequiredParams(&params)
+	mockCtrl := gomock.NewController(t)
+	mockService := workflowservicetest.NewMockClient(mockCtrl)
+	return newActivityTaskHandler(mockService, params, registry)
+}
+
+func createBasicPollForActivityTaskResponse() *s.PollForActivityTaskResponse {
+	now := time.Now()
+	return &s.PollForActivityTaskResponse{
 		TaskToken: []byte("token"),
 		WorkflowExecution: &s.WorkflowExecution{
 			WorkflowId: common.StringPtr("wID"),
-			RunId:      common.StringPtr("rID")},
-		ActivityType:                    &s.ActivityType{Name: common.StringPtr("activityWithUserContext")},
+			RunId:      common.StringPtr("rID"),
+		},
+		ActivityType:                    &s.ActivityType{Name: common.StringPtr("activityType")},
 		ActivityId:                      common.StringPtr(uuid.New()),
 		ScheduledTimestamp:              common.Int64Ptr(now.UnixNano()),
 		ScheduledTimestampOfThisAttempt: common.Int64Ptr(now.UnixNano()),
 		ScheduleToCloseTimeoutSeconds:   common.Int32Ptr(1),
 		StartedTimestamp:                common.Int64Ptr(now.UnixNano()),
 		StartToCloseTimeoutSeconds:      common.Int32Ptr(1),
-		HeartbeatTimeoutSeconds:         common.Int32Ptr(1),
 		Attempt:                         common.Int32Ptr(0),
 		WorkflowType: &s.WorkflowType{
 			Name: common.StringPtr("wType"),
 		},
 		WorkflowDomain: common.StringPtr("domain"),
 	}
-	res, err := activityHandler.Execute(tasklist, pats)
-	require.NoError(t, err)
-	_, ok := res.(*s.RespondActivityTaskCompletedRequest)
-	require.True(t, ok, "response is not of type *s.RespondActivityTaskCompletedRequest but of type %T", res)
 }
 
 func TestActivityOutcome(t *testing.T) {
@@ -351,15 +304,6 @@ func activityWithWorkerStop(ctx context.Context) error {
 	case <-time.NewTimer(time.Second * 5).C:
 		return fmt.Errorf("Activity failed to handle worker stop event")
 	}
-}
-
-type deadlineTest struct {
-	actWaitDuration  time.Duration
-	ScheduleTS       time.Time
-	ScheduleDuration int32
-	StartTS          time.Time
-	StartDuration    int32
-	err              error
 }
 
 type failingContextPropagator struct {

--- a/internal/compatibility/api_test.go
+++ b/internal/compatibility/api_test.go
@@ -1746,7 +1746,16 @@ func TestRespondActivityTaskFailedByIDRequest(t *testing.T) {
 	runFuzzTest(t,
 		thrift.RespondActivityTaskFailedByIDRequest,
 		proto.RespondActivityTaskFailedByIDRequest,
-		FuzzOptions{},
+		FuzzOptions{
+			CustomFuncs: []interface{}{
+				func(req *apiv1.RespondActivityTaskFailedByIDRequest, _ fuzz.Continue) {
+					if req.WorkflowExecution != nil && req.WorkflowExecution.WorkflowId == "" && req.WorkflowExecution.RunId == "" {
+						req.WorkflowExecution = nil
+					}
+				},
+				fuzzFailureWithOptions,
+			},
+		},
 	)
 }
 func TestRespondActivityTaskFailedRequest(t *testing.T) {
@@ -1757,7 +1766,11 @@ func TestRespondActivityTaskFailedRequest(t *testing.T) {
 	runFuzzTest(t,
 		thrift.RespondActivityTaskFailedRequest,
 		proto.RespondActivityTaskFailedRequest,
-		FuzzOptions{},
+		FuzzOptions{
+			CustomFuncs: []any{
+				fuzzFailureWithOptions,
+			},
+		},
 	)
 }
 func TestRespondDecisionTaskCompletedRequest(t *testing.T) {
@@ -3307,6 +3320,26 @@ func TestFailure(t *testing.T) {
 	assert.Equal(t, testdata.FailureReason, *thrift.FailureReason(failure))
 	assert.Equal(t, testdata.FailureDetails, thrift.FailureDetails(failure))
 }
+
+func TestFailureOptions(t *testing.T) {
+	assert.Nil(t, proto.FailureOptions(nil))
+	assert.Nil(t, thrift.FailureOptions(nil))
+	assert.Nil(t, thrift.FailureOptions(&apiv1.Failure{}))
+
+	options := &shared.FailureOptions{
+		FailureCategory:          shared.FailureCategoryFatal.Ptr(),
+		NextRetryIntervalSeconds: common.Int32Ptr(int32(testdata.Duration2.Seconds)),
+	}
+
+	failure := proto.FailureWithOptions(&testdata.FailureReason, testdata.FailureDetails, options)
+	assert.NotNil(t, failure)
+	assert.Equal(t, testdata.FailureReason, *thrift.FailureReason(failure))
+	assert.Equal(t, testdata.FailureDetails, thrift.FailureDetails(failure))
+	assert.Equal(t, apiv1.FailureCategory_FAILURE_CATEGORY_FATAL, failure.GetOptions().GetFailureCategory())
+	assert.Equal(t, testdata.Duration2, failure.GetOptions().GetNextRetryInterval())
+	assert.Equal(t, options, thrift.FailureOptions(failure))
+}
+
 func TestHistoryEvent(t *testing.T) {
 	historyEvents := []*apiv1.HistoryEvent{
 		nil,
@@ -3408,6 +3441,32 @@ func TestListOpenWorkflowExecutionsRequest(t *testing.T) {
 	}
 }
 
+// Thrift doesn't have a Failure type, with reason, details, and options all being separate fields.
+// Several Thrift types that a Failure is mapped into don't support the FailureOptions field.
+func fuzzFailureWithoutOptions(failure *apiv1.Failure, c fuzz.Continue) {
+	c.Fuzz(&failure.Reason)
+	if failure.GetReason() != "" {
+		length := c.Intn(MaxPayloadBytes) + 1
+		failure.Details = make([]byte, length)
+		for i := 0; i < length; i++ {
+			failure.Details[i] = byte(c.Uint32())
+		}
+	}
+	failure.Options = nil
+}
+
+func fuzzFailureWithOptions(failure *apiv1.Failure, c fuzz.Continue) {
+	c.Fuzz(&failure.Reason)
+	if failure.GetReason() != "" {
+		length := c.Intn(MaxPayloadBytes) + 1
+		failure.Details = make([]byte, length)
+		for i := 0; i < length; i++ {
+			failure.Details[i] = byte(c.Uint32())
+		}
+		c.Fuzz(&failure.Options)
+	}
+}
+
 // runFuzzTest provides a more type-safe version of runFuzzTest using generics
 func runFuzzTest[TProto protobuf.Message, TThrift any](
 	t *testing.T,
@@ -3444,6 +3503,18 @@ func runFuzzTest[TProto protobuf.Message, TThrift any](
 			for i := 0; i < length; i++ {
 				p.Data[i] = byte(c.Uint32())
 			}
+		},
+		// Default: keep Failure.Options nil unless a test explicitly overrides this type fuzzer.
+		fuzzFailureWithoutOptions,
+		// Default: constrain FailureCategory to known enum values.
+		func(category *apiv1.FailureCategory, c fuzz.Continue) {
+			validValues := []apiv1.FailureCategory{
+				apiv1.FailureCategory_FAILURE_CATEGORY_INVALID,
+				apiv1.FailureCategory_FAILURE_CATEGORY_POLL,
+				apiv1.FailureCategory_FAILURE_CATEGORY_STANDARD,
+				apiv1.FailureCategory_FAILURE_CATEGORY_FATAL,
+			}
+			*category = validValues[c.Intn(len(validValues))]
 		},
 	}
 

--- a/internal/compatibility/enum_test.go
+++ b/internal/compatibility/enum_test.go
@@ -358,3 +358,15 @@ func TestFailoverType(t *testing.T) {
 	}
 	assert.Equal(t, apiv1.FailoverType_FAILOVER_TYPE_INVALID, proto.FailoverType(thrift.FailoverType(999)))
 }
+
+func TestFailureCategory(t *testing.T) {
+	for _, v := range []apiv1.FailureCategory{
+		apiv1.FailureCategory_FAILURE_CATEGORY_INVALID,
+		apiv1.FailureCategory_FAILURE_CATEGORY_POLL,
+		apiv1.FailureCategory_FAILURE_CATEGORY_STANDARD,
+		apiv1.FailureCategory_FAILURE_CATEGORY_FATAL,
+	} {
+		assert.Equal(t, v, proto.FailureCategory(thrift.FailureCategory(v)))
+	}
+	assert.Equal(t, apiv1.FailureCategory_FAILURE_CATEGORY_INVALID, proto.FailureCategory(thrift.FailureCategory(999)))
+}

--- a/internal/compatibility/proto/enum.go
+++ b/internal/compatibility/proto/enum.go
@@ -423,3 +423,18 @@ func FailoverType(t *shared.FailoverType) apiv1.FailoverType {
 	}
 	return apiv1.FailoverType_FAILOVER_TYPE_INVALID
 }
+
+func FailureCategory(t *shared.FailureCategory) apiv1.FailureCategory {
+	if t == nil {
+		return apiv1.FailureCategory_FAILURE_CATEGORY_INVALID
+	}
+	switch *t {
+	case shared.FailureCategoryPoll:
+		return apiv1.FailureCategory_FAILURE_CATEGORY_POLL
+	case shared.FailureCategoryStandard:
+		return apiv1.FailureCategory_FAILURE_CATEGORY_STANDARD
+	case shared.FailureCategoryFatal:
+		return apiv1.FailureCategory_FAILURE_CATEGORY_FATAL
+	}
+	return apiv1.FailureCategory_FAILURE_CATEGORY_INVALID
+}

--- a/internal/compatibility/proto/history.go
+++ b/internal/compatibility/proto/history.go
@@ -187,7 +187,7 @@ func ActivityTaskFailedEventAttributes(t *shared.ActivityTaskFailedEventAttribut
 		return nil
 	}
 	return &apiv1.ActivityTaskFailedEventAttributes{
-		Failure:          Failure(t.Reason, t.Details),
+		Failure:          FailureWithOptions(t.Reason, t.Details, t.FailureOptions),
 		ScheduledEventId: t.GetScheduledEventId(),
 		StartedEventId:   t.GetStartedEventId(),
 		Identity:         t.GetIdentity(),
@@ -223,7 +223,7 @@ func ActivityTaskStartedEventAttributes(t *shared.ActivityTaskStartedEventAttrib
 		Identity:         t.GetIdentity(),
 		RequestId:        t.GetRequestId(),
 		Attempt:          t.GetAttempt(),
-		LastFailure:      Failure(t.LastFailureReason, t.LastFailureDetails),
+		LastFailure:      FailureWithOptions(t.LastFailureReason, t.LastFailureDetails, t.LastFailureOptions),
 	}
 }
 
@@ -236,7 +236,7 @@ func ActivityTaskTimedOutEventAttributes(t *shared.ActivityTaskTimedOutEventAttr
 		ScheduledEventId: t.GetScheduledEventId(),
 		StartedEventId:   t.GetStartedEventId(),
 		TimeoutType:      TimeoutType(t.TimeoutType),
-		LastFailure:      Failure(t.LastFailureReason, t.LastFailureDetails),
+		LastFailure:      FailureWithOptions(t.LastFailureReason, t.LastFailureDetails, t.LastFailureOptions),
 	}
 }
 

--- a/internal/compatibility/proto/request.go
+++ b/internal/compatibility/proto/request.go
@@ -329,8 +329,9 @@ func RespondActivityTaskFailedByIDRequest(t *shared.RespondActivityTaskFailedByI
 		Domain:            t.GetDomain(),
 		WorkflowExecution: WorkflowRunPair(t.GetWorkflowID(), t.GetRunID()),
 		ActivityId:        t.GetActivityID(),
-		Failure:           Failure(t.Reason, t.Details),
+		Failure:           FailureWithOptions(t.Reason, t.Details, t.FailureOptions),
 		Identity:          t.GetIdentity(),
+		HeartbeatDetails:  Payload(t.HeartbeatDetails),
 	}
 }
 
@@ -339,9 +340,10 @@ func RespondActivityTaskFailedRequest(t *shared.RespondActivityTaskFailedRequest
 		return nil
 	}
 	return &apiv1.RespondActivityTaskFailedRequest{
-		TaskToken: t.TaskToken,
-		Failure:   Failure(t.Reason, t.Details),
-		Identity:  t.GetIdentity(),
+		TaskToken:        t.TaskToken,
+		Failure:          FailureWithOptions(t.Reason, t.Details, t.FailureOptions),
+		Identity:         t.GetIdentity(),
+		HeartbeatDetails: Payload(t.HeartbeatDetails),
 	}
 }
 

--- a/internal/compatibility/proto/schedule.go
+++ b/internal/compatibility/proto/schedule.go
@@ -258,14 +258,16 @@ func ScheduleInfo(t *shared.ScheduleInfo) *apiv1.ScheduleInfo {
 		}
 	}
 	return &apiv1.ScheduleInfo{
-		LastRunTime:      unixNanoToTime(t.LastRunTimeNano),
-		NextRunTime:      unixNanoToTime(t.NextRunTimeNano),
-		TotalRuns:        t.GetTotalRuns(),
-		CreateTime:       unixNanoToTime(t.CreateTimeNano),
-		LastUpdateTime:   unixNanoToTime(t.LastUpdateTimeNano),
-		OngoingBackfills: ongoing,
-		MissedRuns:       t.GetMissedRuns(),
-		SkippedRuns:      t.GetSkippedRuns(),
+		LastRunTime:          unixNanoToTime(t.LastRunTimeNano),
+		NextRunTime:          unixNanoToTime(t.NextRunTimeNano),
+		TotalRuns:            t.GetTotalRuns(),
+		CreateTime:           unixNanoToTime(t.CreateTimeNano),
+		LastUpdateTime:       unixNanoToTime(t.LastUpdateTimeNano),
+		OngoingBackfills:     ongoing,
+		MissedRuns:           t.GetMissedRuns(),
+		SkippedRuns:          t.GetSkippedRuns(),
+		BufferedFireCount:    t.GetBufferedFireCount(),
+		RunningWorkflowCount: t.GetRunningWorkflowCount(),
 	}
 }
 

--- a/internal/compatibility/proto/types.go
+++ b/internal/compatibility/proto/types.go
@@ -45,6 +45,25 @@ func Failure(reason *string, details []byte) *apiv1.Failure {
 	}
 }
 
+func FailureWithOptions(reason *string, details []byte, options *shared.FailureOptions) *apiv1.Failure {
+	failure := Failure(reason, details)
+	if failure == nil {
+		return nil
+	}
+	failure.Options = FailureOptions(options)
+	return failure
+}
+
+func FailureOptions(options *shared.FailureOptions) *apiv1.FailureOptions {
+	if options == nil {
+		return nil
+	}
+	return &apiv1.FailureOptions{
+		FailureCategory:   FailureCategory(options.FailureCategory),
+		NextRetryInterval: secondsToDuration(options.NextRetryIntervalSeconds),
+	}
+}
+
 func WorkflowExecution(t *shared.WorkflowExecution) *apiv1.WorkflowExecution {
 	if t == nil {
 		return nil
@@ -474,7 +493,7 @@ func PendingActivityInfo(t *shared.PendingActivityInfo) *apiv1.PendingActivityIn
 		MaximumAttempts:    t.GetMaximumAttempts(),
 		ScheduledTime:      unixNanoToTime(t.ScheduledTimestamp),
 		ExpirationTime:     unixNanoToTime(t.ExpirationTimestamp),
-		LastFailure:        Failure(t.LastFailureReason, t.LastFailureDetails),
+		LastFailure:        FailureWithOptions(t.LastFailureReason, t.LastFailureDetails, t.LastFailureOptions),
 		LastWorkerIdentity: t.GetLastWorkerIdentity(),
 	}
 }

--- a/internal/compatibility/thrift/enum.go
+++ b/internal/compatibility/thrift/enum.go
@@ -408,3 +408,17 @@ func FailoverType(t apiv1.FailoverType) *shared.FailoverType {
 	}
 	return shared.FailoverTypeInvalid.Ptr()
 }
+
+func FailureCategory(t apiv1.FailureCategory) *shared.FailureCategory {
+	switch t {
+	case apiv1.FailureCategory_FAILURE_CATEGORY_INVALID:
+		return nil
+	case apiv1.FailureCategory_FAILURE_CATEGORY_POLL:
+		return shared.FailureCategoryPoll.Ptr()
+	case apiv1.FailureCategory_FAILURE_CATEGORY_STANDARD:
+		return shared.FailureCategoryStandard.Ptr()
+	case apiv1.FailureCategory_FAILURE_CATEGORY_FATAL:
+		return shared.FailureCategoryFatal.Ptr()
+	}
+	return nil
+}

--- a/internal/compatibility/thrift/history.go
+++ b/internal/compatibility/thrift/history.go
@@ -233,6 +233,7 @@ func ActivityTaskFailedEventAttributes(t *apiv1.ActivityTaskFailedEventAttribute
 	return &shared.ActivityTaskFailedEventAttributes{
 		Reason:           FailureReason(t.Failure),
 		Details:          FailureDetails(t.Failure),
+		FailureOptions:   FailureOptions(t.Failure),
 		ScheduledEventId: &t.ScheduledEventId,
 		StartedEventId:   &t.StartedEventId,
 		Identity:         &t.Identity,
@@ -270,6 +271,7 @@ func ActivityTaskStartedEventAttributes(t *apiv1.ActivityTaskStartedEventAttribu
 		Attempt:            &t.Attempt,
 		LastFailureReason:  FailureReason(t.LastFailure),
 		LastFailureDetails: FailureDetails(t.LastFailure),
+		LastFailureOptions: FailureOptions(t.LastFailure),
 	}
 }
 
@@ -284,6 +286,7 @@ func ActivityTaskTimedOutEventAttributes(t *apiv1.ActivityTaskTimedOutEventAttri
 		TimeoutType:        TimeoutType(t.TimeoutType),
 		LastFailureReason:  FailureReason(t.LastFailure),
 		LastFailureDetails: FailureDetails(t.LastFailure),
+		LastFailureOptions: FailureOptions(t.LastFailure),
 	}
 }
 

--- a/internal/compatibility/thrift/request.go
+++ b/internal/compatibility/thrift/request.go
@@ -329,13 +329,15 @@ func RespondActivityTaskFailedByIDRequest(t *apiv1.RespondActivityTaskFailedByID
 		return nil
 	}
 	return &shared.RespondActivityTaskFailedByIDRequest{
-		Domain:     &t.Domain,
-		WorkflowID: WorkflowID(t.WorkflowExecution),
-		RunID:      RunID(t.WorkflowExecution),
-		ActivityID: &t.ActivityId,
-		Reason:     FailureReason(t.Failure),
-		Details:    FailureDetails(t.Failure),
-		Identity:   &t.Identity,
+		Domain:           &t.Domain,
+		WorkflowID:       WorkflowID(t.WorkflowExecution),
+		RunID:            RunID(t.WorkflowExecution),
+		ActivityID:       &t.ActivityId,
+		Reason:           FailureReason(t.Failure),
+		Details:          FailureDetails(t.Failure),
+		FailureOptions:   FailureOptions(t.Failure),
+		Identity:         &t.Identity,
+		HeartbeatDetails: Payload(t.HeartbeatDetails),
 	}
 }
 
@@ -344,10 +346,12 @@ func RespondActivityTaskFailedRequest(t *apiv1.RespondActivityTaskFailedRequest)
 		return nil
 	}
 	return &shared.RespondActivityTaskFailedRequest{
-		TaskToken: t.TaskToken,
-		Reason:    FailureReason(t.Failure),
-		Details:   FailureDetails(t.Failure),
-		Identity:  &t.Identity,
+		TaskToken:        t.TaskToken,
+		Reason:           FailureReason(t.Failure),
+		Details:          FailureDetails(t.Failure),
+		FailureOptions:   FailureOptions(t.Failure),
+		Identity:         &t.Identity,
+		HeartbeatDetails: Payload(t.HeartbeatDetails),
 	}
 }
 

--- a/internal/compatibility/thrift/schedule.go
+++ b/internal/compatibility/thrift/schedule.go
@@ -174,14 +174,16 @@ func ScheduleInfo(t *apiv1.ScheduleInfo) *shared.ScheduleInfo {
 		return nil
 	}
 	return &shared.ScheduleInfo{
-		LastRunTimeNano:    timeToUnixNano(t.LastRunTime),
-		NextRunTimeNano:    timeToUnixNano(t.NextRunTime),
-		TotalRuns:          common.Int64Ptr(t.TotalRuns),
-		CreateTimeNano:     timeToUnixNano(t.CreateTime),
-		LastUpdateTimeNano: timeToUnixNano(t.LastUpdateTime),
-		OngoingBackfills:   BackfillInfoArray(t.OngoingBackfills),
-		MissedRuns:         common.Int64Ptr(t.MissedRuns),
-		SkippedRuns:        common.Int64Ptr(t.SkippedRuns),
+		LastRunTimeNano:      timeToUnixNano(t.LastRunTime),
+		NextRunTimeNano:      timeToUnixNano(t.NextRunTime),
+		TotalRuns:            common.Int64Ptr(t.TotalRuns),
+		CreateTimeNano:       timeToUnixNano(t.CreateTime),
+		LastUpdateTimeNano:   timeToUnixNano(t.LastUpdateTime),
+		OngoingBackfills:     BackfillInfoArray(t.OngoingBackfills),
+		MissedRuns:           common.Int64Ptr(t.MissedRuns),
+		SkippedRuns:          common.Int64Ptr(t.SkippedRuns),
+		BufferedFireCount:    common.Int64Ptr(t.BufferedFireCount),
+		RunningWorkflowCount: common.Int64Ptr(t.RunningWorkflowCount),
 	}
 }
 

--- a/internal/compatibility/thrift/types.go
+++ b/internal/compatibility/thrift/types.go
@@ -62,6 +62,16 @@ func FailureDetails(failure *apiv1.Failure) []byte {
 	return failure.Details
 }
 
+func FailureOptions(failure *apiv1.Failure) *shared.FailureOptions {
+	if failure == nil || failure.Options == nil {
+		return nil
+	}
+	return &shared.FailureOptions{
+		FailureCategory:          FailureCategory(failure.Options.GetFailureCategory()),
+		NextRetryIntervalSeconds: durationToSeconds(failure.Options.GetNextRetryInterval()),
+	}
+}
+
 func WorkflowExecution(t *apiv1.WorkflowExecution) *shared.WorkflowExecution {
 	if t == nil {
 		return nil
@@ -490,6 +500,7 @@ func PendingActivityInfo(t *apiv1.PendingActivityInfo) *shared.PendingActivityIn
 		ExpirationTimestamp:    timeToUnixNano(t.ExpirationTime),
 		LastFailureReason:      FailureReason(t.LastFailure),
 		LastFailureDetails:     FailureDetails(t.LastFailure),
+		LastFailureOptions:     FailureOptions(t.LastFailure),
 		LastWorkerIdentity:     &t.LastWorkerIdentity,
 	}
 }

--- a/internal/error.go
+++ b/internal/error.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/internal/common/util"
@@ -89,9 +90,14 @@ That decision task will be retried at a later time (with exponential backoff ret
 type (
 	// CustomError returned from workflow and activity implementations with reason and optional details.
 	CustomError struct {
-		reason  string
-		details Values
+		reason          string
+		details         Values
+		failureCategory *shared.FailureCategory
+		nextRetryDelay  time.Duration
 	}
+
+	// CustomErrorOption defines and additional option that can be specified on a CustomError
+	CustomErrorOption func(customError *CustomError)
 
 	// GenericError returned from workflow/workflow when the implementations return errors other than from NewCustomError() API.
 	GenericError struct {
@@ -220,8 +226,34 @@ func NewCustomError(reason string, details ...interface{}) *CustomError {
 			return &CustomError{reason: reason, details: d}
 		}
 	}
-	// When create error for server, use ErrorDetailsValues as details to hold values and encode later
-	return &CustomError{reason: reason, details: ErrorDetailsValues(details)}
+	if details == nil {
+		// details must be a valid implementation of Values, so we use a typed-nil
+		return &CustomError{reason: reason, details: ErrorDetailsValues(nil)}
+	}
+	customError := &CustomError{reason: reason}
+	// CustomErrorOptions get immediately applied, everything else goes to the ErrorDetailsValues
+	detailsValues := make(ErrorDetailsValues, 0, len(details))
+	for _, detail := range details {
+		if asOption, ok := detail.(CustomErrorOption); ok {
+			asOption(customError)
+			continue
+		}
+		detailsValues = append(detailsValues, detail)
+	}
+	customError.details = detailsValues
+	return customError
+}
+
+func WithFailureCategory(failureCategory shared.FailureCategory) CustomErrorOption {
+	return func(customError *CustomError) {
+		customError.failureCategory = failureCategory.Ptr()
+	}
+}
+
+func WithNextRetryDelay(delay time.Duration) CustomErrorOption {
+	return func(customError *CustomError) {
+		customError.nextRetryDelay = delay
+	}
 }
 
 // NewTimeoutError creates TimeoutError instance.
@@ -319,6 +351,17 @@ func (e *CustomError) Details(d ...interface{}) error {
 		return ErrNoData
 	}
 	return e.details.Get(d...)
+}
+
+func (e *CustomError) GetFailureCategory() shared.FailureCategory {
+	if e.failureCategory == nil {
+		return shared.FailureCategoryStandard
+	}
+	return *e.failureCategory
+}
+
+func (e *CustomError) GetNextRetryDelay() time.Duration {
+	return e.nextRetryDelay
 }
 
 // Error from error interface

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -23,7 +23,9 @@ package internal
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
+	"time"
 
 	"go.uber.org/cadence/internal/common/testlogger"
 
@@ -300,6 +302,92 @@ func Test_CustomError_Pointer(t *testing.T) {
 	err6.Details(&b2)
 	require.NoError(t, err6.Details(&b2))
 	require.Equal(t, &testErrorDetails4, b2)
+}
+
+func Test_NewCustomError_Options(t *testing.T) {
+	tests := []struct {
+		name                    string
+		args                    []interface{}
+		expectedDetails         []interface{}
+		expectedFailureCategory shared.FailureCategory
+		expectedNextRetryDelay  time.Duration
+	}{
+		{
+			name: "with failure category option",
+			args: []interface{}{
+				WithFailureCategory(shared.FailureCategoryFatal),
+			},
+			expectedFailureCategory: shared.FailureCategoryFatal,
+			expectedNextRetryDelay:  0,
+		},
+		{
+			name: "with next retry delay option",
+			args: []interface{}{
+				WithNextRetryDelay(37 * time.Second),
+			},
+			expectedFailureCategory: shared.FailureCategoryStandard,
+			expectedNextRetryDelay:  37 * time.Second,
+		},
+		{
+			name: "with both options interleaved with details",
+			args: []interface{}{
+				testErrorDetails1,
+				WithFailureCategory(shared.FailureCategoryStandard),
+				testErrorDetails2,
+				WithNextRetryDelay(19 * time.Second),
+				testErrorDetails3,
+			},
+			expectedDetails:         []interface{}{testErrorDetails1, testErrorDetails2, testErrorDetails3},
+			expectedFailureCategory: shared.FailureCategoryStandard,
+			expectedNextRetryDelay:  19 * time.Second,
+		},
+		{
+			name: "no options",
+			args: []interface{}{
+				testErrorDetails1,
+				testErrorDetails2,
+				testErrorDetails3,
+			},
+			expectedDetails:         []interface{}{testErrorDetails1, testErrorDetails2, testErrorDetails3},
+			expectedFailureCategory: shared.FailureCategoryStandard,
+			expectedNextRetryDelay:  0,
+		},
+		{
+			name:                    "no options and no details",
+			args:                    nil,
+			expectedDetails:         nil,
+			expectedFailureCategory: shared.FailureCategoryStandard,
+			expectedNextRetryDelay:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewCustomError(customErrReasonA, tt.args...)
+
+			require.Equal(t, customErrReasonA, err.Reason())
+			require.Equal(t, tt.expectedFailureCategory, err.GetFailureCategory())
+			require.Equal(t, tt.expectedNextRetryDelay, err.GetNextRetryDelay())
+
+			if len(tt.expectedDetails) == 0 {
+				require.False(t, err.HasDetails())
+				require.Equal(t, ErrNoData, err.Details())
+				return
+			}
+
+			require.True(t, err.HasDetails())
+
+			decodedPtrs := make([]interface{}, 0, len(tt.expectedDetails))
+			for _, expectedDetail := range tt.expectedDetails {
+				decodedPtrs = append(decodedPtrs, reflect.New(reflect.TypeOf(expectedDetail)).Interface())
+			}
+
+			require.NoError(t, err.Details(decodedPtrs...))
+			for i, expectedDetail := range tt.expectedDetails {
+				require.Equal(t, expectedDetail, reflect.ValueOf(decodedPtrs[i]).Elem().Interface())
+			}
+		})
+	}
 }
 
 func Test_CustomError_WrongDecodedType(t *testing.T) {

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -1475,35 +1475,6 @@ func (t *TaskHandlersTestSuite) TestHeartBeat_NilResponseWithDomainNotActiveErro
 	t.True(called)
 }
 
-type testActivityDeadline struct {
-	logger *zap.Logger
-	d      time.Duration
-}
-
-func (t *testActivityDeadline) Execute(ctx context.Context, input []byte) ([]byte, error) {
-	if d, _ := ctx.Deadline(); d.IsZero() {
-		panic("invalid deadline provided")
-	}
-	if t.d != 0 {
-		// Wait till deadline expires.
-		<-ctx.Done()
-		return nil, ctx.Err()
-	}
-	return nil, nil
-}
-
-func (t *testActivityDeadline) ActivityType() ActivityType {
-	return ActivityType{Name: "test"}
-}
-
-func (t *testActivityDeadline) GetFunction() interface{} {
-	return t.Execute
-}
-
-func (t *testActivityDeadline) GetOptions() RegisterActivityOptions {
-	return RegisterActivityOptions{}
-}
-
 // a regrettably-hacky func to use goleak to count leaking goroutines.
 // ideally there will be a structured way to do this in the future, rather than string parsing
 func countLeaks(leaks error) int {

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -1449,10 +1449,12 @@ func convertActivityResultToRespondRequest(identity string, taskToken, result []
 	}
 
 	return &s.RespondActivityTaskFailedRequest{
-		TaskToken: taskToken,
-		Reason:    common.StringPtr(reason),
-		Details:   details,
-		Identity:  common.StringPtr(identity)}
+		TaskToken:      taskToken,
+		Reason:         common.StringPtr(reason),
+		Details:        details,
+		Identity:       common.StringPtr(identity),
+		FailureOptions: getFailureOptions(err),
+	}
 }
 
 func convertActivityResultToRespondRequestByID(identity, domain, workflowID, runID, activityID string,
@@ -1485,11 +1487,13 @@ func convertActivityResultToRespondRequestByID(identity, domain, workflowID, run
 	}
 
 	return &s.RespondActivityTaskFailedByIDRequest{
-		Domain:     common.StringPtr(domain),
-		WorkflowID: common.StringPtr(workflowID),
-		RunID:      common.StringPtr(runID),
-		ActivityID: common.StringPtr(activityID),
-		Reason:     common.StringPtr(reason),
-		Details:    details,
-		Identity:   common.StringPtr(identity)}
+		Domain:         common.StringPtr(domain),
+		WorkflowID:     common.StringPtr(workflowID),
+		RunID:          common.StringPtr(runID),
+		ActivityID:     common.StringPtr(activityID),
+		Reason:         common.StringPtr(reason),
+		Details:        details,
+		Identity:       common.StringPtr(identity),
+		FailureOptions: getFailureOptions(err),
+	}
 }

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -318,6 +318,16 @@ func getErrorDetails(err error, dataConverter DataConverter) (string, []byte) {
 	}
 }
 
+func getFailureOptions(err error) *s.FailureOptions {
+	if asCustom, ok := err.(*CustomError); ok {
+		return &s.FailureOptions{
+			FailureCategory:          asCustom.GetFailureCategory().Ptr(),
+			NextRetryIntervalSeconds: durationToThriftSeconds(asCustom.GetNextRetryDelay()),
+		}
+	}
+	return nil
+}
+
 // constructError construct error from reason and details sending down from server.
 func constructError(reason string, details []byte, dataConverter DataConverter) error {
 	if strings.HasPrefix(reason, errReasonTimeout) {

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -2267,10 +2267,11 @@ func (s *workflowClientTestSuite) TestCompleteActivity() {
 
 			mockRPC: func() {
 				request := &shared.RespondActivityTaskFailedRequest{
-					TaskToken: []byte(taskToken),
-					Reason:    common.StringPtr("some reason"),
-					Details:   []byte("\"some details\"\n"),
-					Identity:  common.StringPtr(identity),
+					TaskToken:      []byte(taskToken),
+					Reason:         common.StringPtr("some reason"),
+					Details:        []byte("\"some details\"\n"),
+					Identity:       common.StringPtr(identity),
+					FailureOptions: &shared.FailureOptions{FailureCategory: shared.FailureCategoryStandard.Ptr()},
 				}
 				s.service.EXPECT().
 					RespondActivityTaskFailed(gomock.Any(), request, gomock.Any()).
@@ -2426,13 +2427,14 @@ func (s *workflowClientTestSuite) TestCompleteActivityByID() {
 
 			mockRPC: func() {
 				request := &shared.RespondActivityTaskFailedByIDRequest{
-					Domain:     common.StringPtr(domain),
-					WorkflowID: common.StringPtr(workflowID),
-					RunID:      common.StringPtr(runID),
-					ActivityID: common.StringPtr(activityID),
-					Reason:     common.StringPtr("some reason"),
-					Details:    []byte("\"some details\"\n"),
-					Identity:   common.StringPtr(identity),
+					Domain:         common.StringPtr(domain),
+					WorkflowID:     common.StringPtr(workflowID),
+					RunID:          common.StringPtr(runID),
+					ActivityID:     common.StringPtr(activityID),
+					Reason:         common.StringPtr("some reason"),
+					Details:        []byte("\"some details\"\n"),
+					Identity:       common.StringPtr(identity),
+					FailureOptions: &shared.FailureOptions{FailureCategory: shared.FailureCategoryStandard.Ptr()},
 				}
 				s.service.EXPECT().
 					RespondActivityTaskFailedByID(gomock.Any(), request, gomock.Any()).


### PR DESCRIPTION
Add support for specifying a FailureCategory and NextRetryDelay on CustomError instances. These allow activity implementations more granular control over retry behavior (whether it retries and the delay until the retry), as well as the ability for polling-style Activities to suppress error messages from expected failures.

Update the idls module to pull in the changes introducing these new fields and update the corresponding mappers. This is necessary due to the fuzzer tests. Fields must be either mapped or exempted.

<!-- Describe what has changed in this PR -->
**What changed?**
- Add support for specifying FailureOptions on CustomError instances returned by activities.
- Update the proto/thrift mappers for newly introduced fields
  - FailureOptions
  - New fields in ScheduleInfo
  - Last heartbeat in RespondActivityFailed

<!-- Tell your future self why have you made these changes -->
**Why?**
- Allow activities to override the RetryPolicy for specific failures.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Incorrect behavior could change the retries for activities.
- In general, failures in activity processing would cause activities to time out.