### PR TITLE
feat: Add Activity lifecycle logging

### DIFF
--- a/internal/activity_task_handler.go
+++ b/internal/activity_task_handler.go
@@ -233,6 +233,8 @@ func (ath *activityTaskHandlerImpl) getRegisteredActivityNames() (activityNames 
 // activityOutcome classifies the values Execute returns
 func activityOutcome(result interface{}, err error) string {
 	switch {
+	case err == context.DeadlineExceeded:
+		return "timeout"
 	case err != nil:
 		return "failed_to_report"
 	case result == ErrActivityResultPending:

--- a/internal/activity_task_handler.go
+++ b/internal/activity_task_handler.go
@@ -39,21 +39,22 @@ import (
 type (
 	// activityTaskHandlerImpl is the implementation of ActivityTaskHandler
 	activityTaskHandlerImpl struct {
-		clock              clockwork.Clock
-		taskListName       string
-		identity           string
-		service            workflowserviceclient.Interface
-		metricsScope       *metrics.TaggedScope
-		logger             *zap.Logger
-		userContext        context.Context
-		registry           *registry
-		activityProvider   activityProvider
-		dataConverter      DataConverter
-		workerStopCh       <-chan struct{}
-		contextPropagators []ContextPropagator
-		tracer             opentracing.Tracer
-		featureFlags       FeatureFlags
-		activityTracker    debug.ActivityTracker
+		clock                  clockwork.Clock
+		taskListName           string
+		identity               string
+		service                workflowserviceclient.Interface
+		metricsScope           *metrics.TaggedScope
+		logger                 *zap.Logger
+		userContext            context.Context
+		registry               *registry
+		activityProvider       activityProvider
+		dataConverter          DataConverter
+		workerStopCh           <-chan struct{}
+		contextPropagators     []ContextPropagator
+		tracer                 opentracing.Tracer
+		featureFlags           FeatureFlags
+		activityTracker        debug.ActivityTracker
+		enableLifecycleLogging bool
 	}
 )
 
@@ -79,32 +80,49 @@ func newActivityTaskHandlerWithCustomProvider(
 		params.WorkerStats.ActivityTracker = debug.NewNoopActivityTracker()
 	}
 	return &activityTaskHandlerImpl{
-		clock:              clock,
-		taskListName:       params.TaskList.GetName(),
-		identity:           params.Identity,
-		service:            service,
-		logger:             params.Logger,
-		metricsScope:       metrics.NewTaggedScope(params.MetricsScope),
-		userContext:        params.UserContext,
-		registry:           registry,
-		activityProvider:   activityProvider,
-		dataConverter:      params.DataConverter,
-		workerStopCh:       params.WorkerStopChannel,
-		contextPropagators: params.ContextPropagators,
-		tracer:             params.Tracer,
-		featureFlags:       params.FeatureFlags,
-		activityTracker:    params.WorkerStats.ActivityTracker,
+		clock:                  clock,
+		taskListName:           params.TaskList.GetName(),
+		identity:               params.Identity,
+		service:                service,
+		logger:                 params.Logger,
+		metricsScope:           metrics.NewTaggedScope(params.MetricsScope),
+		userContext:            params.UserContext,
+		registry:               registry,
+		activityProvider:       activityProvider,
+		dataConverter:          params.DataConverter,
+		workerStopCh:           params.WorkerStopChannel,
+		contextPropagators:     params.ContextPropagators,
+		tracer:                 params.Tracer,
+		featureFlags:           params.FeatureFlags,
+		activityTracker:        params.WorkerStats.ActivityTracker,
+		enableLifecycleLogging: params.EnableActivityLifecycleLogging,
 	}
 }
 
 // Execute executes an implementation of the activity.
 func (ath *activityTaskHandlerImpl) Execute(taskList string, t *s.PollForActivityTaskResponse) (result interface{}, err error) {
+	logger := ath.logger.With(
+		zap.String(tagWorkflowID, t.GetWorkflowExecution().GetWorkflowId()),
+		zap.String(tagWorkflowType, t.GetWorkflowType().GetName()),
+		zap.String(tagRunID, t.GetWorkflowExecution().GetRunId()),
+		zap.String(tagActivityID, t.GetActivityId()),
+		zap.String(tagActivityType, t.GetActivityType().GetName()),
+		zap.Int32(tagAttempt, t.GetAttempt()),
+	)
 	traceLog(func() {
-		ath.logger.Debug("Processing new activity task",
-			zap.String(tagWorkflowID, t.WorkflowExecution.GetWorkflowId()),
-			zap.String(tagRunID, t.WorkflowExecution.GetRunId()),
-			zap.String(tagActivityType, t.ActivityType.GetName()))
+		logger.Debug("Processing new activity task")
 	})
+
+	if ath.enableLifecycleLogging {
+		logger.Info("Activity started.")
+		defer func() {
+			fields := []zap.Field{zap.String(tagActivityOutcome, activityOutcome(result, err))}
+			if err != nil {
+				fields = append(fields, zap.Error(err))
+			}
+			logger.Info("Activity completed.", fields...)
+		}()
+	}
 
 	rootCtx := ath.userContext
 	if rootCtx == nil {
@@ -136,10 +154,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskList string, t *s.PollForActivit
 		if p := recover(); p != nil {
 			topLine := fmt.Sprintf("activity for %s [panic]:", ath.taskListName)
 			st := getStackTraceRaw(topLine, 7, 0)
-			ath.logger.Error("Activity panic.",
-				zap.String(tagWorkflowID, t.WorkflowExecution.GetWorkflowId()),
-				zap.String(tagRunID, t.WorkflowExecution.GetRunId()),
-				zap.String(tagActivityType, activityType),
+			logger.Error("Activity panic.",
 				zap.String(tagPanicError, fmt.Sprintf("%v", p)),
 				zap.String(tagPanicStack, st))
 			metricsScope.Counter(metrics.ActivityTaskPanicCounter).Inc(1)
@@ -187,20 +202,11 @@ func (ath *activityTaskHandlerImpl) Execute(taskList string, t *s.PollForActivit
 
 	dlCancelFunc()
 	if <-ctx.Done(); ctx.Err() == context.DeadlineExceeded {
-		ath.logger.Warn("Activity timeout.",
-			zap.String(tagWorkflowID, t.WorkflowExecution.GetWorkflowId()),
-			zap.String(tagRunID, t.WorkflowExecution.GetRunId()),
-			zap.String(tagActivityType, activityType),
-		)
+		logger.Warn("Activity timeout.")
 		return nil, ctx.Err()
 	}
 	if err != nil && err != ErrActivityResultPending {
-		ath.logger.Error("Activity error.",
-			zap.String(tagWorkflowID, t.WorkflowExecution.GetWorkflowId()),
-			zap.String(tagRunID, t.WorkflowExecution.GetRunId()),
-			zap.String(tagActivityType, activityType),
-			zap.Error(err),
-		)
+		logger.Error("Activity error.", zap.Error(err))
 	}
 	return convertActivityResultToRespondRequest(ath.identity, t.TaskToken, output, err, ath.dataConverter), nil
 }
@@ -222,4 +228,24 @@ func (ath *activityTaskHandlerImpl) getRegisteredActivityNames() (activityNames 
 		activityNames = append(activityNames, a.ActivityType().Name)
 	}
 	return
+}
+
+// activityOutcome classifies the values Execute returns
+func activityOutcome(result interface{}, err error) string {
+	switch {
+	case err != nil:
+		return "failed_to_report"
+	case result == ErrActivityResultPending:
+		return "pending"
+	}
+	switch result.(type) {
+	case *s.RespondActivityTaskCompletedRequest:
+		return "succeeded"
+	case *s.RespondActivityTaskCanceledRequest:
+		return "canceled"
+	case *s.RespondActivityTaskFailedRequest:
+		return "failed"
+	default:
+		return "unknown"
+	}
 }

--- a/internal/activity_task_handler.go
+++ b/internal/activity_task_handler.go
@@ -95,7 +95,7 @@ func newActivityTaskHandlerWithCustomProvider(
 		tracer:                 params.Tracer,
 		featureFlags:           params.FeatureFlags,
 		activityTracker:        params.WorkerStats.ActivityTracker,
-		enableLifecycleLogging: params.EnableActivityLifecycleLogging,
+		enableLifecycleLogging: params.EnableWorkflowLifecycleLogging,
 	}
 }
 

--- a/internal/activity_task_handler_test.go
+++ b/internal/activity_task_handler_test.go
@@ -325,6 +325,8 @@ func TestActivityOutcome(t *testing.T) {
 		want   string
 	}{
 		{"classifies error", &s.RespondActivityTaskCompletedRequest{}, assert.AnError, "failed_to_report"},
+		{"classifies deadline exceeded as timeout", nil, context.DeadlineExceeded, "timeout"},
+		{"classifies wrapped deadline exceeded as failed_to_report", nil, fmt.Errorf("wrapped: %w", context.DeadlineExceeded), "failed_to_report"},
 		{"classifies pending", ErrActivityResultPending, nil, "pending"},
 		{"classifies completed", &s.RespondActivityTaskCompletedRequest{}, nil, "succeeded"},
 		{"classifies canceled", &s.RespondActivityTaskCanceledRequest{}, nil, "canceled"},

--- a/internal/activity_task_handler_test.go
+++ b/internal/activity_task_handler_test.go
@@ -317,6 +317,28 @@ func TestActivityTaskHandler_Execute_with_auto_heartbeat(t *testing.T) {
 	require.True(t, ok, "response is not of type *s.RespondActivityTaskCompletedRequest but of type %T", res)
 }
 
+func TestActivityOutcome(t *testing.T) {
+	tests := []struct {
+		name   string
+		result interface{}
+		err    error
+		want   string
+	}{
+		{"classifies error", &s.RespondActivityTaskCompletedRequest{}, assert.AnError, "failed_to_report"},
+		{"classifies pending", ErrActivityResultPending, nil, "pending"},
+		{"classifies completed", &s.RespondActivityTaskCompletedRequest{}, nil, "succeeded"},
+		{"classifies canceled", &s.RespondActivityTaskCanceledRequest{}, nil, "canceled"},
+		{"classifies failed", &s.RespondActivityTaskFailedRequest{}, nil, "failed"},
+		{"classifies unrecognized result as unknown", "surprise", nil, "unknown"},
+		{"classifies nil result as unknown", nil, nil, "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, activityOutcome(tt.result, tt.err))
+		})
+	}
+}
+
 func activityWithWorkerStop(ctx context.Context) error {
 	fmt.Println("Executing Activity with worker stop")
 	workerStopCh := GetWorkerStopChannel(ctx)

--- a/internal/internal_logging_tags.go
+++ b/internal/internal_logging_tags.go
@@ -23,6 +23,7 @@ package internal
 const (
 	tagActivityID                  = "ActivityID"
 	tagActivityType                = "ActivityType"
+	tagActivityOutcome             = "ActivityOutcome"
 	tagDomain                      = "Domain"
 	tagEventID                     = "EventID"
 	tagEventType                   = "EventType"

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -296,11 +296,12 @@ type (
 		// default: false
 		EnableLoggingInReplay bool
 
-		// Optional: Enable logging of activity lifecycle events.
+		// Optional: Enable logging of workflow lifecycle events.
 		// When enabled, the worker logs a message when each activity attempt starts and when it ends,
 		// including the outcome (succeeded / failed / canceled / timeout / pending / failed_to_report).
+		// Note: this currently covers activity attempts only
 		// default: false
-		EnableActivityLifecycleLogging bool
+		EnableWorkflowLifecycleLogging bool
 
 		// Optional: Disable running workflow workers.
 		// default: false

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -296,6 +296,14 @@ type (
 		// default: false
 		EnableLoggingInReplay bool
 
+		// Optional: Enable logging of activity lifecycle events.
+		// When enabled, the worker logs a message when each activity attempt starts and when it ends,
+		// including the outcome (succeeded / failed / canceled / pending / failed_to_report).
+		// All messages are tagged with ActivityID, ActivityType, Attempt, WorkflowID,
+		// RunID, WorkflowType and Domain.
+		// default: false
+		EnableActivityLifecycleLogging bool
+
 		// Optional: Disable running workflow workers.
 		// default: false
 		DisableWorkflowWorker bool

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -298,9 +298,7 @@ type (
 
 		// Optional: Enable logging of activity lifecycle events.
 		// When enabled, the worker logs a message when each activity attempt starts and when it ends,
-		// including the outcome (succeeded / failed / canceled / pending / failed_to_report).
-		// All messages are tagged with ActivityID, ActivityType, Attempt, WorkflowID,
-		// RunID, WorkflowType and Domain.
+		// including the outcome (succeeded / failed / canceled / timeout / pending / failed_to_report).
 		// default: false
 		EnableActivityLifecycleLogging bool
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
New `EnableWorkflowLifecycleLogging` option in `WorkerOptions`, defaulted to `false`. When on, the activity worker logs `Activity started` and `Activity completed` for every activity attempt, with an `ActivityOutcome` field of succeeded / failed / canceled / pending / failed_to_report / timeout.

Fixes: https://github.com/cadence-workflow/cadence/issues/7583

<!-- Tell your future self why have you made these changes -->
**Why?**
- Workflow history keeps only the last attempt of a retried activity, so repeated failures leave no per-attempt record to debug from
- When activity runs longer than its timeout, workflow history only shows that it fails according to timeout, without logs tracking actual resource usage and behavior on the client


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test: `go test ./internal/ -run 'TestActivityOutcome'`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Writes 2 extra `Info` lines to logs per activity attempt

---
**Detailed Description**
[In-depth description of the changes made to the interfaces, specifying new fields, removed fields, or modified data structures]

New `EnableActivityLifecycleLogging` option in `WorkerOptions`, defaulted to `false`. When on, the activity worker logs `Activity started` and `Activity completed` for every activity attempt, with an `ActivityOutcome` field of succeeded / failed / canceled / pending / failed_to_report / timeout.

**Impact Analysis**
- **Backward Compatibility**: Existing logs are unaffected
- **Forward Compatibility**: Existing logs do not affect the new version of logs

**Testing Plan**
- **Unit Tests**: [Do we have unit test covering the change?] `go test ./internal/ -run 'TestActivityOutcome'`
- **Persistence Tests**: [If the change is related to a data type which is persisted, do we have persistence tests covering the change?]
- **Integration Tests**: [Do we have integration test covering the change?]
- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?]

**Rollout Plan**
- What is the rollout plan?
- Does the order of deployment matter?
- Is it safe to rollback? Does the order of rollback matter?
- Is there a kill switch to mitigate the impact immediately?
---